### PR TITLE
Optimize vertex shader output texture coordinates count.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/math/Plane.cppm
         interface/shader_selector/primitive_frag.cppm
         interface/shader_selector/primitive_vert.cppm
+        interface/shader_selector/unlit_primitive_frag.cppm
         interface/vulkan/attachment_group/DepthPrepass.cppm
         interface/vulkan/attachment_group/JumpFloodSeed.cppm
         interface/vulkan/attachment_group/SceneOpaque.cppm
@@ -225,10 +226,6 @@ target_link_shaders(vk-gltf-viewer
     shaders/jump_flood_seed.frag
     shaders/jump_flood_seed.vert
     shaders/jump_flood.comp
-    shaders/mask_depth.frag
-    shaders/mask_depth.vert
-    shaders/mask_jump_flood_seed.frag
-    shaders/mask_jump_flood_seed.vert
     shaders/multiply.comp
     shaders/outline.frag
     shaders/screen_quad.vert
@@ -236,9 +233,9 @@ target_link_shaders(vk-gltf-viewer
     shaders/skybox.vert
     shaders/spherical_harmonic_coefficients_sum.comp
     shaders/spherical_harmonics.comp
-    shaders/unlit_primitive.vert
     shaders/weighted_blended_composition.frag
 )
+
 target_link_shader_variants(vk-gltf-viewer
     shaders/prefilteredmap.comp
     "AMD_SHADER_IMAGE_LOAD_STORE_LOD" 0 1
@@ -249,6 +246,22 @@ target_link_shader_variants(vk-gltf-viewer
     "16 0" "16 1"
     "32 0" "32 1"
     "64 0" "64 1"
+)
+target_link_shader_variants(vk-gltf-viewer
+    shaders/mask_depth.vert
+    "HAS_BASE_COLOR_TEXTURE" 0 1
+)
+target_link_shader_variants(vk-gltf-viewer
+    shaders/mask_depth.frag
+    "HAS_BASE_COLOR_TEXTURE" 0 1
+)
+target_link_shader_variants(vk-gltf-viewer
+    shaders/mask_jump_flood_seed.vert
+    "HAS_BASE_COLOR_TEXTURE" 0 1
+)
+target_link_shader_variants(vk-gltf-viewer
+    shaders/mask_jump_flood_seed.frag
+    "HAS_BASE_COLOR_TEXTURE" 0 1
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/primitive.vert
@@ -271,6 +284,12 @@ target_link_shader_variants(vk-gltf-viewer
     "5 0 0" "5 0 1" "5 0 2" "5 1 0" "5 1 1" "5 1 2"
 )
 target_link_shader_variants(vk-gltf-viewer
+    shaders/unlit_primitive.vert
+    "HAS_BASE_COLOR_TEXTURE" 0 1
+)
+target_link_shader_variants(vk-gltf-viewer
     shaders/unlit_primitive.frag
-    "ALPHA_MODE" 0 1 2
+    "HAS_BASE_COLOR_TEXTURE;ALPHA_MODE"
+    "0 0" "0 1" "0 2"
+    "1 0" "1 1" "1 2"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/math/extended_arithmetic.cppm
         interface/math/Frustum.cppm
         interface/math/Plane.cppm
+        interface/shader_selector/primitive_frag.cppm
+        interface/shader_selector/primitive_vert.cppm
         interface/vulkan/attachment_group/DepthPrepass.cppm
         interface/vulkan/attachment_group/JumpFloodSeed.cppm
         interface/vulkan/attachment_group/SceneOpaque.cppm
@@ -249,13 +251,23 @@ target_link_shader_variants(vk-gltf-viewer
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/primitive.vert
-    "FRAGMENT_SHADER_GENERATED_TBN" 0 1
+    "TEXCOORD_COUNT;FRAGMENT_SHADER_GENERATED_TBN"
+    "0 0" "0 1"
+    "1 0" "1 1"
+    "2 0" "2 1"
+    "3 0" "3 1"
+    "4 0" "4 1"
+    "5 0" "5 1"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/primitive.frag
-    "FRAGMENT_SHADER_GENERATED_TBN;ALPHA_MODE"
-    "0 0" "0 1" "0 2"
-    "1 0" "1 1" "1 2"
+    "TEXCOORD_COUNT;FRAGMENT_SHADER_GENERATED_TBN;ALPHA_MODE"
+    "0 0 0" "0 0 1" "0 0 2" "0 1 0" "0 1 1" "0 1 2"
+    "1 0 0" "1 0 1" "1 0 2" "1 1 0" "1 1 1" "1 1 2"
+    "2 0 0" "2 0 1" "2 0 2" "2 1 0" "2 1 1" "2 1 2"
+    "3 0 0" "3 0 1" "3 0 2" "3 1 0" "3 1 1" "3 1 2"
+    "4 0 0" "4 0 1" "4 0 2" "4 1 0" "4 1 1" "4 1 2"
+    "5 0 0" "5 0 1" "5 0 2" "5 1 0" "5 1 1" "5 1 2"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/unlit_primitive.frag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/gltf/AssetSceneGpuBuffers.cppm
         interface/gltf/AssetSceneHierarchy.cppm
         interface/gltf/MaterialVariantsMapping.cppm
+        interface/helpers/AggregateHasher.cppm
         interface/helpers/concepts.cppm
         interface/helpers/fastgltf.cppm
         interface/helpers/formatter/ByteSize.cppm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,6 @@ target_link_shader_variants(vk-gltf-viewer
     "2 0" "2 1"
     "3 0" "3 1"
     "4 0" "4 1"
-    "5 0" "5 1"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/primitive.frag
@@ -281,7 +280,6 @@ target_link_shader_variants(vk-gltf-viewer
     "2 0 0" "2 0 1" "2 0 2" "2 1 0" "2 1 1" "2 1 2"
     "3 0 0" "3 0 1" "3 0 2" "3 1 0" "3 1 1" "3 1 2"
     "4 0 0" "4 0 1" "4 0 2" "4 1 0" "4 1 1" "4 1 2"
-    "5 0 0" "5 0 1" "5 0 2" "5 1 0" "5 1 1" "5 1 2"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/unlit_primitive.vert

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -110,6 +110,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
         CommandSeparationCriteria result {
             .subpass = 0U,
             .pipeline = sharedData.getPrimitiveRenderer({
+                .texcoordCount = static_cast<std::uint8_t>(primitiveInfo.texcoordsInfo.attributeInfos.size()),
                 .fragmentShaderGeneratedTBN = !primitiveInfo.normalInfo.has_value(),
             }),
             .indexBufferAndType = primitiveInfo.indexInfo.transform([&](const auto &info) {
@@ -123,6 +124,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
             result.subpass = material.alphaMode == fastgltf::AlphaMode::Blend;
             result.pipeline = sharedData.getPrimitiveRenderer({
                 .unlit = material.unlit,
+                .texcoordCount = static_cast<std::uint8_t>(primitiveInfo.texcoordsInfo.attributeInfos.size()),
                 .fragmentShaderGeneratedTBN = !material.unlit && !primitiveInfo.normalInfo.has_value(),
                 .alphaMode = material.alphaMode,
             });

--- a/interface/helpers/AggregateHasher.cppm
+++ b/interface/helpers/AggregateHasher.cppm
@@ -1,0 +1,76 @@
+module;
+
+#include <boost/container_hash/hash.hpp>
+
+export module vk_gltf_viewer:helpers.AggregateHasher;
+
+import std;
+
+export template <std::size_t FieldCount> requires (FieldCount >= 1 && FieldCount <= 8)
+struct AggregateHasher {
+    template <typename T> requires std::is_aggregate_v<T>
+    [[nodiscard]] constexpr std::size_t operator()(const T &v) const noexcept {
+        std::size_t seed = 0;
+        if constexpr (FieldCount == 1) {
+            const auto &[x1] = v;
+            boost::hash_combine(seed, x1);
+        }
+        if constexpr (FieldCount == 2) {
+            const auto &[x1, x2] = v;
+            boost::hash_combine(seed, x1);
+            boost::hash_combine(seed, x2);
+        }
+        if constexpr (FieldCount == 3) {
+            const auto &[x1, x2, x3] = v;
+            boost::hash_combine(seed, x1);
+            boost::hash_combine(seed, x2);
+            boost::hash_combine(seed, x3);
+        }
+        if constexpr (FieldCount == 4) {
+            const auto &[x1, x2, x3, x4] = v;
+            boost::hash_combine(seed, x1);
+            boost::hash_combine(seed, x2);
+            boost::hash_combine(seed, x3);
+            boost::hash_combine(seed, x4);
+        }
+        if constexpr (FieldCount == 5) {
+            const auto &[x1, x2, x3, x4, x5] = v;
+            boost::hash_combine(seed, x1);
+            boost::hash_combine(seed, x2);
+            boost::hash_combine(seed, x3);
+            boost::hash_combine(seed, x4);
+            boost::hash_combine(seed, x5);
+        }
+        if constexpr (FieldCount == 6) {
+            const auto &[x1, x2, x3, x4, x5, x6] = v;
+            boost::hash_combine(seed, x1);
+            boost::hash_combine(seed, x2);
+            boost::hash_combine(seed, x3);
+            boost::hash_combine(seed, x4);
+            boost::hash_combine(seed, x5);
+            boost::hash_combine(seed, x6);
+        }
+        if constexpr (FieldCount == 7) {
+            const auto &[x1, x2, x3, x4, x5, x6, x7] = v;
+            boost::hash_combine(seed, x1);
+            boost::hash_combine(seed, x2);
+            boost::hash_combine(seed, x3);
+            boost::hash_combine(seed, x4);
+            boost::hash_combine(seed, x5);
+            boost::hash_combine(seed, x6);
+            boost::hash_combine(seed, x7);
+        }
+        if constexpr (FieldCount == 8) {
+            const auto &[x1, x2, x3, x4, x5, x6, x7, x8] = v;
+            boost::hash_combine(seed, x1);
+            boost::hash_combine(seed, x2);
+            boost::hash_combine(seed, x3);
+            boost::hash_combine(seed, x4);
+            boost::hash_combine(seed, x5);
+            boost::hash_combine(seed, x6);
+            boost::hash_combine(seed, x7);
+            boost::hash_combine(seed, x8);
+        }
+        return seed;
+    }
+};

--- a/interface/shader_selector/primitive_frag.cppm
+++ b/interface/shader_selector/primitive_frag.cppm
@@ -1,0 +1,31 @@
+export module vk_gltf_viewer:shader_selector.primitive_frag;
+
+import std;
+export import fastgltf;
+import :shader.primitive_frag;
+import :helpers.type_map;
+
+namespace vk_gltf_viewer::shader_selector {
+    [[nodiscard]] std::span<const unsigned int> primitive_frag(std::uint8_t texcoordCount, bool fragmentShaderGeneratedTBN, fastgltf::AlphaMode alphaMode) {
+        constexpr type_map texcoordCountMap {
+            make_type_map_entry<std::integral_constant<int, 0>, std::uint8_t>(0),
+            make_type_map_entry<std::integral_constant<int, 1>, std::uint8_t>(1),
+            make_type_map_entry<std::integral_constant<int, 2>, std::uint8_t>(2),
+            make_type_map_entry<std::integral_constant<int, 3>, std::uint8_t>(3),
+            make_type_map_entry<std::integral_constant<int, 4>, std::uint8_t>(4),
+            make_type_map_entry<std::integral_constant<int, 5>, std::uint8_t>(5),
+        };
+        constexpr type_map fragmentShaderGeneratedTBNMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        constexpr type_map alphaModeMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(fastgltf::AlphaMode::Opaque),
+            make_type_map_entry<std::integral_constant<int, 1>>(fastgltf::AlphaMode::Mask),
+            make_type_map_entry<std::integral_constant<int, 2>>(fastgltf::AlphaMode::Blend),
+        };
+        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
+            return shader::primitive_frag<Is...>;
+        }, texcoordCountMap.get_variant(texcoordCount), fragmentShaderGeneratedTBNMap.get_variant(fragmentShaderGeneratedTBN), alphaModeMap.get_variant(alphaMode));
+    }
+}

--- a/interface/shader_selector/primitive_frag.cppm
+++ b/interface/shader_selector/primitive_frag.cppm
@@ -13,7 +13,6 @@ namespace vk_gltf_viewer::shader_selector {
             make_type_map_entry<std::integral_constant<int, 2>, std::uint8_t>(2),
             make_type_map_entry<std::integral_constant<int, 3>, std::uint8_t>(3),
             make_type_map_entry<std::integral_constant<int, 4>, std::uint8_t>(4),
-            make_type_map_entry<std::integral_constant<int, 5>, std::uint8_t>(5),
         };
         constexpr type_map fragmentShaderGeneratedTBNMap {
             make_type_map_entry<std::integral_constant<int, 0>>(false),

--- a/interface/shader_selector/primitive_vert.cppm
+++ b/interface/shader_selector/primitive_vert.cppm
@@ -12,7 +12,6 @@ namespace vk_gltf_viewer::shader_selector {
             make_type_map_entry<std::integral_constant<int, 2>, std::uint8_t>(2),
             make_type_map_entry<std::integral_constant<int, 3>, std::uint8_t>(3),
             make_type_map_entry<std::integral_constant<int, 4>, std::uint8_t>(4),
-            make_type_map_entry<std::integral_constant<int, 5>, std::uint8_t>(5),
         };
         constexpr type_map fragmentShaderGeneratedTBNMap {
             make_type_map_entry<std::integral_constant<int, 0>>(false),

--- a/interface/shader_selector/primitive_vert.cppm
+++ b/interface/shader_selector/primitive_vert.cppm
@@ -1,0 +1,25 @@
+export module vk_gltf_viewer:shader_selector.primitive_vert;
+
+import std;
+import :shader.primitive_vert;
+import :helpers.type_map;
+
+namespace vk_gltf_viewer::shader_selector {
+    [[nodiscard]] std::span<const unsigned int> primitive_vert(std::uint8_t texcoordCount, bool fragmentShaderGeneratedTBN) {
+        constexpr type_map texcoordCountMap {
+            make_type_map_entry<std::integral_constant<int, 0>, std::uint8_t>(0),
+            make_type_map_entry<std::integral_constant<int, 1>, std::uint8_t>(1),
+            make_type_map_entry<std::integral_constant<int, 2>, std::uint8_t>(2),
+            make_type_map_entry<std::integral_constant<int, 3>, std::uint8_t>(3),
+            make_type_map_entry<std::integral_constant<int, 4>, std::uint8_t>(4),
+            make_type_map_entry<std::integral_constant<int, 5>, std::uint8_t>(5),
+        };
+        constexpr type_map fragmentShaderGeneratedTBNMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
+            return shader::primitive_vert<Is...>;
+        }, texcoordCountMap.get_variant(texcoordCount), fragmentShaderGeneratedTBNMap.get_variant(fragmentShaderGeneratedTBN));
+    }
+}

--- a/interface/shader_selector/unlit_primitive_frag.cppm
+++ b/interface/shader_selector/unlit_primitive_frag.cppm
@@ -1,0 +1,24 @@
+export module vk_gltf_viewer:shader_selector.unlit_primitive_frag;
+
+import std;
+export import fastgltf;
+import :shader.unlit_primitive_frag;
+import :helpers.type_map;
+
+namespace vk_gltf_viewer::shader_selector {
+    export
+    [[nodiscard]] std::span<const unsigned int> unlit_primitive_frag(bool hasBaseColorTexture, fastgltf::AlphaMode alphaMode) {
+        constexpr type_map hasBaseColorTextureMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        constexpr type_map alphaModeMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(fastgltf::AlphaMode::Opaque),
+            make_type_map_entry<std::integral_constant<int, 1>>(fastgltf::AlphaMode::Mask),
+            make_type_map_entry<std::integral_constant<int, 2>>(fastgltf::AlphaMode::Blend),
+        };
+        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
+            return shader::unlit_primitive_frag<Is...>;
+        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), alphaModeMap.get_variant(alphaMode));
+    }
+}

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -27,17 +27,18 @@ import :vulkan.sampler.SingleTexelSampler;
  * It combines the hash of each field using <tt>boost::hash_combine</tt>.
  *
  * @tparam T Aggregate struct type.
- * @note Currently this is only for <tt>SharedData::PrimitivePipelineKey</tt> (whose members are 3), therefore number of the structured bindings is assumed as 3. Need fix.
+ * @note Currently this is only for <tt>SharedData::PrimitivePipelineKey</tt> (whose members are 4), therefore number of the structured bindings is assumed as 4. Need fix.
  */
 template <typename T> requires std::is_aggregate_v<T>
 struct AggregateHasher {
     [[nodiscard]] constexpr std::size_t operator()(const T &v) const noexcept {
         // TODO.CXX26: use structured binding packs.
-        const auto &[x1, x2, x3] = v;
+        const auto &[x1, x2, x3, x4] = v;
         std::size_t seed = 0;
         boost::hash_combine(seed, x1);
         boost::hash_combine(seed, x2);
         boost::hash_combine(seed, x3);
+        boost::hash_combine(seed, x4);
         return seed;
     }
 };
@@ -49,6 +50,7 @@ namespace vk_gltf_viewer::vulkan {
     public:
         struct PrimitivePipelineKey {
             bool unlit;
+            std::uint8_t texcoordCount;
             bool fragmentShaderGeneratedTBN;
             fastgltf::AlphaMode alphaMode;
 
@@ -138,7 +140,7 @@ namespace vk_gltf_viewer::vulkan {
             }
             else {
                 return primitivePipelines.try_emplace(it, key, createPrimitiveRenderer(
-                    gpu.device, primitivePipelineLayout, sceneRenderPass, key.fragmentShaderGeneratedTBN, key.alphaMode))->second;
+                    gpu.device, primitivePipelineLayout, sceneRenderPass, key.texcoordCount, key.fragmentShaderGeneratedTBN, key.alphaMode))->second;
             }
         }
 

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -8,6 +8,7 @@ import std;
 export import fastgltf;
 export import vku;
 import :helpers.AggregateHasher;
+import :helpers.ranges;
 export import :vulkan.ag.Swapchain;
 export import :vulkan.Gpu;
 export import :vulkan.pipeline.DepthRenderer;
@@ -27,12 +28,18 @@ namespace vk_gltf_viewer::vulkan {
 
     public:
         struct PrimitivePipelineKey {
-            bool unlit;
             std::uint8_t texcoordCount;
             bool fragmentShaderGeneratedTBN;
             fastgltf::AlphaMode alphaMode;
 
-            [[nodiscard]] constexpr std::strong_ordering operator<=>(const PrimitivePipelineKey&) const noexcept = default;
+            [[nodiscard]] std::strong_ordering operator<=>(const PrimitivePipelineKey&) const noexcept = default;
+        };
+
+        struct UnlitPrimitivePipelineKey {
+            bool hasBaseColorTexture;
+            fastgltf::AlphaMode alphaMode;
+
+            [[nodiscard]] std::strong_ordering operator<=>(const UnlitPrimitivePipelineKey&) const noexcept = default;
         };
 
         // --------------------
@@ -103,49 +110,48 @@ namespace vk_gltf_viewer::vulkan {
                     skyboxDescriptorSetLayout));
         }
 
-        /**
-         * @brief Get corresponding Vulkan pipeline for given key.
-         * @param key A key that represents the primitive's rendering policy (alpha mode, normal/tangent space generation, etc.).
-         * @return Vulkan pipeline for the given key.
-         */
+        // --------------------
+        // Pipeline selectors.
+        // --------------------
+
+        [[nodiscard]] vk::Pipeline getDepthRenderer() const {
+            if (!depthRenderer) {
+                depthRenderer = createDepthRenderer(gpu.device, primitiveNoShadingPipelineLayout);
+            }
+            return *depthRenderer;
+        }
+
+        [[nodiscard]] vk::Pipeline getMaskDepthRenderer(bool hasBaseColorTexture) const {
+            return ranges::try_emplace_if_not_exists(maskDepthPipelines, hasBaseColorTexture, [&]() {
+                return createMaskDepthRenderer(gpu.device, primitiveNoShadingPipelineLayout, hasBaseColorTexture);
+            }).first->second;
+        }
+
+        [[nodiscard]] vk::Pipeline getJumpFloodSeedRenderer() const {
+            if (!jumpFloodSeedRenderer) {
+                jumpFloodSeedRenderer = createJumpFloodSeedRenderer(gpu.device, primitiveNoShadingPipelineLayout);
+            }
+            return *jumpFloodSeedRenderer;
+        }
+
+        [[nodiscard]] vk::Pipeline getMaskJumpFloodSeedRenderer(bool hasBaseColorTexture) const {
+            return ranges::try_emplace_if_not_exists(maskJumpFloodSeedPipelines, hasBaseColorTexture, [&]() {
+                return createMaskJumpFloodSeedRenderer(gpu.device, primitiveNoShadingPipelineLayout, hasBaseColorTexture);
+            }).first->second;
+        }
+
         [[nodiscard]] vk::Pipeline getPrimitiveRenderer(const PrimitivePipelineKey &key) const {
-            if (auto it = primitivePipelines.find(key); it != primitivePipelines.end()) {
-                return it->second;
-            }
-            else if (key.unlit) {
-                return primitivePipelines.try_emplace(it, key, createUnlitPrimitiveRenderer(
-                    gpu.device, primitivePipelineLayout, sceneRenderPass, key.alphaMode))->second;
-            }
-            else {
-                return primitivePipelines.try_emplace(it, key, createPrimitiveRenderer(
-                    gpu.device, primitivePipelineLayout, sceneRenderPass, key.texcoordCount, key.fragmentShaderGeneratedTBN, key.alphaMode))->second;
-            }
+            return ranges::try_emplace_if_not_exists(primitivePipelines, key, [&]() {
+                return createPrimitiveRenderer(
+                    gpu.device, primitivePipelineLayout, sceneRenderPass, key.texcoordCount, key.fragmentShaderGeneratedTBN, key.alphaMode);
+            }).first->second;
         }
 
-        /**
-         * @brief Get corresponding Vulkan pipeline for depth prepass rendering.
-         * @param mask Boolean whether the rendering primitive's material alpha mode is MASK or not.
-         * @return Vulkan pipeline for depth prepass rendering.
-         */
-        [[nodiscard]] vk::Pipeline getDepthPrepassRenderer(bool mask) const {
-            std::optional<vk::raii::Pipeline> &targetPipeline = mask ? maskDepthRenderer : depthRenderer;
-            if (!targetPipeline) {
-                targetPipeline = createDepthRenderer(gpu.device, primitiveNoShadingPipelineLayout, mask);
-            }
-            return *targetPipeline;
-        }
-
-        /**
-         * @brief Get corresponding Vulkan pipeline for jump flood seeding.
-         * @param mask Boolean whether the rendering primitive's material alpha mode is MASK or not.
-         * @return Vulkan pipeline for jump flood seeding.
-         */
-        [[nodiscard]] vk::Pipeline getJumpFloodSeedRenderer(bool mask) const {
-            std::optional<vk::raii::Pipeline> &targetPipeline = mask ? maskJumpFloodSeedRenderer : jumpFloodSeedRenderer;
-            if (!targetPipeline) {
-                targetPipeline = createJumpFloodSeedRenderer(gpu.device, primitiveNoShadingPipelineLayout, mask);
-            }
-            return *targetPipeline;
+        [[nodiscard]] vk::Pipeline getUnlitPrimitiveRenderer(const UnlitPrimitivePipelineKey &key) const {
+            return ranges::try_emplace_if_not_exists(unlitPrimitivePipelines, key, [&]() {
+                return createUnlitPrimitiveRenderer(
+                    gpu.device, primitivePipelineLayout, sceneRenderPass, key.hasBaseColorTexture, key.alphaMode);
+            }).first->second;
         }
 
         // --------------------
@@ -168,11 +174,12 @@ namespace vk_gltf_viewer::vulkan {
             }
 
             // Following pipelines are dependent to the assetDescriptorSetLayout.
-            primitivePipelines.clear();
             depthRenderer.reset();
+            maskDepthPipelines.clear();
             jumpFloodSeedRenderer.reset();
-            maskDepthRenderer.reset();
-            maskJumpFloodSeedRenderer.reset();
+            maskJumpFloodSeedPipelines.clear();
+            primitivePipelines.clear();
+            unlitPrimitivePipelines.clear();
 
             assetDescriptorSetLayout = { gpu.device, textureCount };
             primitivePipelineLayout = { gpu.device, std::tie(imageBasedLightingDescriptorSetLayout, assetDescriptorSetLayout, sceneDescriptorSetLayout) };
@@ -188,11 +195,12 @@ namespace vk_gltf_viewer::vulkan {
         // --------------------
 
         // glTF primitive rendering pipelines.
-        mutable std::unordered_map<PrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher<PrimitivePipelineKey>> primitivePipelines;
         mutable std::optional<vk::raii::Pipeline> depthRenderer;
+        mutable std::unordered_map<bool, vk::raii::Pipeline> maskDepthPipelines;
         mutable std::optional<vk::raii::Pipeline> jumpFloodSeedRenderer;
-        mutable std::optional<vk::raii::Pipeline> maskDepthRenderer;
-        mutable std::optional<vk::raii::Pipeline> maskJumpFloodSeedRenderer;
+        mutable std::unordered_map<bool, vk::raii::Pipeline> maskJumpFloodSeedPipelines;
+        mutable std::unordered_map<PrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher<3>> primitivePipelines;
+        mutable std::unordered_map<UnlitPrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher<2>> unlitPrimitivePipelines;
 
         [[nodiscard]] std::variant<ag::Swapchain, std::reference_wrapper<ag::Swapchain>> getImGuiSwapchainAttachmentGroup() {
             if (gpu.supportSwapchainMutableFormat) {

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -1,6 +1,5 @@
 module;
 
-#include <boost/container_hash/hash.hpp>
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vk_gltf_viewer:vulkan.SharedData;
@@ -8,6 +7,7 @@ export module vk_gltf_viewer:vulkan.SharedData;
 import std;
 export import fastgltf;
 export import vku;
+import :helpers.AggregateHasher;
 export import :vulkan.ag.Swapchain;
 export import :vulkan.Gpu;
 export import :vulkan.pipeline.DepthRenderer;
@@ -20,28 +20,6 @@ export import :vulkan.pipeline.UnlitPrimitiveRenderer;
 export import :vulkan.pipeline.WeightedBlendedCompositionRenderer;
 export import :vulkan.rp.Scene;
 import :vulkan.sampler.SingleTexelSampler;
-
-/**
- * @brief Hasher for aggregate struct.
- *
- * It combines the hash of each field using <tt>boost::hash_combine</tt>.
- *
- * @tparam T Aggregate struct type.
- * @note Currently this is only for <tt>SharedData::PrimitivePipelineKey</tt> (whose members are 4), therefore number of the structured bindings is assumed as 4. Need fix.
- */
-template <typename T> requires std::is_aggregate_v<T>
-struct AggregateHasher {
-    [[nodiscard]] constexpr std::size_t operator()(const T &v) const noexcept {
-        // TODO.CXX26: use structured binding packs.
-        const auto &[x1, x2, x3, x4] = v;
-        std::size_t seed = 0;
-        boost::hash_combine(seed, x1);
-        boost::hash_combine(seed, x2);
-        boost::hash_combine(seed, x3);
-        boost::hash_combine(seed, x4);
-        return seed;
-    }
-};
 
 namespace vk_gltf_viewer::vulkan {
     export class SharedData {

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -1,5 +1,6 @@
 export module vk_gltf_viewer:vulkan.pipeline.DepthRenderer;
 
+import std;
 import vku;
 import :shader.depth_vert;
 import :shader.depth_frag;

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -10,62 +10,74 @@ export import :vulkan.pl.PrimitiveNoShading;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     [[nodiscard]] vk::raii::Pipeline createDepthRenderer(
         const vk::raii::Device &device,
-        const pl::PrimitiveNoShading &pipelineLayout,
-        bool mask
+        const pl::PrimitiveNoShading &pipelineLayout
     ) {
-        if (mask) {
-            return { device, nullptr, vk::StructureChain {
-                vku::getDefaultGraphicsPipelineCreateInfo(
-                    createPipelineStages(
-                        device,
-                        vku::Shader { shader::mask_depth_vert, vk::ShaderStageFlagBits::eVertex },
-                        vku::Shader { shader::mask_depth_frag, vk::ShaderStageFlagBits::eFragment }).get(),
-                    *pipelineLayout, 1, true)
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                    }))
-                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                        {},
-                        vku::unsafeProxy({
-                            vk::DynamicState::eViewport,
-                            vk::DynamicState::eScissor,
-                            vk::DynamicState::eCullMode,
-                        }),
-                    })),
-                vk::PipelineRenderingCreateInfo {
+        return { device, nullptr, vk::StructureChain {
+            vku::getDefaultGraphicsPipelineCreateInfo(
+                createPipelineStages(
+                    device,
+                    vku::Shader { shader::depth_vert, vk::ShaderStageFlagBits::eVertex },
+                    vku::Shader { shader::depth_frag, vk::ShaderStageFlagBits::eFragment }).get(),
+                *pipelineLayout, 1, true)
+                .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                    {},
+                    true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                }))
+                .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                    {},
+                    vku::unsafeProxy({
+                        vk::DynamicState::eViewport,
+                        vk::DynamicState::eScissor,
+                        vk::DynamicState::eCullMode,
+                    }),
+                })),
+            vk::PipelineRenderingCreateInfo {
+                {},
+                vku::unsafeProxy(vk::Format::eR16Uint),
+                vk::Format::eD32Sfloat,
+            }
+        }.get() };
+    }
+
+    [[nodiscard]] vk::raii::Pipeline createMaskDepthRenderer(
+        const vk::raii::Device &device,
+        const pl::PrimitiveNoShading &pipelineLayout,
+        bool hasBaseColorTexture
+    ) {
+        return { device, nullptr, vk::StructureChain {
+            vku::getDefaultGraphicsPipelineCreateInfo(
+                createPipelineStages(
+                    device,
+                    vku::Shader {
+                        hasBaseColorTexture
+                            ? std::span<const std::uint32_t> { shader::mask_depth_vert<1> }
+                            : std::span<const std::uint32_t> { shader::mask_depth_vert<0> },
+                        vk::ShaderStageFlagBits::eVertex,
+                    },
+                    vku::Shader {
+                        hasBaseColorTexture
+                            ? std::span<const std::uint32_t> { shader::mask_depth_frag<1> }
+                            : std::span<const std::uint32_t> { shader::mask_depth_frag<0> },
+                        vk::ShaderStageFlagBits::eFragment,
+                    }).get(),
+                *pipelineLayout, 1, true)
+                .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                    {},
+                    true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                }))
+                .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                    {},
+                    vku::unsafeProxy({
+                        vk::DynamicState::eViewport,
+                        vk::DynamicState::eScissor,
+                        vk::DynamicState::eCullMode,
+                    }),
+                })),
+            vk::PipelineRenderingCreateInfo {
                     {},
                     vku::unsafeProxy(vk::Format::eR16Uint),
                     vk::Format::eD32Sfloat,
                 }
