### PR TITLE
Embed shader in executable.

### DIFF
--- a/cmake/CompileShader.cmake
+++ b/cmake/CompileShader.cmake
@@ -1,12 +1,16 @@
-function(target_link_shaders TARGET)
-    if (${Vulkan_glslc_FOUND})
-        message(STATUS "Using Vulkan glslc for shader compilation.")
-    elseif (${Vulkan_glslangValidator_FOUND})
-        message(WARNING "Vulkan glslc not found, using glslangValidator for shader compilation instead. Modifying indirectly included files will NOT trigger recompilation.")
-    else()
-        message(FATAL_ERROR "No shader compiler found.")
-    endif ()
+if (${Vulkan_glslc_FOUND})
+    message(STATUS "Using Vulkan glslc for shader compilation.")
+elseif (${Vulkan_glslangValidator_FOUND})
+    message(WARNING "Vulkan glslc not found, using glslangValidator for shader compilation instead. Modifying indirectly included files will NOT trigger recompilation.")
+else()
+    message(FATAL_ERROR "No shader compiler found.")
+endif ()
 
+function(target_link_shaders TARGET)
+    # Make target identifier.
+    string(MAKE_C_IDENTIFIER ${TARGET} target_identifier)
+
+    set(outputs "")
     foreach (source IN LISTS ARGN)
         # Get filename from source.
         cmake_path(GET source FILENAME filename)
@@ -14,88 +18,117 @@ function(target_link_shaders TARGET)
         # Make source path absolute.
         cmake_path(ABSOLUTE_PATH source OUTPUT_VARIABLE source)
 
-        set(output "shader/${filename}.spv")
+        # Make shader identifier.
+        string(MAKE_C_IDENTIFIER ${filename} shader_identifier)
 
         if (${Vulkan_glslc_FOUND})
-            set(depfile "shader_depfile/${filename}.d")
             add_custom_command(
-                OUTPUT "${output}"
-                COMMAND ${Vulkan_GLSLC_EXECUTABLE} -MD -MF "${depfile}" $<$<CONFIG:Release>:-O> --target-env=vulkan1.2 "${source}" -o "${output}"
-                DEPENDS "${source}"
-                BYPRODUCTS "${depfile}"
-                COMMENT "Compiling SPIRV: ${source} -> ${output}"
-                DEPFILE "${depfile}"
+                OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm
+                COMMAND ${Vulkan_GLSLC_EXECUTABLE} -MD -MF shader_depfile/${filename}.d $<$<CONFIG:Release>:-O> --target-env=vulkan1.2 -mfmt=num ${source} -o "shader/${filename}.h"
+                    && ${CMAKE_COMMAND} -E echo "export module ${target_identifier}:shader.${shader_identifier}\;" > shader/${filename}.cppm
+                    && ${CMAKE_COMMAND} -E echo "namespace ${target_identifier}::shader { export constexpr unsigned int ${shader_identifier}[] = {" >> shader/${filename}.cppm
+                    && ${CMAKE_COMMAND} -E cat shader/${filename}.h >> shader/${filename}.cppm
+                    && ${CMAKE_COMMAND} -E rm shader/${filename}.h
+                    && ${CMAKE_COMMAND} -E echo "}\;}" >> shader/${filename}.cppm
+                DEPENDS ${source}
+                BYPRODUCTS shader_depfile/${filename}.d
+                COMMENT "Compiling SPIR-V: ${source} -> ${filename}.cppm"
+                DEPFILE shader_depfile/${filename}.d
                 VERBATIM
                 COMMAND_EXPAND_LISTS
             )
         elseif (${Vulkan_glslangValidator_FOUND})
             add_custom_command(
-                OUTPUT "${output}"
-                COMMAND ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE} -V $<$<CONFIG:Debug>:-Od> --target-env vulkan1.2 "${source}" -o "${output}"
-                DEPENDS "${source}"
-                COMMENT "Compiling SPIRV: ${source} -> ${output}"
+                OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm
+                COMMAND ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE} -V $<$<CONFIG:Debug>:-Od> --target-env vulkan1.2 -x ${source} -o "shader/${filename}.h"
+                    && ${CMAKE_COMMAND} -E echo "export module ${target_identifier}:shader.${shader_identifier}\;" > shader/${filename}.cppm
+                    && ${CMAKE_COMMAND} -E echo "namespace ${target_identifier}::shader { export constexpr unsigned int ${shader_identifier}[] = {" >> shader/${filename}.cppm
+                    && ${CMAKE_COMMAND} -E cat shader/${filename}.h >> shader/${filename}.cppm
+                    && ${CMAKE_COMMAND} -E rm shader/${filename}.h
+                    && ${CMAKE_COMMAND} -E echo "}\;}" >> shader/${filename}.cppm
+                DEPENDS ${source}
+                COMMENT "Compiling SPIR-V: ${source}"
                 VERBATIM
                 COMMAND_EXPAND_LISTS
             )
         endif ()
 
