### PR TITLE
Implemented KHR_materials_variants.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/gltf/AssetProcessError.cppm
         interface/gltf/AssetSceneGpuBuffers.cppm
         interface/gltf/AssetSceneHierarchy.cppm
+        interface/gltf/MaterialVariantsMapping.cppm
         interface/helpers/concepts.cppm
         interface/helpers/fastgltf.cppm
         interface/helpers/formatter/ByteSize.cppm

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Blazingly fast[^1] Vulkan glTF viewer.
   - Binary format (`.glb`).
 - Support glTF 2.0 extensions:
   - [`KHR_materials_unlit`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_unlit) for lighting independent material shading
+  - [`KHR_materials_variants`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_variants)
   - [`KHR_texture_basisu`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_basisu) for BC7 GPU compression texture decoding
   - [`EXT_mesh_gpu_instancing`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing) for instancing multiple meshes with the same geometry
 - Use 4x MSAA by default.

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -335,6 +335,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::assetSamplers(std::span<fastgl
 
     // bottomSidebar
     ImGui::DockBuilderDockWindow("Material Editor", bottomSidebar);
+    ImGui::DockBuilderDockWindow("Material Variants", bottomSidebar);
 
     ImGui::DockBuilderFinish(dockSpaceOverViewport);
 
@@ -655,6 +656,24 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
     ImGui::End();
 
     materialEditorCalled = true;
+}
+
+void vk_gltf_viewer::control::ImGuiTaskCollector::materialVariants(const fastgltf::Asset &asset) {
+    assert(!asset.materialVariants.empty());
+
+    if (ImGui::Begin("Material Variants")) {
+        static int selectedMaterialVariantIndex = 0;
+        if (asset.materialVariants.size() <= selectedMaterialVariantIndex) {
+            selectedMaterialVariantIndex = 0;
+        }
+
+        for (const auto &[i, variantName] : asset.materialVariants | ranges::views::enumerate) {
+            if (ImGui::RadioButton(variantName.c_str(), &selectedMaterialVariantIndex, i)) {
+                tasks.emplace_back(std::in_place_type<task::SelectMaterialVariants>, i);
+            }
+        }
+    }
+    ImGui::End();
 }
 
 void vk_gltf_viewer::control::ImGuiTaskCollector::sceneHierarchy(

--- a/impl/gltf/AssetGpuBuffers.cpp
+++ b/impl/gltf/AssetGpuBuffers.cpp
@@ -8,10 +8,34 @@ import :gltf.AssetGpuBuffers;
 
 import std;
 import :helpers.fastgltf;
+import :helpers.functional;
 import :helpers.ranges;
 
 #define FWD(...) static_cast<decltype(__VA_ARGS__) &&>(__VA_ARGS__)
 #define LIFT(...) [&](auto &&...xs) { return (__VA_ARGS__)(FWD(xs)...); }
+
+bool vk_gltf_viewer::gltf::AssetGpuBuffers::updatePrimitiveMaterial(
+    const fastgltf::Primitive &primitive,
+    std::uint32_t materialIndex,
+    vk::CommandBuffer transferCommandBuffer
+) {
+    const std::uint16_t orderedPrimitiveIndex = primitiveInfos.at(&primitive).index;
+    const std::uint32_t paddedMaterialIndex = padMaterialIndex(materialIndex);
+    return std::visit(multilambda {
+        [&](vku::MappedBuffer &primitiveBuffer) {
+            primitiveBuffer.asRange<GpuPrimitive>()[orderedPrimitiveIndex].materialIndex = paddedMaterialIndex;
+            return false;
+        },
+        [&](vk::Buffer primitiveBuffer) {
+            transferCommandBuffer.updateBuffer(
+                primitiveBuffer,
+                sizeof(GpuPrimitive) * orderedPrimitiveIndex + offsetof(GpuPrimitive, materialIndex),
+                sizeof(GpuPrimitive::materialIndex),
+                &paddedMaterialIndex);
+            return true;
+        }
+    }, primitiveBuffer);
+}
 
 std::vector<const fastgltf::Primitive*> vk_gltf_viewer::gltf::AssetGpuBuffers::createOrderedPrimitives() const {
     return asset.meshes
@@ -94,8 +118,8 @@ vku::AllocatedBuffer vk_gltf_viewer::gltf::AssetGpuBuffers::createMaterialBuffer
     return dstBuffer;
 }
 
-vku::AllocatedBuffer vk_gltf_viewer::gltf::AssetGpuBuffers::createPrimitiveBuffer() {
-    vku::AllocatedBuffer stagingBuffer = vku::MappedBuffer {
+std::variant<vku::AllocatedBuffer, vku::MappedBuffer> vk_gltf_viewer::gltf::AssetGpuBuffers::createPrimitiveBuffer() {
+    vku::MappedBuffer stagingBuffer {
         gpu.allocator,
         std::from_range, orderedPrimitives | std::views::transform([this](const fastgltf::Primitive *pPrimitive) {
             const AssetPrimitiveInfo &primitiveInfo = primitiveInfos[pPrimitive];
@@ -114,15 +138,11 @@ vku::AllocatedBuffer vk_gltf_viewer::gltf::AssetGpuBuffers::createPrimitiveBuffe
                 .positionByteStride = primitiveInfo.positionInfo.byteStride,
                 .normalByteStride = normalInfo.byteStride,
                 .tangentByteStride = tangentInfo.byteStride,
-                .materialIndex
-                    = primitiveInfo.materialIndex.transform([](std::size_t index) {
-                        return 1U /* index 0 is reserved for the fallback material */ + static_cast<std::uint32_t>(index);
-                    })
-                    .value_or(0U),
+                .materialIndex = primitiveInfo.materialIndex.transform(padMaterialIndex).value_or(0U),
             };
         }),
         gpu.isUmaDevice ? vk::BufferUsageFlagBits::eStorageBuffer : vk::BufferUsageFlagBits::eTransferSrc,
-    }.unmap();
+    };
 
     if (gpu.isUmaDevice || vku::contains(gpu.allocator.getAllocationMemoryProperties(stagingBuffer.allocation), vk::MemoryPropertyFlagBits::eDeviceLocal)) {
         return stagingBuffer;
@@ -134,7 +154,7 @@ vku::AllocatedBuffer vk_gltf_viewer::gltf::AssetGpuBuffers::createPrimitiveBuffe
         vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferDst,
     } };
     stagingInfos.emplace_back(
-        std::move(stagingBuffer),
+        std::move(stagingBuffer).unmap(),
         dstBuffer,
         vk::BufferCopy{ 0, 0, dstBuffer.size });
     return dstBuffer;

--- a/impl/gltf/AssetGpuBuffers.cpp
+++ b/impl/gltf/AssetGpuBuffers.cpp
@@ -24,7 +24,7 @@ std::vector<const fastgltf::Primitive*> vk_gltf_viewer::gltf::AssetGpuBuffers::c
 auto vk_gltf_viewer::gltf::AssetGpuBuffers::createPrimitiveInfos() const -> std::unordered_map<const fastgltf::Primitive*, AssetPrimitiveInfo> {
     return orderedPrimitives
         | ranges::views::enumerate
-        | ranges::views::decompose_transform([](std::uint32_t primitiveIndex, const fastgltf::Primitive *pPrimitive) {
+        | ranges::views::decompose_transform([](std::uint16_t primitiveIndex, const fastgltf::Primitive *pPrimitive) {
             return std::pair {
                 pPrimitive,
                 AssetPrimitiveInfo {

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -9,6 +9,7 @@ import :gltf.AssetGpuTextures;
 import :gltf.AssetGpuFallbackTexture;
 import :gltf.AssetSceneGpuBuffers;
 import :gltf.AssetSceneHierarchy;
+import :gltf.MaterialVariantsMapping;
 import :vulkan.dsl.Asset;
 import :vulkan.dsl.ImageBasedLighting;
 import :vulkan.dsl.Scene;
@@ -45,6 +46,11 @@ namespace vk_gltf_viewer {
              * type is mutable reference is to allow the user to change some trivial properties.
              */
             fastgltf::Asset asset;
+
+            /**
+             * @brief Associative data structure for KHR_materials_variants.
+             */
+            gltf::MaterialVariantsMapping materialVariantsMapping { asset };
 
         private:
             const vulkan::Gpu &gpu;
@@ -127,7 +133,7 @@ namespace vk_gltf_viewer {
         // glTF resources.
         // --------------------
 
-        fastgltf::Parser parser { fastgltf::Extensions::KHR_materials_unlit | fastgltf::Extensions::KHR_texture_basisu | fastgltf::Extensions::EXT_mesh_gpu_instancing };
+        fastgltf::Parser parser { fastgltf::Extensions::KHR_materials_unlit | fastgltf::Extensions::KHR_materials_variants | fastgltf::Extensions::KHR_texture_basisu | fastgltf::Extensions::EXT_mesh_gpu_instancing };
         std::optional<Gltf> gltf;
 
         // --------------------

--- a/interface/control/ImGuiTaskCollector.cppm
+++ b/interface/control/ImGuiTaskCollector.cppm
@@ -20,6 +20,7 @@ namespace vk_gltf_viewer::control {
         void menuBar(const std::list<std::filesystem::path> &recentGltfs, const std::list<std::filesystem::path> &recentSkyboxes);
         void assetInspector(fastgltf::Asset &asset, const std::filesystem::path &assetDir);
         void materialEditor(fastgltf::Asset &asset, std::span<const vk::DescriptorSet> assetTextureImGuiDescriptorSets);
+        void materialVariants(const fastgltf::Asset &asset);
         void sceneHierarchy(fastgltf::Asset &asset, std::size_t sceneIndex, const std::variant<std::vector<std::optional<bool>>, std::vector<bool>> &visibilities, const std::optional<std::uint16_t> &hoveringNodeIndex, const std::unordered_set<std::uint16_t> &selectedNodeIndices);
         void nodeInspector(fastgltf::Asset &asset, const std::unordered_set<std::uint16_t> &selectedNodeIndices);
         void background(bool canSelectSkyboxBackground, full_optional<glm::vec3> &solidBackground);

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -21,6 +21,7 @@ namespace vk_gltf_viewer::control {
         struct TightenNearFarPlane { };
         struct ChangeCameraView { };
         struct InvalidateDrawCommandSeparation { };
+        struct SelectMaterialVariants { std::size_t variantIndex; };
     }
 
     export using Task = std::variant<
@@ -39,5 +40,6 @@ namespace vk_gltf_viewer::control {
         task::ChangeSelectedNodeWorldTransform,
         task::TightenNearFarPlane,
         task::ChangeCameraView,
-        task::InvalidateDrawCommandSeparation>;
+        task::InvalidateDrawCommandSeparation,
+        task::SelectMaterialVariants>;
 }

--- a/interface/gltf/AssetPrimitiveInfo.cppm
+++ b/interface/gltf/AssetPrimitiveInfo.cppm
@@ -10,7 +10,7 @@ namespace vk_gltf_viewer::gltf {
         struct AttributeBufferInfo { vk::DeviceAddress address; std::uint8_t byteStride; };
         struct IndexedAttributeBufferInfos { vk::DeviceAddress pMappingBuffer; std::vector<AttributeBufferInfo> attributeInfos; };
 
-        std::uint32_t index;
+        std::uint16_t index;
         std::optional<std::size_t> materialIndex;
         std::uint32_t drawCount;
         std::optional<IndexBufferInfo> indexInfo{};

--- a/interface/gltf/MaterialVariantsMapping.cppm
+++ b/interface/gltf/MaterialVariantsMapping.cppm
@@ -1,0 +1,37 @@
+export module vk_gltf_viewer:gltf.MaterialVariantsMapping;
+
+import std;
+export import fastgltf;
+import :helpers.ranges;
+
+namespace vk_gltf_viewer::gltf {
+    /**
+     * @brief Associative data structure of mappings for KHR_materials_variants.
+     *
+     * KHR_materials_variants extension defines the material variants for each primitive. For each variant index, you can call `at` to get the list of primitives and their material indices that use the corresponding material variant.
+     */
+    class MaterialVariantsMapping {
+    public:
+        struct VariantPrimitive {
+            fastgltf::Primitive *pPrimitive;
+            std::uint32_t materialIndex;
+        };
+
+        explicit MaterialVariantsMapping(fastgltf::Asset &asset [[clang::lifetimebound]]) noexcept {
+            for (fastgltf::Primitive &primitive : asset.meshes | std::views::transform(&fastgltf::Mesh::primitives) | std::views::join) {
+                for (const auto &[materialVariantIndex, mapping] : primitive.mappings | ranges::views::enumerate) {
+                    if (mapping) {
+                        data[materialVariantIndex].emplace_back(&primitive, *mapping);
+                    }
+                }
+            }
+        }
+
+        [[nodiscard]] std::span<const VariantPrimitive> at(std::size_t materialVariantIndex) const {
+            return data.at(materialVariantIndex);
+        }
+
+    private:
+        std::unordered_map<std::size_t, std::vector<VariantPrimitive>> data;
+    };
+}


### PR DESCRIPTION
Implemented [KHR_materials_variants](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_variants).

For changing the material index in the GPU primitive buffer, its type is changed to `std::variant<vku::AllocatedBuffer, vku::MappedBuffer>` for optimally handles the data uploading for UMA and non-UMA GPU.