-            }.get() };
-        }
-        else {
-            return { device, nullptr, vk::StructureChain {
-                vku::getDefaultGraphicsPipelineCreateInfo(
-                    createPipelineStages(
-                        device,
-                        vku::Shader { shader::depth_vert, vk::ShaderStageFlagBits::eVertex },
-                        vku::Shader { shader::depth_frag, vk::ShaderStageFlagBits::eFragment }).get(),
-                    *pipelineLayout, 1, true)
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                    }))
-                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                        {},
-                        vku::unsafeProxy({
-                            vk::DynamicState::eViewport,
-                            vk::DynamicState::eScissor,
-                            vk::DynamicState::eCullMode,
-                        }),
-                    })),
-                vk::PipelineRenderingCreateInfo {
-                    {},
-                    vku::unsafeProxy(vk::Format::eR16Uint),
-                    vk::Format::eD32Sfloat,
-                }
-            }.get() };
-        }
+        }.get() };
     }
 }

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -10,62 +10,74 @@ export import :vulkan.pl.PrimitiveNoShading;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     [[nodiscard]] vk::raii::Pipeline createJumpFloodSeedRenderer(
         const vk::raii::Device &device,
-        const pl::PrimitiveNoShading &pipelineLayout,
-        bool mask
+        const pl::PrimitiveNoShading &pipelineLayout
     ) {
-        if (mask) {
-            return { device, nullptr, vk::StructureChain {
-                vku::getDefaultGraphicsPipelineCreateInfo(
-                    createPipelineStages(
-                        device,
-                        vku::Shader { shader::mask_jump_flood_seed_vert, vk::ShaderStageFlagBits::eVertex },
-                        vku::Shader { shader::mask_jump_flood_seed_frag, vk::ShaderStageFlagBits::eFragment }).get(),
-                    *pipelineLayout, 1, true)
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                    }))
-                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                        {},
-                        vku::unsafeProxy({
-                            vk::DynamicState::eViewport,
-                            vk::DynamicState::eScissor,
-                            vk::DynamicState::eCullMode,
-                        }),
-                    })),
-                vk::PipelineRenderingCreateInfo {
+        return { device, nullptr, vk::StructureChain {
+            vku::getDefaultGraphicsPipelineCreateInfo(
+                createPipelineStages(
+                    device,
+                    vku::Shader { shader::jump_flood_seed_vert, vk::ShaderStageFlagBits::eVertex },
+                    vku::Shader { shader::jump_flood_seed_frag, vk::ShaderStageFlagBits::eFragment }).get(),
+                *pipelineLayout, 1, true)
+                .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                     {},
-                    vku::unsafeProxy(vk::Format::eR16G16Uint),
-                    vk::Format::eD32Sfloat,
-                }
-            }.get() };
-        }
-        else {
-            return { device, nullptr, vk::StructureChain {
-                vku::getDefaultGraphicsPipelineCreateInfo(
-                    createPipelineStages(
-                        device,
-                        vku::Shader { shader::jump_flood_seed_vert, vk::ShaderStageFlagBits::eVertex },
-                        vku::Shader { shader::jump_flood_seed_frag, vk::ShaderStageFlagBits::eFragment }).get(),
-                    *pipelineLayout, 1, true)
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                    }))
-                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                        {},
-                        vku::unsafeProxy({
-                            vk::DynamicState::eViewport,
-                            vk::DynamicState::eScissor,
-                            vk::DynamicState::eCullMode,
-                        }),
-                    })),
-                vk::PipelineRenderingCreateInfo {
+                    true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                }))
+                .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
                     {},