-        # Make target depends on output shader file.
-        string(CONFIGURE "${TARGET}_${filename}" shader_target)
-        add_custom_target("${shader_target}" DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${output}")
-        add_dependencies("${TARGET}" "${shader_target}")
+        list(APPEND outputs ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm)
     endforeach ()
 
-    target_compile_definitions(${TARGET} PRIVATE COMPILED_SHADER_DIR="shader")
+    target_sources(${TARGET} PRIVATE FILE_SET CXX_MODULES FILES ${outputs})
 endfunction()
 
 function(target_link_shaders_variant TARGET MACRO_NAME MACRO_VALUES)
-    if (${Vulkan_glslc_FOUND})
-        message(STATUS "Using Vulkan glslc for shader compilation.")
-    elseif (${Vulkan_glslangValidator_FOUND})
-        message(WARNING "Vulkan glslc not found, using glslangValidator for shader compilation instead. Modifying indirectly included files will NOT trigger recompilation.")
-    else()
-        message(FATAL_ERROR "No shader compiler found.")
-    endif ()
+    # Make target identifier.
+    string(MAKE_C_IDENTIFIER ${TARGET} target_identifier)
 
+    set(outputs "")
     foreach (source IN LISTS ARGN)
         # Get filename from source.
         cmake_path(GET source FILENAME filename)
 
+        # Make shader identifier.
+        string(MAKE_C_IDENTIFIER ${filename} shader_identifier)
+
         # Make source path absolute.
         cmake_path(ABSOLUTE_PATH source OUTPUT_VARIABLE source)
 
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm
+            COMMAND ${CMAKE_COMMAND} -E echo "export module ${target_identifier}:shader.${shader_identifier}\;" > shader/${filename}.cppm
+            COMMAND ${CMAKE_COMMAND} -E echo "namespace ${target_identifier}::shader {" >> shader/${filename}.cppm
+            COMMENT "Compiling SPIR-V: ${source} (${MACRO_NAME}=${MACRO_VALUES})"
+            VERBATIM
+            COMMAND_EXPAND_LISTS
+        )
+
         foreach (macro_value IN LISTS MACRO_VALUES)
-            set(output "shader/${filename}_${MACRO_NAME}_${macro_value}.spv")
+            # Make variant identifier.
+            string(MAKE_C_IDENTIFIER "${MACRO_NAME}_${macro_value}" variant_identifier)
 
             if (${Vulkan_glslc_FOUND})
-                set(depfile "shader_depfile/${filename}_${MACRO_NAME}_${macro_value}.d")
                 add_custom_command(
-                    OUTPUT "${output}"
-                    COMMAND ${Vulkan_GLSLC_EXECUTABLE} -MD -MF "${depfile}" $<$<CONFIG:Release>:-O> --target-env=vulkan1.2 -D${MACRO_NAME}=${macro_value} "${source}" -o "${output}"
+                    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm
+                    COMMAND ${Vulkan_GLSLC_EXECUTABLE} -MD -MF shader_depfile/${filename}_${variant_identifier}.d $<$<CONFIG:Release>:-O> --target-env=vulkan1.2 -mfmt=num -D${MACRO_NAME}=${macro_value} "${source}" -o shader/${filename}_${variant_identifier}_body.h
+                        && ${CMAKE_COMMAND} -E echo "export constexpr unsigned int ${shader_identifier}_${variant_identifier}[] = {" >> shader/${filename}.cppm
+                        && ${CMAKE_COMMAND} -E cat shader/${filename}_${variant_identifier}_body.h >> shader/${filename}.cppm
+                        && ${CMAKE_COMMAND} -E rm shader/${filename}_${variant_identifier}_body.h
+                        && ${CMAKE_COMMAND} -E echo "}\;" >> shader/${filename}.cppm
                     DEPENDS "${source}"
-                    BYPRODUCTS "${depfile}"
-                    COMMENT "Compiling SPIRV: ${source} -> ${output}"
-                    DEPFILE "${depfile}"
+                    BYPRODUCTS shader_depfile/${filename}_${variant_identifier}.d
+                    DEPFILE shader_depfile/${filename}_${variant_identifier}.d
                     VERBATIM
                     COMMAND_EXPAND_LISTS
+                    APPEND
                 )
             elseif (${Vulkan_glslangValidator_FOUND})
                 add_custom_command(
-                    OUTPUT "${output}"
-                    COMMAND ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE} -V $<$<CONFIG:Debug>:-Od> --target-env vulkan1.2 "${source}" -D${MACRO_NAME}=${macro_value} -o "${output}"
+                    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm
+                    COMMAND ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE} -V $<$<CONFIG:Debug>:-Od> --target-env vulkan1.2 -x ${source} -D${MACRO_NAME}=${macro_value} -o shader/${filename}_${variant_identifier}_body.h
+                        && ${CMAKE_COMMAND} -E echo "export constexpr unsigned int ${shader_identifier}_${variant_identifier}[] = {" >> shader/${filename}.cppm
+                        && ${CMAKE_COMMAND} -E cat shader/${filename}_${variant_identifier}_body.h >> shader/${filename}.cppm
+                        && ${CMAKE_COMMAND} -E rm shader/${filename}_${variant_identifier}_body.h
+                        && ${CMAKE_COMMAND} -E echo "}\;" >> shader/${filename}.cppm
                     DEPENDS "${source}"
