### PR TITLE
Support VK_AMD_shader_image_load_store_lod extension.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,6 @@ target_link_shaders(vk-gltf-viewer
     shaders/mask_unlit_primitive.frag
     shaders/multiply.comp
     shaders/outline.frag
-    shaders/prefilteredmap.comp
     shaders/primitive.frag
     shaders/primitive.vert
     shaders/screen_quad.vert
@@ -216,10 +215,14 @@ target_link_shaders(vk-gltf-viewer
     shaders/skybox.vert
     shaders/spherical_harmonic_coefficients_sum.comp
     shaders/spherical_harmonics.comp
-    shaders/subgroup_mipmap_16.comp
-    shaders/subgroup_mipmap_32.comp
-    shaders/subgroup_mipmap_64.comp
     shaders/unlit_primitive.frag
     shaders/unlit_primitive.vert
     shaders/weighted_blended_composition.frag
+)
+target_link_shaders_variant(vk-gltf-viewer
+    AMD_SHADER_IMAGE_LOAD_STORE_LOD "0;1"
+    shaders/prefilteredmap.comp
+    shaders/subgroup_mipmap_16.comp
+    shaders/subgroup_mipmap_32.comp
+    shaders/subgroup_mipmap_64.comp
 )

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The extensions and feature used in this application are quite common in the mode
   - `VK_KHR_swapchain`
   - (optional) `VK_KHR_swapchain_mutable_format` (proper ImGui gamma correction, UI color will lose the color if the extension not presented)
   - (optional) `VK_EXT_index_type_uint8` (if not presented, unsigned byte primitive indices will re-generated with `uint16_t`s)
+  - (optional) `VK_AMD_shader_image_load_store_lod` (can replace the descriptor indexing based cubemap mipmapping and prefilteredmap generation[^3])
 - Device Features
   - `VkPhysicalDeviceFeatures`
     - `samplerAnistropy`
@@ -109,7 +110,7 @@ The extensions and feature used in this application are quite common in the mode
     - `bufferDeviceAddress`
     - `descriptorIndexing`
     - `descriptorBindingSampledImageUpdateAfterBind`
-    - `descriptorBindingStorageImageUpdateAfterBind`
+    - `descriptorBindingStorageImageUpdateAfterBind` (if `VK_AMD_shader_image_load_store_lod` is not available)
     - `runtimeDescriptorArray`
     - `storageBuffer8BitAccess`
     - `uniformAndStorageBuffer8BitAccess`
@@ -125,7 +126,7 @@ The extensions and feature used in this application are quite common in the mode
   - Subgroup size must be at least 16 and 64 at maximum.
   - Sampler anisotropy must support 16x.
   - Loading asset texture count must be less than `maxDescriptorSetUpdateAfterBindSampledImages`
-  - Cubemap size must be less than `2^(maxDescriptorSetUpdateAfterBindStorageImages)`.
+  - Cubemap size must be less than `2^(maxDescriptorSetUpdateAfterBindStorageImages)` unless `VK_AMD_shader_image_load_store_lod` is available.
 
 </details>
 
@@ -324,3 +325,4 @@ This project is **licensed under the GPL-v3 License**. See the [LICENSE](LICENSE
 
 [^1]: I like this term because it's hilarious for several reasons, but it's no joke! It has the **significantly faster glTF model loading speed than the other the viewers** I've tested. See [Performance Comparison](https://github.com/stripe2933/vk-gltf-viewer/blob/master/docs/performance-comparison.md) page for details.
 [^2]: Applied for standard glTF 2.0 asset only. Asset with material related extensions may require additional draw calls for pipeline changing.
+[^3]: On Apple GPU platform prior to the MoltenVK 1.2.11 (which enables the Metal Argument Buffer by default), [`maxPerStageDescriptorUpdateAfterBindStorageImages` is 8](https://vulkan.gpuinfo.org/displaycoreproperty.php?platform=macos&name=maxPerStageDescriptorUpdateAfterBindStorageImages&core=1.2). It limited the cubemap resoluton and prefilteredmap roughnesslevels. Instead, it can use `VK_AMD_shader_image_load_store_lod` extension to replace the descriptor indexing based cubemap mipmapping and prefilteredmap generation.

--- a/cmake/CompileShader.cmake
+++ b/cmake/CompileShader.cmake
@@ -20,7 +20,7 @@ function(target_link_shaders TARGET)
             set(depfile "shader_depfile/${filename}.d")
             add_custom_command(
                 OUTPUT "${output}"
-                COMMAND ${Vulkan_GLSLC_EXECUTABLE} -MD -MF "${depfile}" $<$<NOT:$<CONFIG:Debug>>:-O> --target-env=vulkan1.2 "${source}" -o "${output}"
+                COMMAND ${Vulkan_GLSLC_EXECUTABLE} -MD -MF "${depfile}" $<$<CONFIG:Release>:-O> --target-env=vulkan1.2 "${source}" -o "${output}"
                 DEPENDS "${source}"
                 BYPRODUCTS "${depfile}"
                 COMMENT "Compiling SPIRV: ${source} -> ${output}"
@@ -31,7 +31,7 @@ function(target_link_shaders TARGET)
         elseif (${Vulkan_glslangValidator_FOUND})
             add_custom_command(
                 OUTPUT "${output}"
-                COMMAND ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE} -V --target-env vulkan1.2 "${source}" -o "${output}"
+                COMMAND ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE} -V $<$<CONFIG:Debug>:-Od> --target-env vulkan1.2 "${source}" -o "${output}"
                 DEPENDS "${source}"
                 COMMENT "Compiling SPIRV: ${source} -> ${output}"
                 VERBATIM
@@ -43,6 +43,58 @@ function(target_link_shaders TARGET)
         string(CONFIGURE "${TARGET}_${filename}" shader_target)
         add_custom_target("${shader_target}" DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${output}")
         add_dependencies("${TARGET}" "${shader_target}")
+    endforeach ()
+
+    target_compile_definitions(${TARGET} PRIVATE COMPILED_SHADER_DIR="shader")
+endfunction()
+
+function(target_link_shaders_variant TARGET MACRO_NAME MACRO_VALUES)
+    if (${Vulkan_glslc_FOUND})
+        message(STATUS "Using Vulkan glslc for shader compilation.")
+    elseif (${Vulkan_glslangValidator_FOUND})
+        message(WARNING "Vulkan glslc not found, using glslangValidator for shader compilation instead. Modifying indirectly included files will NOT trigger recompilation.")
+    else()
+        message(FATAL_ERROR "No shader compiler found.")
+    endif ()
+
+    foreach (source IN LISTS ARGN)
+        # Get filename from source.
+        cmake_path(GET source FILENAME filename)
+
+        # Make source path absolute.
+        cmake_path(ABSOLUTE_PATH source OUTPUT_VARIABLE source)
+
+        foreach (macro_value IN LISTS MACRO_VALUES)
+            set(output "shader/${filename}_${MACRO_NAME}_${macro_value}.spv")
+
+            if (${Vulkan_glslc_FOUND})
+                set(depfile "shader_depfile/${filename}_${MACRO_NAME}_${macro_value}.d")
+                add_custom_command(
+                    OUTPUT "${output}"
+                    COMMAND ${Vulkan_GLSLC_EXECUTABLE} -MD -MF "${depfile}" $<$<CONFIG:Release>:-O> --target-env=vulkan1.2 -D${MACRO_NAME}=${macro_value} "${source}" -o "${output}"
+                    DEPENDS "${source}"
+                    BYPRODUCTS "${depfile}"
+                    COMMENT "Compiling SPIRV: ${source} -> ${output}"
+                    DEPFILE "${depfile}"
+                    VERBATIM
+                    COMMAND_EXPAND_LISTS
+                )
+            elseif (${Vulkan_glslangValidator_FOUND})
+                add_custom_command(
+                    OUTPUT "${output}"
+                    COMMAND ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE} -V $<$<CONFIG:Debug>:-Od> --target-env vulkan1.2 "${source}" -D${MACRO_NAME}=${macro_value} -o "${output}"
+                    DEPENDS "${source}"
+                    COMMENT "Compiling SPIRV: ${source} -> ${output}"
+                    VERBATIM
+                    COMMAND_EXPAND_LISTS
+                )
+            endif ()
+
+            # Make target depends on output shader file.
+            string(CONFIGURE "${TARGET}_${filename}_${MACRO_NAME}_${macro_value}" shader_target)
+            add_custom_target("${shader_target}" DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${output}")
+            add_dependencies("${TARGET}" "${shader_target}")
+        endforeach ()
     endforeach ()
 
     target_compile_definitions(${TARGET} PRIVATE COMPILED_SHADER_DIR="shader")

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -880,7 +880,7 @@ auto vk_gltf_viewer::MainApp::processEqmapChange(
     };
     vulkan::ImageBasedLightingResourceGenerator iblGenerator { gpu, iblGeneratorConfig };
     const vulkan::ImageBasedLightingResourceGenerator::Pipelines iblGeneratorPipelines {
-        vulkan::pipeline::PrefilteredmapComputer { gpu.device, { vku::Image::maxMipLevels(iblGeneratorConfig.prefilteredmapSize), 1024 } },
+        vulkan::pipeline::PrefilteredmapComputer { gpu, { vku::Image::maxMipLevels(iblGeneratorConfig.prefilteredmapSize), 1024 } },
         vulkan::pipeline::SphericalHarmonicsComputer { gpu.device },
         vulkan::pipeline::SphericalHarmonicCoefficientsSumComputer { gpu.device },
         vulkan::pipeline::MultiplyComputer { gpu.device },

--- a/interface/vulkan/Gpu.cppm
+++ b/interface/vulkan/Gpu.cppm
@@ -77,6 +77,7 @@ namespace vk_gltf_viewer::vulkan {
         bool supportDrawIndirectCount;
         bool supportUint8Index;
         std::uint32_t subgroupSize;
+        bool supportShaderImageLoadStoreLod;
 
         Gpu(const vk::raii::Instance &instance [[clang::lifetimebound]], vk::SurfaceKHR surface);
         ~Gpu();

--- a/shaders/prefilteredmap.comp
+++ b/shaders/prefilteredmap.comp
@@ -1,5 +1,8 @@
 #version 450
 #extension GL_GOOGLE_include_directive : require
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+#extension GL_AMD_shader_image_load_store_lod : enable
+#endif
 
 #include "cubemap.glsl"
 #include "pbr.glsl"
@@ -8,10 +11,14 @@ layout (constant_id = 0) const uint ROUGHNESS_LEVELS = 8;
 layout (constant_id = 1) const uint SAMPLES = 1024;
 
 layout (set = 0, binding = 0) uniform samplerCube cubemapSampler;
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+layout (set = 0, binding = 1) writeonly uniform imageCube prefilteredmapImage;
+#else
 layout (set = 0, binding = 1) writeonly uniform imageCube prefilteredmapMipImages[ROUGHNESS_LEVELS];
+#endif
 
 layout (push_constant) uniform PushConstant {
-    uint mipLevel;
+    int mipLevel;
 } pc;
 
 layout (local_size_x = 16, local_size_y = 16) in;
@@ -19,7 +26,12 @@ layout (local_size_x = 16, local_size_y = 16) in;
 void main(){
     const float PI = 3.14159265359;
 
-    uint prefilteredmapImageSize = imageSize(prefilteredmapMipImages[0]).x >> pc.mipLevel;
+    uint prefilteredmapImageSize
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        = imageSize(prefilteredmapImage).x >> pc.mipLevel;
+#else
+        = imageSize(prefilteredmapMipImages[0]).x >> pc.mipLevel;
+#endif
     if (gl_GlobalInvocationID.x >= prefilteredmapImageSize || gl_GlobalInvocationID.y >= prefilteredmapImageSize){
         return;
     }
@@ -58,5 +70,9 @@ void main(){
     }
     prefilteredColor /= totalWeight;
 
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+    imageStoreLodAMD(prefilteredmapImage, ivec3(gl_GlobalInvocationID), pc.mipLevel, vec4(prefilteredColor, 1.0));
+#else
     imageStore(prefilteredmapMipImages[pc.mipLevel], ivec3(gl_GlobalInvocationID), vec4(prefilteredColor, 1.0));
+#endif
 }

--- a/shaders/subgroup_mipmap_16.comp
+++ b/shaders/subgroup_mipmap_16.comp
@@ -1,11 +1,18 @@
 #version 450
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_KHR_shader_subgroup_shuffle : require
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+#extension GL_AMD_shader_image_load_store_lod : enable
+#endif
 
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+layout (set = 0, binding = 0, rgba32f) uniform imageCube image;
+#else
 layout (set = 0, binding = 0, rgba32f) uniform imageCube mipImages[];
+#endif
 
 layout (push_constant) uniform PushConstant {
-    uint baseLevel;
+    int baseLevel;
     uint remainingMipLevels;
 } pc;
 
@@ -20,12 +27,23 @@ void main(){
     ));
 
     vec4 averageColor
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        = imageLoadLodAMD(image, ivec3(2 * sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel)
+        + imageLoadLodAMD(image, ivec3(2 * sampleCoordinate + ivec2(1, 0), gl_GlobalInvocationID.z), pc.baseLevel)
+        + imageLoadLodAMD(image, ivec3(2 * sampleCoordinate + ivec2(0, 1), gl_GlobalInvocationID.z), pc.baseLevel)
+        + imageLoadLodAMD(image, ivec3(2 * sampleCoordinate + ivec2(1, 1), gl_GlobalInvocationID.z), pc.baseLevel);
+#else
         = imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate, gl_GlobalInvocationID.z))
         + imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate + ivec2(1, 0), gl_GlobalInvocationID.z))
         + imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate + ivec2(0, 1), gl_GlobalInvocationID.z))
         + imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate + ivec2(1, 1), gl_GlobalInvocationID.z));