-                    vku::unsafeProxy(vk::Format::eR16G16Uint),
-                    vk::Format::eD32Sfloat,
-                }
-            }.get() };
-        }
+                    vku::unsafeProxy({
+                        vk::DynamicState::eViewport,
+                        vk::DynamicState::eScissor,
+                        vk::DynamicState::eCullMode,
+                    }),
+                })),
+            vk::PipelineRenderingCreateInfo {
+                {},
+                vku::unsafeProxy(vk::Format::eR16G16Uint),
+                vk::Format::eD32Sfloat,
+            }
+        }.get() };
+    }
+
+    [[nodiscard]] vk::raii::Pipeline createMaskJumpFloodSeedRenderer(
+        const vk::raii::Device &device,
+        const pl::PrimitiveNoShading &pipelineLayout,
+        bool hasBaseColorTexture
+    ) {
+        return { device, nullptr, vk::StructureChain {
+            vku::getDefaultGraphicsPipelineCreateInfo(
+                createPipelineStages(
+                    device,
+                    vku::Shader {
+                        hasBaseColorTexture
+                            ? std::span<const std::uint32_t> { shader::mask_jump_flood_seed_vert<1> }
+                            : std::span<const std::uint32_t> { shader::mask_jump_flood_seed_vert<0> },
+                        vk::ShaderStageFlagBits::eVertex,
+                    },
+                    vku::Shader {
+                        hasBaseColorTexture
+                            ? std::span<const std::uint32_t> { shader::mask_jump_flood_seed_frag<1> }
+                            : std::span<const std::uint32_t> { shader::mask_jump_flood_seed_frag<0> },
+                        vk::ShaderStageFlagBits::eFragment,
+                    }).get(),
+                *pipelineLayout, 1, true)
+                .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                    {},
+                    true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                }))
+                .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                    {},
+                    vku::unsafeProxy({
+                        vk::DynamicState::eViewport,
+                        vk::DynamicState::eScissor,
+                        vk::DynamicState::eCullMode,
+                    }),
+                })),
+            vk::PipelineRenderingCreateInfo {
+                {},
+                vku::unsafeProxy(vk::Format::eR16G16Uint),
+                vk::Format::eD32Sfloat,
+            }
+        }.get() };
     }
 }

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -1,5 +1,6 @@
 export module vk_gltf_viewer:vulkan.pipeline.JumpFloodSeedRenderer;
 