-                    COMMENT "Compiling SPIRV: ${source} -> ${output}"
                     VERBATIM
                     COMMAND_EXPAND_LISTS
+                    APPEND
                 )
             endif ()
 
-            # Make target depends on output shader file.
-            string(CONFIGURE "${TARGET}_${filename}_${MACRO_NAME}_${macro_value}" shader_target)
-            add_custom_target("${shader_target}" DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${output}")
-            add_dependencies("${TARGET}" "${shader_target}")
         endforeach ()
+
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm
+            COMMAND ${CMAKE_COMMAND} -E echo "}" >> shader/${filename}.cppm
+            APPEND
+            VERBATIM
+            COMMAND_EXPAND_LISTS
+        )
+
+        list(APPEND outputs ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm)
     endforeach ()
 
-    target_compile_definitions(${TARGET} PRIVATE COMPILED_SHADER_DIR="shader")
+    target_sources(${TARGET} PRIVATE FILE_SET CXX_MODULES FILES ${outputs})
 endfunction()

--- a/impl/vulkan/pipeline/BrdfmapComputer.cpp
+++ b/impl/vulkan/pipeline/BrdfmapComputer.cpp
@@ -6,6 +6,7 @@ module vk_gltf_viewer;
 import :vulkan.pipeline.BrdfmapComputer;
 
 import std;
+import :shader.brdfmap_comp;
 
 vk_gltf_viewer::vulkan::pipeline::BrdfmapComputer::DescriptorSetLayout::DescriptorSetLayout(
     const vk::raii::Device &device
@@ -29,13 +30,14 @@ vk_gltf_viewer::vulkan::pipeline::BrdfmapComputer::BrdfmapComputer(
         {},
         createPipelineStages(
             device,
-            vku::Shader::fromSpirvFile(
-                COMPILED_SHADER_DIR "/brdfmap.comp.spv",
+            vku::Shader {
+                shader::brdfmap_comp,
                 vk::ShaderStageFlagBits::eCompute,
                 vku::unsafeAddress(vk::SpecializationInfo {
                     vku::unsafeProxy(vk::SpecializationMapEntry { 0, 0, sizeof(SpecializationConstants::numSamples) }),
                     vk::ArrayProxyNoTemporaries<const SpecializationConstants>(specializationConstants),
-                }))).get()[0],
+                }),
+            }).get()[0],
         *pipelineLayout,
     } } { }
 

--- a/impl/vulkan/pipeline/JumpFloodComputer.cpp
+++ b/impl/vulkan/pipeline/JumpFloodComputer.cpp
@@ -7,6 +7,7 @@ import :vulkan.pipeline.JumpFloodComputer;
 
 import std;
 import :math.extended_arithmetic;
+import :shader.jump_flood_comp;
 
 struct vk_gltf_viewer::vulkan::pipeline::JumpFloodComputer::PushConstant {
     vk::Bool32 forward;
@@ -38,7 +39,7 @@ vk_gltf_viewer::vulkan::pipeline::JumpFloodComputer::JumpFloodComputer(
         {},
         createPipelineStages(
             device,
-            vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/jump_flood.comp.spv", vk::ShaderStageFlagBits::eCompute)).get()[0],
+            vku::Shader { shader::jump_flood_comp, vk::ShaderStageFlagBits::eCompute }).get()[0],
         *pipelineLayout,
     } } { }
 

