### PR TITLE
Adjust camera position based on the scene bounding sphere. 

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
           vulkan-use-cache: true
 
       - name: Install latest LLVM, Ninja and build dependencies
-        run: brew install llvm ninja autoconf automake
+        run: brew install llvm ninja autoconf automake libtool nasm pkgconf
 
       - name: Install vcpkg
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,9 +50,5 @@ jobs:
           mv .github/workflows/scripts/* .
           cmake --preset=macos-clang
 
-      - name: Show error
-        if: failure()
-        run: cat /Users/runner/work/vk-gltf-viewer/vk-gltf-viewer/vcpkg/buildtrees/gmp/autoconf-arm64-osx-err.log
-
       - name: Build
         run: cmake --build build --config release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
           vulkan-use-cache: true
 
       - name: Install latest LLVM, Ninja and build dependencies
-        run: brew install llvm ninja autoconf automake libtool nasm pkgconf
+        run: brew install llvm ninja autoconf automake libtool nasm
 
       - name: Install vcpkg
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
           vulkan-use-cache: true
 
       - name: Install latest LLVM, Ninja and build dependencies
-        run: brew install llvm ninja automake
+        run: brew install llvm ninja autoreconf automake
 
       - name: Install vcpkg
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,5 +50,9 @@ jobs:
           mv .github/workflows/scripts/* .
           cmake --preset=macos-clang
 
+      - name: Show error
+        if: failure()
+        run: cat /Users/runner/work/vk-gltf-viewer/vk-gltf-viewer/vcpkg/buildtrees/gmp/autoconf-arm64-osx-err.log
+
       - name: Build
         run: cmake --build build --config release

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,8 +26,8 @@ jobs:
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
 
-      - name: Install latest LLVM and Ninja
-        run: brew install llvm ninja
+      - name: Install latest LLVM, Ninja and build dependencies
+        run: brew install llvm ninja automake
 
       - name: Install vcpkg
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
           vulkan-use-cache: true
 
       - name: Install latest LLVM, Ninja and build dependencies
-        run: brew install llvm ninja autoreconf automake
+        run: brew install llvm ninja autoconf automake
 
       - name: Install vcpkg
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_MODULE_STD 1)
 # --------------------
 
 find_package(boost_container CONFIG REQUIRED)
+find_package(CGAL CONFIG REQUIRED)
 find_package(fastgltf CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
@@ -131,6 +132,7 @@ target_sources(vk-gltf-viewer PRIVATE
 )
 target_link_libraries(vk-gltf-viewer PRIVATE
     Boost::container
+    CGAL::CGAL
     fastgltf::fastgltf
     imgui::imgui
     KTX::ktx

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Blazingly fast[^1] Vulkan glTF viewer.
   - PBR material rendering with runtime IBL resources (spherical harmonics + pre-filtered environment map) generation from input equirectangular map.
   - Runtime missing tangent attribute generation using MikkTSpace algorithm for indexed primitive.
   - Runtime missing per-face normal and tangent attribute generation using tessellation shader (if supported) or screen-space fragment shader for non-indexed primitive.
-  - No limits for `TEXCOORD_<i>` attributes: **can render a primitive that has arbitrary number of texture coordinates.**
+  - Unlimited `TEXCOORD_<i>` attributes: **can render a primitive that has arbitrary number of texture coordinates.**
   - `OPAQUE`, `MASK` (using alpha testing and Alpha To Coverage) and `BLEND` (using Weighted Blended OIT) materials.
   - Multiple scenes.
   - Binary format (`.glb`).
   - GPU compressed texture (`KHR_texture_basisu`)
 - Use 4x MSAA by default.
 - Load glTF asset and equirectangular map image using native file dialog.
-- Pixel perfect node selection and transformation usin gizmo.
+- Pixel perfect node selection and transformation using [ImGuizmo](https://github.com/CedricGuillemet/ImGuizmo).
 - Arbitrary sized outline rendering using [Jump Flooding Algorithm](https://en.wikipedia.org/wiki/Jump_flooding_algorithm).
 - Conditionally render a node with three-state visibility in scene hierarchy tree.
 - GUI for used asset resources (buffers, images, samplers, etc.) list with docking support.
@@ -44,7 +44,7 @@ I initially developed this application for leveraging Vulkan's performance and u
 
 ### Speed
 
-- Fully bindless rendering: no descriptor set update/vertex buffer binding during rendering.
+- Fully bindless: no descriptor set update/vertex buffer binding during rendering.
   - Descriptor sets are only updated at the model loading time.
   - Textures are accessed with runtime-descriptor indexing using [`VK_EXT_descriptor_indexing`](https://docs.vulkan.org/samples/latest/samples/extensions/descriptor_indexing/README.html) extension.
   - Use Vertex Pulling with [`VK_KHR_buffer_device_address`](https://docs.vulkan.org/samples/latest/samples/extensions/buffer_device_address/README.html). Only index buffers are bound to the command buffer.
@@ -87,7 +87,7 @@ The extensions and feature used in this application are quite common in the mode
   - `VK_KHR_synchronization2`
   - `VK_EXT_extended_dynamic_state` (dynamic state cull mode)
   - `VK_KHR_swapchain`
-  - `VK_KHR_swapchain_mutable_format` (proper ImGui gamma correction)
+  - (optional) `VK_KHR_swapchain_mutable_format` (proper ImGui gamma correction, UI color will lose the color if the extension not presented)
 - Device Features
   - `VkPhysicalDeviceFeatures`
     - `samplerAnistropy`
@@ -140,15 +140,16 @@ Additionally, you need vcpkg for dependency management. Make sure `VCPKG_ROOT` e
 #### Dependencies
 
 This project depends on:
+- [boost-container](https://www.boost.org/doc/libs/1_86_0/doc/html/container.html) (it uses modular boost.)
+- [CGAL](https://www.cgal.org)
+- [fastgltf](https://github.com/spnda/fastgltf)
 - [GLFW](https://github.com/glfw/glfw)
 - [glm](https://github.com/g-truc/glm)
-- [fastgltf](https://github.com/spnda/fastgltf)
 - [ImGui](https://github.com/ocornut/imgui)
 - [ImGuizmo](https://github.com/CedricGuillemet/ImGuizmo)
 - [MikkTSpace](http://www.mikktspace.com)
 - [Native File Dialog Extended](https://github.com/btzy/nativefiledialog-extended)
 - [stb_image](https://github.com/nothings/stb/blob/master/stb_image.h)
-- [boost-container](https://www.boost.org/doc/libs/1_86_0/doc/html/container.html) (it uses modular boost.)
 - My own Vulkan-Hpp helper library, [vku](https://github.com/stripe2933/vku/tree/module) (branch `module`), which has the following dependencies:
   - [Vulkan-Hpp](https://github.com/KhronosGroup/Vulkan-Hpp)
   - [VulkanMemoryAllocator-Hpp](https://github.com/YaaZ/VulkanMemoryAllocator-Hpp)
@@ -248,7 +249,7 @@ Add the following CMake user preset file in your project directory. I'll assume 
   "version": 6,
   "configurePresets": [
     {
-      "name": "clang-arm64-macos",
+      "name": "macos-clang",
       "inherits": "default",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
@@ -283,10 +284,10 @@ set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/../clang-toolchain.cmake)
 ```
 
-Configure and build the project with `clang-arm64-macos` configuration preset.
+Configure and build the project with `macos-clang` configuration preset.
 
 ```sh
-cmake --preset=clang-arm64-macos
+cmake --preset=macos-clang
 cmake --build build -t vk-gltf-viewer
 ```
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ All shaders are located in the [shaders](/shaders) folder and need to be manuall
 - [x] Basis Universal texture support (`KHR_texture_basisu`).
 - [ ] Reduce skybox memory usage with BC6H compressed cubemap.
 - [ ] Frustum/occlusion culling.
-- [ ] Automatic camera position adjustment based on the bounding sphere calculation. (working now)
+- [x] Automatic camera position adjustment based on the bounding sphere calculation.
 - [ ] Animations.
 
 ## License

--- a/impl/AppState.cpp
+++ b/impl/AppState.cpp
@@ -13,9 +13,11 @@ import glm;
 import vku;
 
 vk_gltf_viewer::AppState::AppState() noexcept
-    : camera { glm::vec3 { 5.f }, normalize(glm::vec3 { -1.f }), glm::vec3 { 0.f, 1.f, 0.f },
-        glm::radians(45.f), 1.f /* will be determined by passthru rect dimension */, 1e-2f, 1e6f }
-{
+    : camera {
+        glm::vec3 { 0.f, 0.f, -5.f }, normalize(glm::vec3 { 0.f, 0.f, 1.f }), glm::vec3 { 0.f, 1.f, 0.f },
+        glm::radians(45.f), 1.f /* will be determined by passthru rect dimension */, 1e-2f, 10.f,
+        5.f,
+    } {
     if (const std::filesystem::path path { "recent_gltf.txt" }; std::filesystem::exists(path)) {
         std::ifstream file { path, std::ios::in };
         if (file.is_open()) {

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -27,6 +27,12 @@ import :vulkan.mipmap;
 import :vulkan.pipeline.BrdfmapComputer;
 import :vulkan.pipeline.CubemapToneMappingRenderer;
 
+#ifdef _MSC_VER
+#define PATH_C_STR(...) (__VA_ARGS__).string().c_str()
+#else
+#define PATH_C_STR(...) (__VA_ARGS__).c_str()
+#endif
+
 vk_gltf_viewer::MainApp::MainApp() {
     const vulkan::pipeline::BrdfmapComputer brdfmapComputer { gpu.device };
 
@@ -612,7 +618,7 @@ auto vk_gltf_viewer::MainApp::processEqmapChange(
 ) -> void {
     // Load equirectangular map image and stage it into eqmapImage.
     int width, height;
-    if (!stbi_info(eqmapPath.string().c_str(), &width, &height, nullptr)) {
+    if (!stbi_info(PATH_C_STR(eqmapPath), &width, &height, nullptr)) {
         throw std::runtime_error { std::format("Failed to load image: {}", stbi_failure_reason()) };
     }
 
@@ -711,7 +717,7 @@ auto vk_gltf_viewer::MainApp::processEqmapChange(
             vku::ExecutionInfo { [&](vk::CommandBuffer cb) {
                 eqmapStagingBuffer = std::make_unique<vku::AllocatedBuffer>(vku::MappedBuffer {
                     gpu.allocator,
-                    std::from_range, io::StbDecoder<float>::fromFile(eqmapPath.string().c_str(), 4).asSpan(),
+                    std::from_range, io::StbDecoder<float>::fromFile(PATH_C_STR(eqmapPath), 4).asSpan(),
                     vk::BufferUsageFlagBits::eTransferSrc
                 }.unmap());
 

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -302,6 +302,13 @@ auto vk_gltf_viewer::MainApp::run() -> void {
 
                 // Update AppState.
                 appState.gltfAsset.emplace(gltfAsset->get(), gltfAsset->assetDir);
+
+                // Adjust the camera based on the scene bounding sphere.
+                const auto [sceneCenter, sceneRadius] = gltfAsset->sceneResources.getSmallestEnclosingSphere();
+                const float distance = sceneRadius / std::sin(appState.camera.fov / 2.f);
+                appState.camera.position = sceneCenter - glm::dvec3 { distance * normalize(appState.camera.direction) };
+                appState.camera.zMin = distance - sceneRadius;
+                appState.camera.zMax = distance + sceneRadius;
             },
             [&](control::imgui::task::CloseGltf) {
                 gltfAsset.reset();

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -258,7 +258,7 @@ auto vk_gltf_viewer::MainApp::run() -> void {
                 //  so I'll just use it for now.
                 gpu.device.waitIdle();
 
-                gltfAsset.emplace(task.path, gpu);
+                gltfAsset.emplace(parser, task.path, gpu);
 
                 sharedData.updateTextureCount(1 + gltfAsset->get().textures.size());
 
@@ -465,11 +465,12 @@ vk_gltf_viewer::MainApp::GltfAsset::DataBufferLoader::DataBufferLoader(const std
 }
 
 vk_gltf_viewer::MainApp::GltfAsset::GltfAsset(
+    fastgltf::Parser &parser,
     const std::filesystem::path &path,
     const vulkan::Gpu &gpu [[clang::lifetimebound]]
 ) : dataBufferLoader { path },
     assetDir { path.parent_path() },
-    assetExpected { fastgltf::Parser { supportedExtensions }.loadGltf(&dataBufferLoader.dataBuffer, assetDir) },
+    assetExpected { parser.loadGltf(&dataBufferLoader.dataBuffer, assetDir) },
     assetExternalBuffers { std::make_unique<gltf::AssetExternalBuffers>(get(), assetDir) },
     assetResources { get(), *assetExternalBuffers, gpu },
     assetTextures { get(), assetDir, *assetExternalBuffers, gpu },

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -309,6 +309,7 @@ auto vk_gltf_viewer::MainApp::run() -> void {
                 appState.camera.position = sceneCenter - glm::dvec3 { distance * normalize(appState.camera.direction) };
                 appState.camera.zMin = distance - sceneRadius;
                 appState.camera.zMax = distance + sceneRadius;
+                appState.camera.targetDistance = distance;
             },
             [&](control::imgui::task::CloseGltf) {
                 gltfAsset.reset();

--- a/impl/control/AppWindow.cpp
+++ b/impl/control/AppWindow.cpp
@@ -85,7 +85,8 @@ auto vk_gltf_viewer::control::AppWindow::createSurface(const vk::raii::Instance 
 auto vk_gltf_viewer::control::AppWindow::onScrollCallback(glm::dvec2 offset) -> void {
     if (const ImGuiIO &io = ImGui::GetIO(); io.WantCaptureMouse) return;
 
-    appState.camera.position *= std::powf(1.01f, -static_cast<float>(offset.y));
+    const glm::vec3 displacementToTarget = appState.camera.direction * appState.camera.targetDistance;
+    appState.camera.position += (1.f - std::powf(1.01f, -static_cast<float>(offset.y))) * displacementToTarget;
 }
 
 auto vk_gltf_viewer::control::AppWindow::onCursorPosCallback(glm::dvec2 position) -> void {

--- a/impl/control/ImGui.cpp
+++ b/impl/control/ImGui.cpp
@@ -1154,7 +1154,7 @@ auto vk_gltf_viewer::control::imgui::viewManipulate(AppState &appState, const Im
     constexpr ImU32 background = 0x00000000; // Transparent.
     const glm::mat4 oldView = appState.camera.getViewMatrix();
     glm::mat4 newView = oldView;
-    ImGuizmo::ViewManipulate(value_ptr(newView), length(appState.camera.position), passthruRectBR - size, size, background);
+    ImGuizmo::ViewManipulate(value_ptr(newView), appState.camera.targetDistance, passthruRectBR - size, size, background);
 
     if (newView != oldView) {
         const glm::mat4 inverseView = inverse(newView);

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -39,7 +39,6 @@ namespace vk_gltf_viewer {
             DataBufferLoader dataBufferLoader;
 
         public:
-            static constexpr fastgltf::Extensions supportedExtensions = fastgltf::Extensions::KHR_texture_basisu;
 
             std::filesystem::path assetDir;
             fastgltf::Expected<fastgltf::Asset> assetExpected;
@@ -56,7 +55,7 @@ namespace vk_gltf_viewer {
             std::unordered_map<std::size_t, vk::raii::ImageView> imageViews;
             gltf::SceneResources sceneResources;
 
-            GltfAsset(const std::filesystem::path &path, const vulkan::Gpu &gpu [[clang::lifetimebound]]);
+            GltfAsset(fastgltf::Parser &parser, const std::filesystem::path &path, const vulkan::Gpu &gpu [[clang::lifetimebound]]);
 
             [[nodiscard]] auto get() noexcept -> fastgltf::Asset&;
 
@@ -78,12 +77,16 @@ namespace vk_gltf_viewer {
             vk::raii::ImageView prefilteredmapImageView;
         };
 
+        static constexpr fastgltf::Extensions supportedExtensions = fastgltf::Extensions::KHR_texture_basisu;
+
         AppState appState;
 
         vk::raii::Context context;
         vk::raii::Instance instance = createInstance();
         control::AppWindow window { instance, appState };
         vulkan::Gpu gpu { instance, window.getSurface() };
+
+        fastgltf::Parser parser { supportedExtensions };
 
         // Buffers, images, image views and samplers.
         vku::AllocatedImage assetFallbackImage = createAssetFallbackImage();

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -39,7 +39,6 @@ namespace vk_gltf_viewer {
             DataBufferLoader dataBufferLoader;
 
         public:
-
             std::filesystem::path assetDir;
             fastgltf::Expected<fastgltf::Asset> assetExpected;
 

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -106,7 +106,7 @@ namespace vk_gltf_viewer {
         vulkan::SharedData sharedData { gpu, window.getSurface(), vk::Extent2D { static_cast<std::uint32_t>(window.getFramebufferSize().x), static_cast<std::uint32_t>(window.getFramebufferSize().y) } };
         std::array<vulkan::Frame, 2> frames{ vulkan::Frame { gpu, sharedData }, vulkan::Frame { gpu, sharedData } };
         
-        [[nodiscard]] auto createInstance() const -> decltype(instance);
+        [[nodiscard]] auto createInstance() const -> vk::raii::Instance;
         [[nodiscard]] auto createAssetFallbackImage() const -> vku::AllocatedImage;
         [[nodiscard]] auto createAssetDefaultSampler() const -> vk::raii::Sampler;
         [[nodiscard]] auto createDefaultImageBasedLightingResources() const -> ImageBasedLightingResources;

--- a/interface/control/Camera.cppm
+++ b/interface/control/Camera.cppm
@@ -13,6 +13,12 @@ namespace vk_gltf_viewer::control {
         float zMin;
         float zMax;
 
+        /**
+         * A distance to be used for <tt>ImGuizmo::ViewManipulate</tt>, which is the distance between pivot and
+         * <tt>position</tt>.
+         */
+        float targetDistance;
+
         [[nodiscard]] auto getViewMatrix() const noexcept -> glm::mat4 {
             return lookAt(position, position + direction, up);
         }

--- a/interface/gltf/SceneResources.cppm
+++ b/interface/gltf/SceneResources.cppm
@@ -110,6 +110,12 @@ namespace vk_gltf_viewer::gltf {
             return result;
         }
 
+        /**
+         * Calculate the smallest enclosing sphere of the scene meshes' bounding spheres, i.e. tight-fitting sphere.
+         * @return Pair of enclosing sphere's center coordinate and radius.
+         */
+        [[nodiscard]] auto getSmallestEnclosingSphere() const -> std::pair<glm::dvec3, double>;
+
     private:
         [[nodiscard]] auto createOrderedNodePrimitiveInfoPtrs() const -> std::vector<std::pair<std::size_t, const AssetResources::PrimitiveInfo*>>;
         [[nodiscard]] auto createNodeWorldTransformBuffer() const -> vku::MappedBuffer;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "dependencies": [
     "boost-container",
+    "cgal",
     "fastgltf",
     "glfw3",
     "glm",


### PR DESCRIPTION
This PR primarily implements the code for calculating the smallest enclosing sphere of the spheres (i.e. miniball) using CGAL, calculate the miniball of loaded scene meshes, then automatically adjusts the optimal camera position.

Also, several minor things were improved:
- `fastgltf::Parser` is now cached and could be reused multiple times.
- Documentation.