+import std;
 import vku;
 import :shader.jump_flood_seed_vert;
 import :shader.jump_flood_seed_frag;

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -3,17 +3,17 @@ export module vk_gltf_viewer:vulkan.pipeline.PrimitiveRenderer;
 import std;
 export import fastgltf;
 import vku;
-import :shader.primitive_vert;
-import :shader.primitive_frag;
+import :shader_selector.primitive_vert;
+import :shader_selector.primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
-    export
     [[nodiscard]] vk::raii::Pipeline createPrimitiveRenderer(
         const vk::raii::Device &device,
         const pl::Primitive &pipelineLayout,
         const rp::Scene &sceneRenderPass,
+        std::uint32_t texcoordCount,
         bool fragmentShaderGeneratedTBN,
         fastgltf::AlphaMode alphaMode
     ) {
@@ -23,15 +23,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     createPipelineStages(
                         device,
                         vku::Shader {
-                            fragmentShaderGeneratedTBN
-                                ? std::span<const std::uint32_t> { shader::primitive_vert<1> }
-                                : std::span<const std::uint32_t> { shader::primitive_vert<0> },
+                            shader_selector::primitive_vert(texcoordCount, fragmentShaderGeneratedTBN),
                             vk::ShaderStageFlagBits::eVertex,
                         },
                         vku::Shader {
-                            fragmentShaderGeneratedTBN
-                                ? std::span<const std::uint32_t> { shader::primitive_frag<1, 0> }
-                                : std::span<const std::uint32_t> { shader::primitive_frag<0, 0> },
+                            shader_selector::primitive_frag(texcoordCount, fragmentShaderGeneratedTBN, fastgltf::AlphaMode::Opaque),
                             vk::ShaderStageFlagBits::eFragment,
                         }).get(),
                     *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
@@ -55,15 +51,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     createPipelineStages(
                         device,
                         vku::Shader {
-                            fragmentShaderGeneratedTBN
-                                ? std::span<const std::uint32_t> { shader::primitive_vert<1> }
-                                : std::span<const std::uint32_t> { shader::primitive_vert<0> },
+                            shader_selector::primitive_vert(texcoordCount, fragmentShaderGeneratedTBN),
                             vk::ShaderStageFlagBits::eVertex,
                         },
                         vku::Shader {
-                            fragmentShaderGeneratedTBN
-                                ? std::span<const std::uint32_t> { shader::primitive_frag<1, 1> }
-                                : std::span<const std::uint32_t> { shader::primitive_frag<0, 1> },
+                            shader_selector::primitive_frag(texcoordCount, fragmentShaderGeneratedTBN, fastgltf::AlphaMode::Mask),
                             vk::ShaderStageFlagBits::eFragment,
                         }).get(),
                     *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
@@ -93,15 +85,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     createPipelineStages(
                         device,
                         vku::Shader {
-                            fragmentShaderGeneratedTBN
-                                ? std::span<const std::uint32_t> { shader::primitive_vert<1> }
-                                : std::span<const std::uint32_t> { shader::primitive_vert<0> },
+                            shader_selector::primitive_vert(texcoordCount, fragmentShaderGeneratedTBN),
                             vk::ShaderStageFlagBits::eVertex,
                         },
                         vku::Shader {
-                            fragmentShaderGeneratedTBN
-                                ? std::span<const std::uint32_t> { shader::primitive_frag<1, 2> }
-                                : std::span<const std::uint32_t> { shader::primitive_frag<0, 2> },
+                            shader_selector::primitive_frag(texcoordCount, fragmentShaderGeneratedTBN, fastgltf::AlphaMode::Blend),
                             vk::ShaderStageFlagBits::eFragment,
                         }).get(),
                     *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -4,16 +4,16 @@ import std;
 import vku;
 export import fastgltf;
 import :shader.unlit_primitive_vert;
-import :shader.unlit_primitive_frag;
+import :shader_selector.unlit_primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
-
     [[nodiscard]] vk::raii::Pipeline createUnlitPrimitiveRenderer(
         const vk::raii::Device &device,
         const pl::Primitive &layout,
         const rp::Scene &sceneRenderPass,
+        bool hasBaseColorTexture,
         fastgltf::AlphaMode alphaMode
     ) {
         switch (alphaMode) {
@@ -21,8 +21,16 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                     createPipelineStages(
                         device,
-                        vku::Shader { shader::unlit_primitive_vert, vk::ShaderStageFlagBits::eVertex },
-                        vku::Shader { shader::unlit_primitive_frag<0>, vk::ShaderStageFlagBits::eFragment }).get(),
+                        vku::Shader {
+                            hasBaseColorTexture
+                                ? std::span<const std::uint32_t> { shader::unlit_primitive_vert<1> }
+                                : std::span<const std::uint32_t> { shader::unlit_primitive_vert<0> },
+                            vk::ShaderStageFlagBits::eVertex,
+                        },
+                        vku::Shader {
+                            shader_selector::unlit_primitive_frag(hasBaseColorTexture, alphaMode),
+                            vk::ShaderStageFlagBits::eFragment,
+                        }).get(),
                     *layout, 1, true, vk::SampleCountFlagBits::e4)
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},
@@ -43,8 +51,16 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                     createPipelineStages(
                         device,
-                        vku::Shader { shader::unlit_primitive_vert, vk::ShaderStageFlagBits::eVertex },
-                        vku::Shader { shader::unlit_primitive_frag<1>, vk::ShaderStageFlagBits::eFragment }).get(),
+                        vku::Shader {
+                            hasBaseColorTexture
+                                ? std::span<const std::uint32_t> { shader::unlit_primitive_vert<1> }
+                                : std::span<const std::uint32_t> { shader::unlit_primitive_vert<0> },
+                            vk::ShaderStageFlagBits::eVertex,
+                        },
+                        vku::Shader {
+                            shader_selector::unlit_primitive_frag(hasBaseColorTexture, alphaMode),
+                            vk::ShaderStageFlagBits::eFragment,
+                        }).get(),
                     *layout, 1, true, vk::SampleCountFlagBits::e4)
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},
@@ -71,8 +87,16 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                     createPipelineStages(
                         device,
-                        vku::Shader { shader::unlit_primitive_vert, vk::ShaderStageFlagBits::eVertex },
-                        vku::Shader { shader::unlit_primitive_frag<2>, vk::ShaderStageFlagBits::eFragment }).get(),
+                        vku::Shader {
+                            hasBaseColorTexture
+                                ? std::span<const std::uint32_t> { shader::unlit_primitive_vert<1> }
+                                : std::span<const std::uint32_t> { shader::unlit_primitive_vert<0> },
+                            vk::ShaderStageFlagBits::eVertex,
+                        },
+                        vku::Shader {
+                            shader_selector::unlit_primitive_frag(hasBaseColorTexture, alphaMode),
+                            vk::ShaderStageFlagBits::eFragment,
+                        }).get(),
                     *layout, 1, true, vk::SampleCountFlagBits::e4)
                     .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                         {},

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -9,7 +9,7 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Vec4Ref { vec4 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
 layout (location = 0) flat out uint outNodeIndex;
@@ -31,7 +31,7 @@ layout (push_constant) uniform PushConstant {
 // --------------------
 
 vec3 getVec3(uint64_t address){
-    return Vec4Ref(address).data.xyz;
+    return Vec3Ref(address).data;
 }
 
 void main(){

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -37,6 +37,6 @@ vec3 getVec3(uint64_t address){
 void main(){
     outNodeIndex = NODE_INDEX;
 
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -9,7 +9,7 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Vec4Ref { vec4 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
@@ -29,7 +29,7 @@ layout (push_constant) uniform PushConstant {
 // --------------------
 
 vec3 getVec3(uint64_t address){
-    return Vec4Ref(address).data.xyz;
+    return Vec3Ref(address).data;
 }
 
 void main(){

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -33,6 +33,6 @@ vec3 getVec3(uint64_t address){
 }
 
 void main(){
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_depth.frag
+++ b/shaders/mask_depth.frag
@@ -14,7 +14,7 @@ layout (location = 2) flat in uint inMaterialIndex;
 
 layout (location = 0) out uint outNodeIndex;
 
-layout (set = 0, binding = 1) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 1, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 layout (set = 0, binding = 2) uniform sampler2D textures[];

--- a/shaders/mask_depth.frag
+++ b/shaders/mask_depth.frag
@@ -8,9 +8,11 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (location = 0) in vec2 inBaseColorTexcoord;
-layout (location = 1) flat in uint inNodeIndex;
-layout (location = 2) flat in uint inMaterialIndex;
+layout (location = 0) flat in uint inNodeIndex;
+layout (location = 1) flat in uint inMaterialIndex;
+#if HAS_BASE_COLOR_TEXTURE
+layout (location = 2) in vec2 inBaseColorTexcoord;
+#endif
 
 layout (location = 0) out uint outNodeIndex;
 
@@ -20,7 +22,10 @@ layout (set = 0, binding = 1, std430) readonly buffer MaterialBuffer {
 layout (set = 0, binding = 2) uniform sampler2D textures[];
 
 void main(){
-    float baseColorAlpha = MATERIAL.baseColorFactor.a * texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord).a;
+    float baseColorAlpha = MATERIAL.baseColorFactor.a;
+#if HAS_BASE_COLOR_TEXTURE
+    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord).a;
+#endif
     if (baseColorAlpha < MATERIAL.alphaCutoff) discard;
 
     outNodeIndex = inNodeIndex;

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -15,9 +15,11 @@ layout (std430, buffer_reference, buffer_reference_align = 8) readonly buffer Ve
 layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Vec4Ref { vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
-layout (location = 0) out vec2 outBaseColorTexcoord;
-layout (location = 1) flat out uint outNodeIndex;
-layout (location = 2) flat out uint outMaterialIndex;
+layout (location = 0) flat out uint outNodeIndex;
+layout (location = 1) flat out uint outMaterialIndex;
+#if HAS_BASE_COLOR_TEXTURE
+layout (location = 2) out vec2 outBaseColorTexcoord;
+#endif
 
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
@@ -38,25 +40,27 @@ layout (push_constant) uniform PushConstant {
 // Functions.
 // --------------------
 
-vec2 getVec2(uint64_t address){
-    return Vec2Ref(address).data;
-}
-
 vec3 getVec3(uint64_t address){
     return Vec4Ref(address).data.xyz;
+}
+
+#if HAS_BASE_COLOR_TEXTURE
+vec2 getVec2(uint64_t address){
+    return Vec2Ref(address).data;
 }
 
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
     return getVec2(mappingInfo.bytesPtr + uint(mappingInfo.stride) * gl_VertexIndex);
 }
+#endif
 
 void main(){
-    if (int(MATERIAL.baseColorTextureIndex) != -1){
-        outBaseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
-    }
     outNodeIndex = NODE_INDEX;
     outMaterialIndex = MATERIAL_INDEX;
+#if HAS_BASE_COLOR_TEXTURE
+    outBaseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
+#endif
 
     vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * gl_VertexIndex);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -22,7 +22,7 @@ layout (location = 2) flat out uint outMaterialIndex;
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
-layout (set = 0, binding = 1) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 1, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -51,7 +51,7 @@ vec2 getVec2(uint64_t address){
 
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return getVec2(mappingInfo.bytesPtr + uint(mappingInfo.stride) * gl_VertexIndex);
+    return getVec2(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex);
 }
 #endif
 
@@ -62,6 +62,6 @@ void main(){
     outBaseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
 #endif
 
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -11,8 +11,8 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (std430, buffer_reference, buffer_reference_align = 8) readonly buffer Vec2Ref { vec2 data; };
-layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Vec4Ref { vec4 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
 layout (location = 0) flat out uint outNodeIndex;
@@ -41,7 +41,7 @@ layout (push_constant) uniform PushConstant {
 // --------------------
 
 vec3 getVec3(uint64_t address){
-    return Vec4Ref(address).data.xyz;
+    return Vec3Ref(address).data;
 }
 
 #if HAS_BASE_COLOR_TEXTURE

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -13,7 +13,7 @@ layout (location = 1) flat in uint inMaterialIndex;
 
 layout (location = 0) out uvec2 outCoordinate;
 
-layout (set = 0, binding = 1) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 1, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 layout (set = 0, binding = 2) uniform sampler2D textures[];

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -8,8 +8,10 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (location = 0) in vec2 inBaseColorTexcoord;
-layout (location = 1) flat in uint inMaterialIndex;
+layout (location = 0) flat in uint inMaterialIndex;
+#if HAS_BASE_COLOR_TEXTURE
+layout (location = 1) in vec2 inBaseColorTexcoord;
+#endif
 
 layout (location = 0) out uvec2 outCoordinate;
 
@@ -19,7 +21,10 @@ layout (set = 0, binding = 1, std430) readonly buffer MaterialBuffer {
 layout (set = 0, binding = 2) uniform sampler2D textures[];
 
 void main(){
-    float baseColorAlpha = MATERIAL.baseColorFactor.a * texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord).a;
+    float baseColorAlpha = MATERIAL.baseColorFactor.a;
+#if HAS_BASE_COLOR_TEXTURE
+    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord).a;
+#endif
     if (baseColorAlpha < MATERIAL.alphaCutoff) discard;
 
     outCoordinate = uvec2(gl_FragCoord.xy);

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -50,7 +50,7 @@ vec2 getVec2(uint64_t address){
 
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return getVec2(mappingInfo.bytesPtr + uint(mappingInfo.stride) * gl_VertexIndex);
+    return getVec2(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex);
 }
 #endif
 
@@ -60,6 +60,6 @@ void main(){
     outBaseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
 #endif
 
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -21,7 +21,7 @@ layout (location = 1) flat out uint outMaterialIndex;
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
-layout (set = 0, binding = 1) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 1, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -11,8 +11,8 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (std430, buffer_reference, buffer_reference_align = 8) readonly buffer Vec2Ref { vec2 data; };
-layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Vec4Ref { vec4 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
 layout (location = 0) flat out uint outMaterialIndex;
@@ -40,7 +40,7 @@ layout (push_constant, std430) uniform PushConstant {
 // --------------------
 
 vec3 getVec3(uint64_t address){
-    return Vec4Ref(address).data.xyz;
+    return Vec3Ref(address).data;
 }
 
 #if HAS_BASE_COLOR_TEXTURE

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -14,33 +14,31 @@
 const vec3 REC_709_LUMA = vec3(0.2126, 0.7152, 0.0722);
 
 layout (location = 0) in vec3 inPosition;
+layout (location = 1) flat in uint inMaterialIndex;
 #if TEXCOORD_COUNT >= 1
-layout (location = 1) in vec2 inTexcoord0;
+layout (location = 2) in vec2 inTexcoord0;
 #endif
 #if TEXCOORD_COUNT >= 2
-layout (location = 2) in vec2 inTexcoord1;
+layout (location = 3) in vec2 inTexcoord1;
 #endif
 #if TEXCOORD_COUNT >= 3
-layout (location = 3) in vec2 inTexcoord2;
+layout (location = 4) in vec2 inTexcoord2;
 #endif
 #if TEXCOORD_COUNT >= 4
-layout (location = 4) in vec2 inTexcoord3;
+layout (location = 5) in vec2 inTexcoord3;
 #endif
 #if TEXCOORD_COUNT >= 5
-layout (location = 5) in vec2 inTexcoord4;
+layout (location = 6) in vec2 inTexcoord4;
 #endif
 #if TEXCOORD_COUNT >= 6
 #error "Maximum texcoord count exceeded."
 #endif
-layout (location = TEXCOORD_COUNT + 1) flat in uint inMaterialIndex;
 #if !FRAGMENT_SHADER_GENERATED_TBN
 layout (location = TEXCOORD_COUNT + 2) in mat3 inTBN;
 #endif
 
-#if ALPHA_MODE == 0 || ALPHA_MODE == 1
 layout (location = 0) out vec4 outColor;
-#elif ALPHA_MODE == 2
-layout (location = 0) out vec4 outAccumulation;
+#if ALPHA_MODE == 2
 layout (location = 1) out float outRevealage;
 #endif
 
@@ -120,7 +118,7 @@ void writeOutput(vec4 color) {
     float weight = clamp(
         pow(min(1.0, color.a * 10.0) + 0.01, 3.0) * 1e8 * pow(1.0 - gl_FragCoord.z * 0.9, 3.0),
         1e-2, 3e3);
-    outAccumulation = vec4(color.rgb * color.a, color.a) * weight;
+    outColor = vec4(color.rgb * color.a, color.a) * weight;
     outRevealage = color.a;
 #endif
 }

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -50,7 +50,7 @@ layout (set = 0, binding = 0, scalar) uniform SphericalHarmonicsBuffer {
 layout (set = 0, binding = 1) uniform samplerCube prefilteredmap;
 layout (set = 0, binding = 2) uniform sampler2D brdfmap;
 
-layout (set = 1, binding = 1) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 1, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 layout (set = 1, binding = 2) uniform sampler2D textures[];

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -3,6 +3,7 @@
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_scalar_block_layout : require
 
 #define FRAGMENT_SHADER
@@ -13,21 +14,27 @@
 const vec3 REC_709_LUMA = vec3(0.2126, 0.7152, 0.0722);
 
 layout (location = 0) in vec3 inPosition;
-#if FRAGMENT_SHADER_GENERATED_TBN
-layout (location = 1) in vec2 inBaseColorTexcoord;
-layout (location = 2) in vec2 inMetallicRoughnessTexcoord;
-layout (location = 3) in vec2 inNormalTexcoord;
-layout (location = 4) in vec2 inOcclusionTexcoord;
-layout (location = 5) in vec2 inEmissiveTexcoord;
-layout (location = 6) flat in uint inMaterialIndex;
-#else
-layout (location = 1) in mat3 inTBN;
-layout (location = 4) in vec2 inBaseColorTexcoord;
-layout (location = 5) in vec2 inMetallicRoughnessTexcoord;
-layout (location = 6) in vec2 inNormalTexcoord;
-layout (location = 7) in vec2 inOcclusionTexcoord;
-layout (location = 8) in vec2 inEmissiveTexcoord;
-layout (location = 9) flat in uint inMaterialIndex;
+#if TEXCOORD_COUNT >= 1
+layout (location = 1) in vec2 inTexcoord0;
+#endif
+#if TEXCOORD_COUNT >= 2
+layout (location = 2) in vec2 inTexcoord1;
+#endif
+#if TEXCOORD_COUNT >= 3
+layout (location = 3) in vec2 inTexcoord2;
+#endif
+#if TEXCOORD_COUNT >= 4
+layout (location = 4) in vec2 inTexcoord3;
+#endif
+#if TEXCOORD_COUNT >= 5
+layout (location = 5) in vec2 inTexcoord4;
+#endif
+#if TEXCOORD_COUNT >= 6
+#error "Maximum texcoord count exceeded."
+#endif
+layout (location = TEXCOORD_COUNT + 1) flat in uint inMaterialIndex;
+#if !FRAGMENT_SHADER_GENERATED_TBN
+layout (location = TEXCOORD_COUNT + 2) in mat3 inTBN;
 #endif
 
 #if ALPHA_MODE == 0 || ALPHA_MODE == 1
@@ -61,6 +68,27 @@ layout (early_fragment_tests) in;
 // Functions.
 // --------------------
 
+#if TEXCOORD_COUNT >= 1
+vec2 getTexcoord(uint texcoordIndex) {
+    switch (texcoordIndex) {
+        case 0: return inTexcoord0;
+#if TEXCOORD_COUNT >= 2
+        case 1: return inTexcoord1;
+#endif
+#if TEXCOORD_COUNT >= 3
+        case 2: return inTexcoord2;
+#endif
+#if TEXCOORD_COUNT >= 4
+        case 3: return inTexcoord3;
+#endif
+#if TEXCOORD_COUNT >= 5
+        case 4: return inTexcoord4;
+#endif
+    }
+    return vec2(0.0);
+}
+#endif
+
 vec3 fresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness){
     return F0 + (max(vec3(1.0 - roughness), F0) - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
 }
@@ -78,10 +106,14 @@ void writeOutput(vec4 color) {
 #if ALPHA_MODE == 0
     outColor = vec4(color.rgb, 1.0);
 #elif ALPHA_MODE == 1
-    color.a *= 1.0 + geometricMean(textureQueryLod(textures[int(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord)) * 0.25;
+#if TEXCOORD_COUNT >= 1
+    color.a *= 1.0 + geometricMean(textureQueryLod(textures[int(MATERIAL.baseColorTextureIndex) + 1], getTexcoord(MATERIAL.baseColorTexcoordIndex))) * 0.25;
     // Apply sharpness to the alpha.
     // See: https://bgolus.medium.com/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f.
     color.a = (color.a - MATERIAL.alphaCutoff) / max(fwidth(color.a), 1e-4) + 0.5;
+#else
+    color.a = color.a >= MATERIAL.alphaCutoff ? 1 : 0;
+#endif
     outColor = color;
 #elif ALPHA_MODE == 2
     // Weighted Blended.
@@ -94,40 +126,54 @@ void writeOutput(vec4 color) {
 }
 
 void main(){
-    vec4 baseColor = MATERIAL.baseColorFactor * texture(textures[int(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord);
+    vec4 baseColor = MATERIAL.baseColorFactor;
+#if TEXCOORD_COUNT >= 1
+    baseColor *= texture(textures[int(MATERIAL.baseColorTextureIndex) + 1], getTexcoord(MATERIAL.baseColorTexcoordIndex));
+#endif
 
-    vec2 metallicRoughness = vec2(MATERIAL.metallicFactor, MATERIAL.roughnessFactor) * texture(textures[int(MATERIAL.metallicRoughnessTextureIndex) + 1], inMetallicRoughnessTexcoord).bg;
-    float metallic = metallicRoughness.x;
-    float roughness = metallicRoughness.y;
+    float metallic = MATERIAL.metallicFactor;
+    float roughness = MATERIAL.roughnessFactor;
+#if TEXCOORD_COUNT >= 1
+    vec2 metallicRoughness = texture(textures[int(MATERIAL.metallicRoughnessTextureIndex) + 1], getTexcoord(MATERIAL.metallicRoughnessTexcoordIndex)).bg;
+    metallic *= metallicRoughness.x;
+    roughness *= metallicRoughness.y;
+#endif
 
     vec3 N;
 #if FRAGMENT_SHADER_GENERATED_TBN
     vec3 tangent = dFdx(inPosition);
     vec3 bitangent = dFdy(inPosition);
-    vec3 normal = normalize(cross(tangent, bitangent));
+    N = normalize(cross(tangent, bitangent));
 
+#if TEXCOORD_COUNT >= 1
     if (int(MATERIAL.normalTextureIndex) != -1){
-        vec3 tangentNormal = texture(textures[int(MATERIAL.normalTextureIndex) + 1], inNormalTexcoord).rgb;
+        vec3 tangentNormal = texture(textures[int(MATERIAL.normalTextureIndex) + 1], getTexcoord(MATERIAL.normalTexcoordIndex)).rgb;
         vec3 scaledNormal = (2.0 * tangentNormal - 1.0) * vec3(MATERIAL.normalScale, MATERIAL.normalScale, 1.0);
-        N = normalize(mat3(tangent, bitangent, normal) * scaledNormal);
+        N = normalize(mat3(tangent, bitangent, N) * scaledNormal);
     }
-    else {
-        N = normal;
-    }
-#else
+#endif
+#elif TEXCOORD_COUNT >= 1
     if (int(MATERIAL.normalTextureIndex) != -1){
-        vec3 tangentNormal = texture(textures[int(MATERIAL.normalTextureIndex) + 1], inNormalTexcoord).rgb;
+        vec3 tangentNormal = texture(textures[int(MATERIAL.normalTextureIndex) + 1], getTexcoord(MATERIAL.normalTexcoordIndex)).rgb;
         vec3 scaledNormal = (2.0 * tangentNormal - 1.0) * vec3(MATERIAL.normalScale, MATERIAL.normalScale, 1.0);
         N = normalize(inTBN * scaledNormal);
     }
     else {
         N = normalize(inTBN[2]);
     }
+#else
+    N = normalize(inTBN[2]);
 #endif
 
-    float occlusion = 1.0 + MATERIAL.occlusionStrength * (texture(textures[int(MATERIAL.occlusionTextureIndex) + 1], inOcclusionTexcoord).r - 1.0);
+    float occlusion = MATERIAL.occlusionStrength;
+#if TEXCOORD_COUNT >= 1
+    occlusion = 1.0 + MATERIAL.occlusionStrength * (texture(textures[int(MATERIAL.occlusionTextureIndex) + 1], getTexcoord(MATERIAL.occlusionTexcoordIndex)).r - 1.0);
+#endif
 
-    vec3 emissive = MATERIAL.emissiveFactor * texture(textures[int(MATERIAL.emissiveTextureIndex) + 1], inEmissiveTexcoord).rgb;
+    vec3 emissive = MATERIAL.emissiveFactor;
+#if TEXCOORD_COUNT >= 1
+    emissive *= texture(textures[int(MATERIAL.emissiveTextureIndex) + 1], getTexcoord(MATERIAL.emissiveTexcoordIndex)).rgb;
+#endif
 
     vec3 V = normalize(pc.viewPosition - inPosition);
     float NdotV = dot(N, V);

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -15,22 +15,15 @@ const vec3 REC_709_LUMA = vec3(0.2126, 0.7152, 0.0722);
 
 layout (location = 0) in vec3 inPosition;
 layout (location = 1) flat in uint inMaterialIndex;
-#if TEXCOORD_COUNT >= 1
-layout (location = 2) in vec2 inTexcoord0;
-#endif
-#if TEXCOORD_COUNT >= 2
-layout (location = 3) in vec2 inTexcoord1;
-#endif
-#if TEXCOORD_COUNT >= 3
-layout (location = 4) in vec2 inTexcoord2;
-#endif
-#if TEXCOORD_COUNT >= 4
-layout (location = 5) in vec2 inTexcoord3;
-#endif
-#if TEXCOORD_COUNT >= 5
-layout (location = 6) in vec2 inTexcoord4;
-#endif
-#if TEXCOORD_COUNT >= 6
+#if TEXCOORD_COUNT == 1
+layout (location = 2) in vec2 inTexcoord;
+#elif TEXCOORD_COUNT == 2
+layout (location = 2) in mat2 inTexcoords;
+#elif TEXCOORD_COUNT >= 3
+layout (location = 2) in mat3x2 inTexcoords;
+#elif TEXCOORD_COUNT >= 4
+layout (location = 2) in mat4x2 inTexcoords;
+#elif TEXCOORD_COUNT >= 5
 #error "Maximum texcoord count exceeded."
 #endif
 #if !FRAGMENT_SHADER_GENERATED_TBN
@@ -66,24 +59,13 @@ layout (early_fragment_tests) in;
 // Functions.
 // --------------------
 
-#if TEXCOORD_COUNT >= 1
+#if TEXCOORD_COUNT == 1
 vec2 getTexcoord(uint texcoordIndex) {
-    switch (texcoordIndex) {
-        case 0: return inTexcoord0;
-#if TEXCOORD_COUNT >= 2
-        case 1: return inTexcoord1;
-#endif
-#if TEXCOORD_COUNT >= 3
-        case 2: return inTexcoord2;
-#endif
-#if TEXCOORD_COUNT >= 4
-        case 3: return inTexcoord3;
-#endif
-#if TEXCOORD_COUNT >= 5
-        case 4: return inTexcoord4;
-#endif
-    }
-    return vec2(0.0);
+    return inTexcoord;
+}
+#elif TEXCOORD_COUNT >= 2
+vec2 getTexcoord(uint texcoordIndex) {
+    return inTexcoords[texcoordIndex];
 }
 #endif
 

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -42,7 +42,7 @@ layout (location = TEXCOORD_COUNT + 2) out mat3 outTBN;
 layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
-layout (set = 1, binding = 1) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 1, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -11,8 +11,9 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (std430, buffer_reference, buffer_reference_align = 8) readonly buffer Vec2Ref { vec2 data; };
-layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Vec4Ref { vec4 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
 layout (location = 0) out vec3 outPosition;
@@ -60,7 +61,7 @@ layout (push_constant, std430) uniform PushConstant {
 // --------------------
 
 vec3 getVec3(uint64_t address){
-    return Vec4Ref(address).data.xyz;
+    return Vec3Ref(address).data;
 }
 
 #if !FRAGMENT_SHADER_GENERATED_TBN

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -18,22 +18,15 @@ layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer N
 
 layout (location = 0) out vec3 outPosition;
 layout (location = 1) flat out uint outMaterialIndex;
-#if TEXCOORD_COUNT >= 1
-layout (location = 2) out vec2 outTexcoord0;
-#endif
-#if TEXCOORD_COUNT >= 2
-layout (location = 3) out vec2 outTexcoord1;
-#endif
-#if TEXCOORD_COUNT >= 3
-layout (location = 4) out vec2 outTexcoord2;
-#endif
-#if TEXCOORD_COUNT >= 4
-layout (location = 5) out vec2 outTexcoord3;
-#endif
-#if TEXCOORD_COUNT >= 5
-layout (location = 6) out vec2 outTexcoord4;
-#endif
-#if TEXCOORD_COUNT >= 6
+#if TEXCOORD_COUNT == 1
+layout (location = 2) out vec2 outTexcoord;
+#elif TEXCOORD_COUNT == 2
+layout (location = 2) out mat2 outTexcoords;
+#elif TEXCOORD_COUNT == 3
+layout (location = 2) out mat3x2 outTexcoords;
+#elif TEXCOORD_COUNT == 4
+layout (location = 2) out mat4x2 outTexcoords;
+#elif TEXCOORD_COUNT >= 5
 #error "Maximum texcoord count exceeded."
 #endif
 #if !FRAGMENT_SHADER_GENERATED_TBN
@@ -87,20 +80,12 @@ void main(){
 
     outMaterialIndex = MATERIAL_INDEX;
 
-#if TEXCOORD_COUNT >= 1
-    outTexcoord0 = getTexcoord(0);
-#endif
-#if TEXCOORD_COUNT >= 2
-    outTexcoord1 = getTexcoord(1);
-#endif
-#if TEXCOORD_COUNT >= 3
-    outTexcoord2 = getTexcoord(2);
-#endif
-#if TEXCOORD_COUNT >= 4
-    outTexcoord3 = getTexcoord(3);
-#endif
-#if TEXCOORD_COUNT >= 5
-    outTexcoord4 = getTexcoord(4);
+#if TEXCOORD_COUNT == 1
+    outTexcoord = getTexcoord(0);
+#elif TEXCOORD_COUNT >= 2
+    for (uint i = 0; i < TEXCOORD_COUNT; i++){
+        outTexcoords[i] = getTexcoord(i);
+    }
 #endif
 
 #if !FRAGMENT_SHADER_GENERATED_TBN

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -77,12 +77,12 @@ vec2 getVec2(uint64_t address){
 
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return getVec2(mappingInfo.bytesPtr + uint(mappingInfo.stride) * gl_VertexIndex);
+    return getVec2(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex);
 }
 #endif
 
 void main(){
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
     outPosition = (TRANSFORM * vec4(inPosition, 1.0)).xyz;
 
     outMaterialIndex = MATERIAL_INDEX;
@@ -104,11 +104,11 @@ void main(){
 #endif
 
 #if !FRAGMENT_SHADER_GENERATED_TBN
-    vec3 inNormal = getVec3(PRIMITIVE.pNormalBuffer + uint(PRIMITIVE.normalByteStride) * gl_VertexIndex);
+    vec3 inNormal = getVec3(PRIMITIVE.pNormalBuffer + int(PRIMITIVE.normalByteStride) * gl_VertexIndex);
     outTBN[2] = normalize(mat3(TRANSFORM) * inNormal); // N
 
     if (int(MATERIAL.normalTextureIndex) != -1){
-        vec4 inTangent = getVec4(PRIMITIVE.pTangentBuffer + uint(PRIMITIVE.tangentByteStride) * gl_VertexIndex);
+        vec4 inTangent = getVec4(PRIMITIVE.pTangentBuffer + int(PRIMITIVE.tangentByteStride) * gl_VertexIndex);
         outTBN[0] = normalize(mat3(TRANSFORM) * inTangent.xyz); // T
         outTBN[1] = cross(outTBN[2], outTBN[0]) * -inTangent.w; // B
     }

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -30,7 +30,7 @@ struct IndexedAttributeMappingInfo {
     uint8_t stride;
 };
 
-layout (std430, buffer_reference, buffer_reference_align = 8) readonly buffer IndexedAttributeMappingInfos { IndexedAttributeMappingInfo data[]; };
+layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer IndexedAttributeMappingInfos { IndexedAttributeMappingInfo data[]; };
 
 struct Primitive {
     uint64_t pPositionBuffer;

--- a/shaders/unlit_primitive.frag
+++ b/shaders/unlit_primitive.frag
@@ -18,7 +18,7 @@ layout (location = 0) out vec4 outAccumulation;
 layout (location = 1) out float outRevealage;
 #endif
 
-layout (set = 1, binding = 1) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 1, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 layout (set = 1, binding = 2) uniform sampler2D textures[];

--- a/shaders/unlit_primitive.frag
+++ b/shaders/unlit_primitive.frag
@@ -8,13 +8,13 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (location = 0) in vec2 inBaseColorTexcoord;
-layout (location = 1) flat in uint inMaterialIndex;
+layout (location = 0) flat in uint inMaterialIndex;
+#if HAS_BASE_COLOR_TEXTURE
+layout (location = 1) in vec2 inBaseColorTexcoord;
+#endif
 
-#if ALPHA_MODE == 0 || ALPHA_MODE == 1
 layout (location = 0) out vec4 outColor;
-#elif ALPHA_MODE == 2
-layout (location = 0) out vec4 outAccumulation;
+#if ALPHA_MODE == 2
 layout (location = 1) out float outRevealage;
 #endif
 
@@ -35,22 +35,30 @@ void writeOutput(vec4 color) {
 #if ALPHA_MODE == 0
     outColor = vec4(color.rgb, 1.0);
 #elif ALPHA_MODE == 1
+#if HAS_BASE_COLOR_TEXTURE
     color.a *= 1.0 + geometricMean(textureQueryLod(textures[int(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord)) * 0.25;
     // Apply sharpness to the alpha.
     // See: https://bgolus.medium.com/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f.
     color.a = (color.a - MATERIAL.alphaCutoff) / max(fwidth(color.a), 1e-4) + 0.5;
+#else
+    color.a = color.a >= MATERIAL.alphaCutoff ? 1 : 0;
+#endif
     outColor = color;
 #elif ALPHA_MODE == 2
     // Weighted Blended.
     float weight = clamp(
         pow(min(1.0, color.a * 10.0) + 0.01, 3.0) * 1e8 * pow(1.0 - gl_FragCoord.z * 0.9, 3.0),
         1e-2, 3e3);
-    outAccumulation = vec4(color.rgb * color.a, color.a) * weight;
+    outColor = vec4(color.rgb * color.a, color.a) * weight;
     outRevealage = color.a;
 #endif
 }
 
 void main(){
-    vec4 baseColor = MATERIAL.baseColorFactor * texture(textures[int(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord);
+    vec4 baseColor = MATERIAL.baseColorFactor;
+#if HAS_BASE_COLOR_TEXTURE
+    baseColor *= texture(textures[int(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord);
+#endif
+
     writeOutput(baseColor);
 }

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -21,7 +21,7 @@ layout (location = 1) flat out uint outMaterialIndex;
 layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
-layout (set = 1, binding = 1) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 1, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -11,8 +11,8 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (std430, buffer_reference, buffer_reference_align = 8) readonly buffer Vec2Ref { vec2 data; };
-layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Vec4Ref { vec4 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
 layout (location = 0) flat out uint outMaterialIndex;
@@ -41,7 +41,7 @@ layout (push_constant, std430) uniform PushConstant {
 // --------------------
 
 vec3 getVec3(uint64_t address){
-    return Vec4Ref(address).data.xyz;
+    return Vec3Ref(address).data;
 }
 
 #if HAS_BASE_COLOR_TEXTURE

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -51,12 +51,12 @@ vec2 getVec2(uint64_t address){
 
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return getVec2(mappingInfo.bytesPtr + uint(mappingInfo.stride) * gl_VertexIndex);
+    return getVec2(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex);
 }
 #endif
 
 void main(){
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
 
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -15,8 +15,10 @@ layout (std430, buffer_reference, buffer_reference_align = 8) readonly buffer Ve
 layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Vec4Ref { vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
-layout (location = 0) out vec2 outBaseColorTexcoord;
-layout (location = 1) flat out uint outMaterialIndex;
+layout (location = 0) flat out uint outMaterialIndex;
+#if HAS_BASE_COLOR_TEXTURE
+layout (location = 1) out vec2 outBaseColorTexcoord;
+#endif
 
 layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
@@ -38,26 +40,28 @@ layout (push_constant, std430) uniform PushConstant {
 // Functions.
 // --------------------
 
-vec2 getVec2(uint64_t address){
-    return Vec2Ref(address).data;
-}
-
 vec3 getVec3(uint64_t address){
     return Vec4Ref(address).data.xyz;
+}
+
+#if HAS_BASE_COLOR_TEXTURE
+vec2 getVec2(uint64_t address){
+    return Vec2Ref(address).data;
 }
 
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
     return getVec2(mappingInfo.bytesPtr + uint(mappingInfo.stride) * gl_VertexIndex);
 }
+#endif
 
 void main(){
     vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * gl_VertexIndex);
 
-    if (int(MATERIAL.baseColorTextureIndex) != -1){
-        outBaseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
-    }
     outMaterialIndex = MATERIAL_INDEX;
+#if HAS_BASE_COLOR_TEXTURE
+    outBaseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
+#endif
 
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }


### PR DESCRIPTION
This PR aims to reduce the overhead for unnecessarily many texture coordinates count between the vertex and the fragment shader. Instead of interpolating every base color/metallic roughness/normal/occlusion/emissive texture coordinates using the uber shader, it creates the pipeline of the exact amount of the texture coordinates on demand (can handle up to `TEXCOORD_4`). Also, diverged the shaders that are using either the only base color texture coordinates (unlit/mask depth/mask jump flood) or not, which makes the latter case to be more optimized.

Additionally, some improvements and fixes are introduced:
- `type_map`'s implementation and asm code generation improved, which is used for runtime shader selection.
- Some incorrect `buffer_reference_align` in the shaders were fixed. This fixes the NVIDIA GPU's wrongly pulling the texture coordinates, which is observed in some sample glTF models (*Sponza* and *BoomBoxWithAxes*).