--- a/interface/vulkan/pipeline/BlendPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/BlendPrimitiveRenderer.cppm
@@ -1,6 +1,11 @@
 export module vk_gltf_viewer:vulkan.pipeline.BlendPrimitiveRenderer;
 
+import std;
 import vku;
+import :shader.faceted_primitive_vert;
+import :shader.primitive_vert;
+import :shader.blend_faceted_primitive_frag;
+import :shader.blend_primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
 
@@ -14,16 +19,18 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         ) : Pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(
+                    vku::Shader {
                         fragmentShaderTBN
-                            ? COMPILED_SHADER_DIR "/faceted_primitive.vert.spv"
-                            : COMPILED_SHADER_DIR "/primitive.vert.spv",
-                        vk::ShaderStageFlagBits::eVertex),
-                    vku::Shader::fromSpirvFile(
+                            ? std::span<const std::uint32_t> { shader::faceted_primitive_vert }
+                            : std::span<const std::uint32_t> { shader::primitive_vert },
+                        vk::ShaderStageFlagBits::eVertex,
+                    },
+                    vku::Shader {
                         fragmentShaderTBN
-                            ? COMPILED_SHADER_DIR "/blend_faceted_primitive.frag.spv"
-                            : COMPILED_SHADER_DIR "/blend_primitive.frag.spv",
-                        vk::ShaderStageFlagBits::eFragment)).get(),
+                            ? std::span<const std::uint32_t> { shader::blend_faceted_primitive_frag }
+                            : std::span<const std::uint32_t> { shader::blend_primitive_frag },
+                        vk::ShaderStageFlagBits::eFragment,
+                    }).get(),
                 *layout, 1, true, vk::SampleCountFlagBits::e4)
             .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/BlendUnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/BlendUnlitPrimitiveRenderer.cppm
@@ -1,6 +1,8 @@
 export module vk_gltf_viewer:vulkan.pipeline.BlendUnlitPrimitiveRenderer;
 
 import vku;
+import :shader.unlit_primitive_vert;
+import :shader.blend_unlit_primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
 
@@ -13,8 +15,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         ) : Pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/unlit_primitive.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/blend_unlit_primitive.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                    vku::Shader { shader::unlit_primitive_vert, vk::ShaderStageFlagBits::eVertex },
+                    vku::Shader { shader::blend_unlit_primitive_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                 *layout, 1, true, vk::SampleCountFlagBits::e4)
             .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/CubemapComputer.cppm
+++ b/interface/vulkan/pipeline/CubemapComputer.cppm
@@ -7,6 +7,7 @@ export module vk_gltf_viewer:vulkan.pipeline.CubemapComputer;
 import std;
 import vku;
 export import vulkan_hpp;
+import :shader.cubemap_comp;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export struct CubemapComputer {
@@ -51,7 +52,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 {},
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/cubemap.comp.spv", vk::ShaderStageFlagBits::eCompute)).get()[0],
+                    vku::Shader { shader::cubemap_comp, vk::ShaderStageFlagBits::eCompute }).get()[0],
                 *pipelineLayout,
             } } { }
 

--- a/interface/vulkan/pipeline/CubemapToneMappingRenderer.cppm
+++ b/interface/vulkan/pipeline/CubemapToneMappingRenderer.cppm
@@ -3,6 +3,8 @@ export module vk_gltf_viewer:vulkan.pipeline.CubemapToneMappingRenderer;
 import std;
 export import glm;
 export import vku;
+import :shader.screen_quad_vert;
+import :shader.cubemap_tone_mapping_frag;
 export import :vulkan.rp.CubemapToneMapping;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -33,8 +35,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/screen_quad.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/cubemap_tone_mapping.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                    vku::Shader { shader::screen_quad_vert, vk::ShaderStageFlagBits::eVertex },
+                    vku::Shader { shader::cubemap_tone_mapping_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                 *pipelineLayout, 1)
                 .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                     {},

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -1,6 +1,8 @@
 export module vk_gltf_viewer:vulkan.pipeline.DepthRenderer;
 
 import vku;