+#endif
     averageColor /= 4.0;
-    imageStore(mipImages[pc.baseLevel + 1U], ivec3(sampleCoordinate, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+    imageStoreLodAMD(image, ivec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
+#else
+    imageStore(mipImages[pc.baseLevel + 1], ivec3(sampleCoordinate, gl_GlobalInvocationID.z), averageColor);
+#endif
     if (pc.remainingMipLevels == 1U){
         return;
     }
@@ -34,7 +52,11 @@ void main(){
     averageColor += subgroupShuffleXor(averageColor, 4U /* 0b0100 */);
     averageColor /= 4.f;
     if ((gl_SubgroupInvocationID & 5U /* 0b101 */) == 5U) {
-        imageStore(mipImages[pc.baseLevel + 2U], ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 2], ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
     if (pc.remainingMipLevels == 2U){
         return;
@@ -45,7 +67,11 @@ void main(){
     averageColor /= 4.f;
 
     if ((gl_SubgroupInvocationID & 15U /* 0b1111 */) == 15U) {
-        imageStore(mipImages[pc.baseLevel + 3U], ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 3], ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
     if (pc.remainingMipLevels == 3U){
         return;
@@ -60,7 +86,11 @@ void main(){
 
     if ((gl_SubgroupID & 5U) == 5U){
         averageColor = (sharedData[gl_SubgroupID] + sharedData[gl_SubgroupID ^ 1U] + sharedData[gl_SubgroupID ^ 4U] + sharedData[gl_SubgroupID ^ 5U]) / 4.f;
-        imageStore(mipImages[pc.baseLevel + 4U], ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 4], ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
     if (pc.remainingMipLevels == 4U){
         return;
@@ -68,6 +98,10 @@ void main(){
 
     if (gl_LocalInvocationIndex == 0U){
         averageColor = (sharedData[0] + sharedData[1] + sharedData[2] + sharedData[3] + sharedData[4] + sharedData[5] + sharedData[6] + sharedData[7] + sharedData[8] + sharedData[9] + sharedData[10] + sharedData[11] + sharedData[12] + sharedData[13] + sharedData[14] + sharedData[15]) / 16.f;
-        imageStore(mipImages[pc.baseLevel + 5U], ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 5], ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
 }

--- a/shaders/subgroup_mipmap_32.comp
+++ b/shaders/subgroup_mipmap_32.comp
@@ -1,11 +1,18 @@
 #version 450
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_KHR_shader_subgroup_shuffle : require
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+#extension GL_AMD_shader_image_load_store_lod : enable
+#endif
 
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+layout (set = 0, binding = 0, rgba32f) uniform imageCube image;
+#else
 layout (set = 0, binding = 0, rgba32f) uniform imageCube mipImages[];
+#endif
 
 layout (push_constant) uniform PushConstant {
-    uint baseLevel;
+    int baseLevel;
     uint remainingMipLevels;
 } pc;
 
@@ -20,12 +27,23 @@ void main(){
     ));
 
     vec4 averageColor
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        = imageLoadLodAMD(image, ivec3(2 * sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel)
+        + imageLoadLodAMD(image, ivec3(2 * sampleCoordinate + ivec2(1, 0), gl_GlobalInvocationID.z), pc.baseLevel)
+        + imageLoadLodAMD(image, ivec3(2 * sampleCoordinate + ivec2(0, 1), gl_GlobalInvocationID.z), pc.baseLevel)
+        + imageLoadLodAMD(image, ivec3(2 * sampleCoordinate + ivec2(1, 1), gl_GlobalInvocationID.z), pc.baseLevel);
+#else
         = imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate, gl_GlobalInvocationID.z))
         + imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate + ivec2(1, 0), gl_GlobalInvocationID.z))
         + imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate + ivec2(0, 1), gl_GlobalInvocationID.z))
         + imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate + ivec2(1, 1), gl_GlobalInvocationID.z));
+#endif
     averageColor /= 4.0;
-    imageStore(mipImages[pc.baseLevel + 1U], ivec3(sampleCoordinate, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+    imageStoreLodAMD(image, ivec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
+#else
+    imageStore(mipImages[pc.baseLevel + 1], ivec3(sampleCoordinate, gl_GlobalInvocationID.z), averageColor);
+#endif
     if (pc.remainingMipLevels == 1U){
         return;
     }
@@ -34,7 +52,11 @@ void main(){
     averageColor += subgroupShuffleXor(averageColor, 8U /* 0b1000 */);
     averageColor /= 4.f;
     if ((gl_SubgroupInvocationID & 9U /* 0b1001 */) == 9U) {
-        imageStore(mipImages[pc.baseLevel + 2U], ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 2], ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
     if (pc.remainingMipLevels == 2U){
         return;
@@ -45,7 +67,11 @@ void main(){
     averageColor /= 4.f;
 
     if ((gl_SubgroupInvocationID & 27U /* 0b11011 */) == 27U) {
-        imageStore(mipImages[pc.baseLevel + 3U], ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 3], ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
     if (pc.remainingMipLevels == 3U){
         return;
@@ -61,7 +87,11 @@ void main(){
 
     if ((gl_SubgroupID & 1U) == 1U){
         averageColor = (sharedData[gl_SubgroupID] + sharedData[gl_SubgroupID ^ 1U]) / 4.f;
-        imageStore(mipImages[pc.baseLevel + 4U], ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 4], ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
     if (pc.remainingMipLevels == 4U){
         return;
@@ -69,6 +99,10 @@ void main(){
 
     if (gl_LocalInvocationIndex == 0U){
         averageColor = (sharedData[0] + sharedData[1] + sharedData[2] + sharedData[3] + sharedData[4] + sharedData[5] + sharedData[6] + sharedData[7]) / 16.f;
-        imageStore(mipImages[pc.baseLevel + 5U], ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 5], ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
 }

--- a/shaders/subgroup_mipmap_64.comp
+++ b/shaders/subgroup_mipmap_64.comp
@@ -1,11 +1,18 @@
 #version 450
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_KHR_shader_subgroup_shuffle : require
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+#extension GL_AMD_shader_image_load_store_lod : enable
+#endif
 
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+layout (set = 0, binding = 0, rgba32f) uniform imageCube image;
+#else
 layout (set = 0, binding = 0, rgba32f) uniform imageCube mipImages[];
+#endif
 
 layout (push_constant) uniform PushConstant {
-    uint baseLevel;
+    int baseLevel;
     uint remainingMipLevels;
 } pc;
 
@@ -20,12 +27,23 @@ void main(){
     ));
 
     vec4 averageColor
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        = imageLoadLodAMD(image, ivec3(2 * sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel)
+        + imageLoadLodAMD(image, ivec3(2 * sampleCoordinate + ivec2(1, 0), gl_GlobalInvocationID.z), pc.baseLevel)
+        + imageLoadLodAMD(image, ivec3(2 * sampleCoordinate + ivec2(0, 1), gl_GlobalInvocationID.z), pc.baseLevel)
+        + imageLoadLodAMD(image, ivec3(2 * sampleCoordinate + ivec2(1, 1), gl_GlobalInvocationID.z), pc.baseLevel);
+#else
         = imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate, gl_GlobalInvocationID.z))
         + imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate + ivec2(1, 0), gl_GlobalInvocationID.z))
         + imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate + ivec2(0, 1), gl_GlobalInvocationID.z))
         + imageLoad(mipImages[pc.baseLevel], ivec3(2 * sampleCoordinate + ivec2(1, 1), gl_GlobalInvocationID.z));
+#endif
     averageColor /= 4.0;
-    imageStore(mipImages[pc.baseLevel + 1U], ivec3(sampleCoordinate, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+    imageStoreLodAMD(image, ivec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
+#else
+    imageStore(mipImages[pc.baseLevel + 1], ivec3(sampleCoordinate, gl_GlobalInvocationID.z), averageColor);
+#endif
     if (pc.remainingMipLevels == 1U){
         return;
     }
@@ -34,7 +52,11 @@ void main(){
     averageColor += subgroupShuffleXor(averageColor, 8U /* 0b1000 */);
     averageColor /= 4.f;
     if ((gl_SubgroupInvocationID & 9U /* 0b1001 */) == 9U) {
-        imageStore(mipImages[pc.baseLevel + 2U], ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 2], ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
     if (pc.remainingMipLevels == 2U){
         return;
@@ -45,7 +67,11 @@ void main(){
     averageColor /= 4.f;
 
     if ((gl_SubgroupInvocationID & 27U /* 0b11011 */) == 27U) {
-        imageStore(mipImages[pc.baseLevel + 3U], ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 3], ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
     if (pc.remainingMipLevels == 3U){
         return;
@@ -56,7 +82,11 @@ void main(){
     averageColor /= 4.f;
 
     if (subgroupElect()) {
-        imageStore(mipImages[pc.baseLevel + 4U], ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 4], ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
     if (pc.remainingMipLevels == 4U){
         return;
@@ -69,6 +99,10 @@ void main(){
 
     if (gl_LocalInvocationIndex == 0U){
         averageColor = (sharedData[0] + sharedData[1] + sharedData[2] + sharedData[3]) / 4.f;
-        imageStore(mipImages[pc.baseLevel + 5U], ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), averageColor);
+#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
+        imageStoreLodAMD(image, ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
+#else
+        imageStore(mipImages[pc.baseLevel + 5], ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), averageColor);
+#endif
     }
 }


### PR DESCRIPTION
This PR adds new optimized shader path when [VK_AMD_shader_image_load_store_lod](https://vkdoc.net/extensions/VK_AMD_shader_image_load_store_lod) is available.

It can directly access the specific mip level of the storage image inside the shader, which **makes the current multiple storage image binding using [VK_EXT_descriptor_indexing](https://vkdoc.net/extensions/VK_EXT_descriptor_indexing) to be a single storage image binding**.

This could help the higher resolution cubemap and prefilteredmap generation in Apple GPU platform (without using Metal Argument Buffer).