+import :shader.depth_vert;
+import :shader.depth_frag;
 export import :vulkan.pl.PrimitiveNoShading;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -12,8 +14,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 vku::getDefaultGraphicsPipelineCreateInfo(
                     createPipelineStages(
                         device,
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/depth.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/depth.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                        vku::Shader { shader::depth_vert, vk::ShaderStageFlagBits::eVertex },
+                        vku::Shader { shader::depth_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                     *layout, 1, true)
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -1,6 +1,8 @@
 export module vk_gltf_viewer:vulkan.pipeline.JumpFloodSeedRenderer;
 
 import vku;
+import :shader.jump_flood_seed_vert;
+import :shader.jump_flood_seed_frag;
 export import :vulkan.pl.PrimitiveNoShading;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -12,8 +14,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 vku::getDefaultGraphicsPipelineCreateInfo(
                     createPipelineStages(
                         device,
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/jump_flood_seed.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/jump_flood_seed.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                        vku::Shader { shader::jump_flood_seed_vert, vk::ShaderStageFlagBits::eVertex },
+                        vku::Shader { shader::jump_flood_seed_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                     *layout, 1, true)
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},

--- a/interface/vulkan/pipeline/MaskDepthRenderer.cppm
+++ b/interface/vulkan/pipeline/MaskDepthRenderer.cppm
@@ -1,6 +1,8 @@
 export module vk_gltf_viewer:vulkan.pipeline.MaskDepthRenderer;
 
 import vku;
+import :shader.mask_depth_vert;
+import :shader.mask_depth_frag;
 export import :vulkan.pl.PrimitiveNoShading;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -12,8 +14,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 vku::getDefaultGraphicsPipelineCreateInfo(
                     createPipelineStages(
                         device,
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/mask_depth.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/mask_depth.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                        vku::Shader { shader::mask_depth_vert, vk::ShaderStageFlagBits::eVertex },
+                        vku::Shader { shader::mask_depth_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                     *layout, 1, true)
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},

--- a/interface/vulkan/pipeline/MaskJumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/MaskJumpFloodSeedRenderer.cppm
@@ -1,6 +1,8 @@
 export module vk_gltf_viewer:vulkan.pipeline.MaskJumpFloodSeedRenderer;
 
 import vku;
+import :shader.mask_jump_flood_seed_vert;
+import :shader.mask_jump_flood_seed_frag;
 export import :vulkan.pl.PrimitiveNoShading;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -12,8 +14,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 vku::getDefaultGraphicsPipelineCreateInfo(
                     createPipelineStages(
                         device,
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/mask_jump_flood_seed.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/mask_jump_flood_seed.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                        vku::Shader { shader::mask_jump_flood_seed_vert, vk::ShaderStageFlagBits::eVertex },
+                        vku::Shader { shader::mask_jump_flood_seed_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                     *layout, 1, true)
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},

--- a/interface/vulkan/pipeline/MaskPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/MaskPrimitiveRenderer.cppm
@@ -1,6 +1,11 @@
 export module vk_gltf_viewer:vulkan.pipeline.MaskPrimitiveRenderer;
 
+import std;
 import vku;
+import :shader.faceted_primitive_vert;
+import :shader.primitive_vert;
+import :shader.mask_faceted_primitive_frag;
+import :shader.mask_primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
 
@@ -14,16 +19,18 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         ) : Pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(
+                    vku::Shader {
                         fragmentShaderTBN
-                            ? COMPILED_SHADER_DIR "/faceted_primitive.vert.spv"
-                            : COMPILED_SHADER_DIR "/primitive.vert.spv",
-                        vk::ShaderStageFlagBits::eVertex),
-                    vku::Shader::fromSpirvFile(
+                            ? std::span<const std::uint32_t> { shader::faceted_primitive_vert }
+                            : std::span<const std::uint32_t> { shader::primitive_vert },
+                        vk::ShaderStageFlagBits::eVertex,
+                    },
+                    vku::Shader {
                         fragmentShaderTBN
-                            ? COMPILED_SHADER_DIR "/mask_faceted_primitive.frag.spv"
-                            : COMPILED_SHADER_DIR "/mask_primitive.frag.spv",
-                        vk::ShaderStageFlagBits::eFragment)).get(),
+                            ? std::span<const std::uint32_t> { shader::mask_faceted_primitive_frag }
+                            : std::span<const std::uint32_t> { shader::mask_primitive_frag },
+                        vk::ShaderStageFlagBits::eFragment,
+                    }).get(),
                 *layout, 1, true, vk::SampleCountFlagBits::e4)
             .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/MaskUnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/MaskUnlitPrimitiveRenderer.cppm
@@ -1,6 +1,8 @@
 export module vk_gltf_viewer:vulkan.pipeline.MaskUnlitPrimitiveRenderer;
 
 import vku;
+import :shader.unlit_primitive_vert;
+import :shader.mask_unlit_primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
 
@@ -13,8 +15,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         ) : Pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/unlit_primitive.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/mask_unlit_primitive.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                    vku::Shader { shader::unlit_primitive_vert, vk::ShaderStageFlagBits::eVertex },
+                    vku::Shader { shader::mask_unlit_primitive_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                 *layout, 1, true, vk::SampleCountFlagBits::e4)
             .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/MultiplyComputer.cppm
+++ b/interface/vulkan/pipeline/MultiplyComputer.cppm
@@ -8,6 +8,7 @@ import std;
 import vku;
 export import vulkan_hpp;
 import :math.extended_arithmetic;
+import :shader.multiply_comp;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class MultiplyComputer {
@@ -51,7 +52,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 {},
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/multiply.comp.spv", vk::ShaderStageFlagBits::eCompute)).get()[0],
+                    vku::Shader { shader::multiply_comp, vk::ShaderStageFlagBits::eCompute }).get()[0],
                 *pipelineLayout,
             } } { }
 

--- a/interface/vulkan/pipeline/OutlineRenderer.cppm
+++ b/interface/vulkan/pipeline/OutlineRenderer.cppm
@@ -3,6 +3,8 @@ export module vk_gltf_viewer:vulkan.pipeline.OutlineRenderer;
 import std;
 export import glm;
 export import vku;
+import :shader.screen_quad_vert;
+import :shader.outline_frag;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export struct OutlineRenderer {
@@ -42,8 +44,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 vku::getDefaultGraphicsPipelineCreateInfo(
                     createPipelineStages(
                         device,
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/screen_quad.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                        vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/outline.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                        vku::Shader { shader::screen_quad_vert, vk::ShaderStageFlagBits::eVertex },
+                        vku::Shader { shader::outline_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                     *pipelineLayout,
                     1)
                     .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {

--- a/interface/vulkan/pipeline/PrefilteredmapComputer.cppm
+++ b/interface/vulkan/pipeline/PrefilteredmapComputer.cppm
@@ -8,6 +8,7 @@ export module vk_gltf_viewer:vulkan.pipeline.PrefilteredmapComputer;
 
 import std;
 import :math.extended_arithmetic;
+import :shader.prefilteredmap_comp;
 export import :vulkan.Gpu;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -86,10 +87,10 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 {},
                 createPipelineStages(
                     gpu.device,
-                    vku::Shader::fromSpirvFile(
+                    vku::Shader {
                         gpu.supportShaderImageLoadStoreLod
-                            ? COMPILED_SHADER_DIR "/prefilteredmap.comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_1.spv"
-                            : COMPILED_SHADER_DIR "/prefilteredmap.comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_0.spv",
+                            ? std::span<const std::uint32_t> { shader::prefilteredmap_comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_1 }
+                            : std::span<const std::uint32_t> { shader::prefilteredmap_comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_0 },
                         vk::ShaderStageFlagBits::eCompute,
                         vku::unsafeAddress(vk::SpecializationInfo {
                             vku::unsafeProxy({
@@ -97,7 +98,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                                 vk::SpecializationMapEntry { 1, offsetof(SpecializationConstants, samples), sizeof(SpecializationConstants::samples) },
                             }),
                             vk::ArrayProxyNoTemporaries<const SpecializationConstants>(specializationConstants),
-                        }))).get()[0],
+                        }),
+                    }).get()[0],
                 *pipelineLayout,
             } } { }
 

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -1,6 +1,11 @@
 export module vk_gltf_viewer:vulkan.pipeline.PrimitiveRenderer;
 
+import std;
 import vku;
+import :shader.faceted_primitive_vert;
+import :shader.primitive_vert;
+import :shader.faceted_primitive_frag;
+import :shader.primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
 
@@ -14,16 +19,18 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         ) : Pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(
+                    vku::Shader {
                         fragmentShaderTBN
-                            ? COMPILED_SHADER_DIR "/faceted_primitive.vert.spv"
-                            : COMPILED_SHADER_DIR "/primitive.vert.spv",
-                        vk::ShaderStageFlagBits::eVertex),
-                    vku::Shader::fromSpirvFile(
+                            ? std::span<const std::uint32_t> { shader::faceted_primitive_vert }
+                            : std::span<const std::uint32_t> { shader::primitive_vert },
+                        vk::ShaderStageFlagBits::eVertex,
+                    },
+                    vku::Shader {
                         fragmentShaderTBN
-                            ? COMPILED_SHADER_DIR "/faceted_primitive.frag.spv"
-                            : COMPILED_SHADER_DIR "/primitive.frag.spv",
-                        vk::ShaderStageFlagBits::eFragment)).get(),
+                            ? std::span<const std::uint32_t> { shader::faceted_primitive_frag }
+                            : std::span<const std::uint32_t> { shader::primitive_frag },
+                        vk::ShaderStageFlagBits::eFragment,
+                    }).get(),
                 *layout, 1, true, vk::SampleCountFlagBits::e4)
             .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/SkyboxRenderer.cppm
+++ b/interface/vulkan/pipeline/SkyboxRenderer.cppm
@@ -6,6 +6,8 @@ export module vk_gltf_viewer:vulkan.pipeline.SkyboxRenderer;
 
 import std;
 export import glm;
+import :shader.skybox_frag;
+import :shader.skybox_vert;
 export import :vulkan.buffer.CubeIndices;
 export import :vulkan.dsl.Skybox;
 export import :vulkan.rp.Scene;
@@ -37,14 +39,15 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/skybox.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                    vku::Shader::fromSpirvFile(
-                        COMPILED_SHADER_DIR "/skybox.frag.spv",
+                    vku::Shader { shader::skybox_vert, vk::ShaderStageFlagBits::eVertex },
+                    vku::Shader {
+                        shader::skybox_frag,
                         vk::ShaderStageFlagBits::eFragment,
                         vku::unsafeAddress(vk::SpecializationInfo {
                             vku::unsafeProxy(vk::SpecializationMapEntry { 0, 0, sizeof(vk::Bool32) }),
                             vku::unsafeProxy<vk::Bool32>(isCubemapImageToneMapped),
-                        }))).get(),
+                        }),
+                    }).get(),
                 *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
                 .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                     {},

--- a/interface/vulkan/pipeline/SphericalHarmonicCoefficientsSumComputer.cppm
+++ b/interface/vulkan/pipeline/SphericalHarmonicCoefficientsSumComputer.cppm
@@ -8,6 +8,7 @@ import std;
 import vku;
 export import vulkan_hpp;
 import :math.extended_arithmetic;
+import :shader.spherical_harmonic_coefficients_sum_comp;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class SphericalHarmonicCoefficientsSumComputer {
@@ -49,7 +50,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 {},
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/spherical_harmonic_coefficients_sum.comp.spv", vk::ShaderStageFlagBits::eCompute)).get()[0],
+                    vku::Shader { shader::spherical_harmonic_coefficients_sum_comp, vk::ShaderStageFlagBits::eCompute }).get()[0],
                 *pipelineLayout,
             } } { }
 

--- a/interface/vulkan/pipeline/SphericalHarmonicsComputer.cppm
+++ b/interface/vulkan/pipeline/SphericalHarmonicsComputer.cppm
@@ -7,6 +7,7 @@ export module vk_gltf_viewer:vulkan.pipeline.SphericalHarmonicsComputer;
 import std;
 import vku;
 export import vulkan_hpp;
+import :shader.spherical_harmonics_comp;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     class SphericalHarmonicsComputer {
@@ -41,7 +42,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 {},
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/spherical_harmonics.comp.spv", vk::ShaderStageFlagBits::eCompute)).get()[0],
+                    vku::Shader { shader::spherical_harmonics_comp, vk::ShaderStageFlagBits::eCompute }).get()[0],
                 *pipelineLayout,
             } } { }
 

--- a/interface/vulkan/pipeline/SubgroupMipmapComputer.cppm
+++ b/interface/vulkan/pipeline/SubgroupMipmapComputer.cppm
@@ -8,6 +8,9 @@ export module vk_gltf_viewer:vulkan.pipeline.SubgroupMipmapComputer;
 
 import std;
 import :helpers.ranges;
+import :shader.subgroup_mipmap_16_comp;
+import :shader.subgroup_mipmap_32_comp;
+import :shader.subgroup_mipmap_64_comp;
 export import :vulkan.Gpu;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -63,9 +66,20 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 {},
                 createPipelineStages(
                     gpu.device,
-                    vku::Shader::fromSpirvFile(std::format(
-                        COMPILED_SHADER_DIR "/subgroup_mipmap_{}.comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_{}.spv",
-                        gpu.subgroupSize, gpu.supportShaderImageLoadStoreLod ? 1 : 0), vk::ShaderStageFlagBits::eCompute)).get()[0],
+                    vku::Shader {
+                        gpu.subgroupSize == 16U
+                            ? gpu.supportShaderImageLoadStoreLod
+                                ? std::span<const std::uint32_t> { shader::subgroup_mipmap_16_comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_1 }
+                                : std::span<const std::uint32_t> { shader::subgroup_mipmap_16_comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_0 }
+                            : gpu.subgroupSize == 32U
+                                ? gpu.supportShaderImageLoadStoreLod
+                                    ? std::span<const std::uint32_t> { shader::subgroup_mipmap_32_comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_1 }
+                                    : std::span<const std::uint32_t> { shader::subgroup_mipmap_32_comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_0 }
+                                : gpu.supportShaderImageLoadStoreLod
+                                    ? std::span<const std::uint32_t> { shader::subgroup_mipmap_64_comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_1 }
+                                    : std::span<const std::uint32_t> { shader::subgroup_mipmap_64_comp_AMD_SHADER_IMAGE_LOAD_STORE_LOD_0 },
+                        vk::ShaderStageFlagBits::eCompute,
+                    }).get()[0],
                 *pipelineLayout,
             } } { }
 

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -1,6 +1,8 @@
 export module vk_gltf_viewer:vulkan.pipeline.UnlitPrimitiveRenderer;
 
 import vku;
+import :shader.unlit_primitive_vert;
+import :shader.unlit_primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
 
@@ -13,8 +15,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         ) : Pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/unlit_primitive.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/unlit_primitive.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                    vku::Shader { shader::unlit_primitive_vert, vk::ShaderStageFlagBits::eVertex },
+                    vku::Shader { shader::unlit_primitive_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                 *layout, 1, true, vk::SampleCountFlagBits::e4)
             .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/WeightedBlendedCompositionRenderer.cppm
+++ b/interface/vulkan/pipeline/WeightedBlendedCompositionRenderer.cppm
@@ -2,6 +2,8 @@ export module vk_gltf_viewer:vulkan.pipeline.WeightedBlendedCompositionRenderer;
 
 import vku;
 export import vulkan_hpp;
+import :shader.screen_quad_vert;
+import :shader.weighted_blended_composition_frag;
 export import :vulkan.rp.Scene;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -35,8 +37,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/screen_quad.vert.spv", vk::ShaderStageFlagBits::eVertex),
-                    vku::Shader::fromSpirvFile(COMPILED_SHADER_DIR "/weighted_blended_composition.frag.spv", vk::ShaderStageFlagBits::eFragment)).get(),
+                    vku::Shader { shader::screen_quad_vert, vk::ShaderStageFlagBits::eVertex },
+                    vku::Shader { shader::weighted_blended_composition_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                 *pipelineLayout, 1)
                 .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                     {},


### PR DESCRIPTION
Instead of loading compiled SPIR-V files in runtime (which could be erroneous if the executable is not in the working directory), it converts a compiled SPIR-V file into 32-bit unsigned int arrays, creates module partition units for them and links it to the target.

For example, the following script

```cmake
target_link_shaders(main
    shaders/triangle.vert
    shaders/triangle.frag
    ...
)
```

will create two module partition units at `build/shader/triangle.vert.cppm`, `build/shader/triangle.frag.cppm`.

`build/shader/triangle.vert.cppm`
```c++
export module main;

namespace main::shader {
    export constexpr unsigned int triangle_vert[] = { ... };
}
```

`build/shader/triangle.frag.cppm`
```c++
export module main;

namespace main::shader {
    export constexpr unsigned int triangle_frag[] = { ... };
}
```

If shader variants are specified using `target_link_shaders_variant`, only primary shader file name is used for module partition unit name, and variants are goes into the same file, like:

```cmake
target_link_shaders_variant(main
    SUBGROUP_SIZE "16;32;64"
    shaders/calculate.comp
)
```

`build/shader/calculate.comp.cppm`
```c++
namespace main::shader {
    export constexpr unsigned int calculate_comp_SUBGROUP_SIZE_16[] = { ... };
    export constexpr unsigned int calculate_comp_SUBGROUP_SIZE_32[] = { ... };
    export constexpr unsigned int calculate_comp_SUBGROUP_SIZE_64[] = { ... };
}
```