### PR TITLE
Implemented vertex color.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,14 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/math/extended_arithmetic.cppm
         interface/math/Frustum.cppm
         interface/math/Plane.cppm
+        interface/shader_selector/mask_depth_frag.cppm
+        interface/shader_selector/mask_depth_vert.cppm
+        interface/shader_selector/mask_jump_flood_seed_frag.cppm
+        interface/shader_selector/mask_jump_flood_seed_vert.cppm
         interface/shader_selector/primitive_frag.cppm
         interface/shader_selector/primitive_vert.cppm
         interface/shader_selector/unlit_primitive_frag.cppm
+        interface/shader_selector/unlit_primitive_vert.cppm
         interface/vulkan/attachment_group/DepthPrepass.cppm
         interface/vulkan/attachment_group/JumpFloodSeed.cppm
         interface/vulkan/attachment_group/SceneOpaque.cppm
@@ -249,45 +254,60 @@ target_link_shader_variants(vk-gltf-viewer
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/mask_depth.vert
-    "HAS_BASE_COLOR_TEXTURE" 0 1
+    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ALPHA_ATTRIBUTE"
+    "0 0" "0 1"
+    "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/mask_depth.frag
-    "HAS_BASE_COLOR_TEXTURE" 0 1
+    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ALPHA_ATTRIBUTE"
+    "0 0" "0 1"
+    "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/mask_jump_flood_seed.vert
-    "HAS_BASE_COLOR_TEXTURE" 0 1
+    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ALPHA_ATTRIBUTE"
+    "0 0" "0 1"
+    "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/mask_jump_flood_seed.frag
-    "HAS_BASE_COLOR_TEXTURE" 0 1
+    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ALPHA_ATTRIBUTE"
+    "0 0" "0 1"
+    "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/primitive.vert
-    "TEXCOORD_COUNT;FRAGMENT_SHADER_GENERATED_TBN"
-    "0 0" "0 1"
-    "1 0" "1 1"
-    "2 0" "2 1"
-    "3 0" "3 1"
-    "4 0" "4 1"
+    "TEXCOORD_COUNT;HAS_COLOR_ATTRIBUTE;FRAGMENT_SHADER_GENERATED_TBN"
+    "0 0 0" "0 0 1" "0 1 0" "0 1 1"
+    "1 0 0" "1 0 1" "1 1 0" "1 1 1"
+    "2 0 0" "2 0 1" "2 1 0" "2 1 1"
+    "3 0 0" "3 0 1" "3 1 0" "3 1 1"
+    "4 0 0" "4 0 1" "4 1 0" "4 1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/primitive.frag
-    "TEXCOORD_COUNT;FRAGMENT_SHADER_GENERATED_TBN;ALPHA_MODE"
-    "0 0 0" "0 0 1" "0 0 2" "0 1 0" "0 1 1" "0 1 2"
-    "1 0 0" "1 0 1" "1 0 2" "1 1 0" "1 1 1" "1 1 2"
-    "2 0 0" "2 0 1" "2 0 2" "2 1 0" "2 1 1" "2 1 2"
-    "3 0 0" "3 0 1" "3 0 2" "3 1 0" "3 1 1" "3 1 2"
-    "4 0 0" "4 0 1" "4 0 2" "4 1 0" "4 1 1" "4 1 2"
+    "TEXCOORD_COUNT;HAS_COLOR_ATTRIBUTE;FRAGMENT_SHADER_GENERATED_TBN;ALPHA_MODE"
+    "0 0 0 0" "0 0 0 1" "0 0 0 2" "0 0 1 0" "0 0 1 1" "0 0 1 2"
+    "0 1 0 0" "0 1 0 1" "0 1 0 2" "0 1 1 0" "0 1 1 1" "0 1 1 2"
+    "1 0 0 0" "1 0 0 1" "1 0 0 2" "1 0 1 0" "1 0 1 1" "1 0 1 2"
+    "1 1 0 0" "1 1 0 1" "1 1 0 2" "1 1 1 0" "1 1 1 1" "1 1 1 2"
+    "2 0 0 0" "2 0 0 1" "2 0 0 2" "2 0 1 0" "2 0 1 1" "2 0 1 2"
+    "2 1 0 0" "2 1 0 1" "2 1 0 2" "2 1 1 0" "2 1 1 1" "2 1 1 2"
+    "3 0 0 0" "3 0 0 1" "3 0 0 2" "3 0 1 0" "3 0 1 1" "3 0 1 2"
+    "3 1 0 0" "3 1 0 1" "3 1 0 2" "3 1 1 0" "3 1 1 1" "3 1 1 2"
+    "4 0 0 0" "4 0 0 1" "4 0 0 2" "4 0 1 0" "4 0 1 1" "4 0 1 2"
+    "4 1 0 0" "4 1 0 1" "4 1 0 2" "4 1 1 0" "4 1 1 1" "4 1 1 2"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/unlit_primitive.vert
-    "HAS_BASE_COLOR_TEXTURE" 0 1
+    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ATTRIBUTE"
+    "0 0" "0 1"
+    "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
     shaders/unlit_primitive.frag
-    "HAS_BASE_COLOR_TEXTURE;ALPHA_MODE"
-    "0 0" "0 1" "0 2"
-    "1 0" "1 1" "1 2"
+    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ATTRIBUTE;ALPHA_MODE"
+    "0 0 0" "0 0 1" "0 0 2" "0 1 0" "0 1 1" "0 1 2"
+    "1 0 0" "1 0 1" "1 0 2" "1 1 0" "1 1 1" "1 1 2"
 )

--- a/impl/gltf/AssetGpuBuffers.cpp
+++ b/impl/gltf/AssetGpuBuffers.cpp
@@ -129,15 +129,19 @@ std::variant<vku::AllocatedBuffer, vku::MappedBuffer> vk_gltf_viewer::gltf::Asse
             const auto normalInfo = primitiveInfo.normalInfo.value_or(AssetPrimitiveInfo::AttributeBufferInfo{});
             const auto tangentInfo = primitiveInfo.tangentInfo.value_or(AssetPrimitiveInfo::AttributeBufferInfo{});
 
+            // If color is not presented, it is not used in the shader. Therefore, it is okay to pass nullptr into shaders.
+            const auto colorInfo = primitiveInfo.colorInfo.value_or(AssetPrimitiveInfo::ColorAttributeBufferInfo{});
+
             return GpuPrimitive {
                 .pPositionBuffer = primitiveInfo.positionInfo.address,
                 .pNormalBuffer = normalInfo.address,
                 .pTangentBuffer = tangentInfo.address,
                 .pTexcoordAttributeMappingInfoBuffer = primitiveInfo.texcoordsInfo.pMappingBuffer,
-                .pColorAttributeMappingInfoBuffer = 0ULL, // TODO: implement color attribute mapping.
+                .pColorBuffer = colorInfo.address,
                 .positionByteStride = primitiveInfo.positionInfo.byteStride,
                 .normalByteStride = normalInfo.byteStride,
                 .tangentByteStride = tangentInfo.byteStride,
+                .colorByteStride = colorInfo.byteStride,
                 .materialIndex = primitiveInfo.materialIndex.transform(padMaterialIndex).value_or(0U),
             };
         }),

--- a/interface/gltf/AssetGpuBuffers.cppm
+++ b/interface/gltf/AssetGpuBuffers.cppm
@@ -140,11 +140,11 @@ namespace vk_gltf_viewer::gltf {
             vk::DeviceAddress pNormalBuffer;
             vk::DeviceAddress pTangentBuffer;
             vk::DeviceAddress pTexcoordAttributeMappingInfoBuffer;
-            vk::DeviceAddress pColorAttributeMappingInfoBuffer;
+            vk::DeviceAddress pColorBuffer;
             std::uint8_t positionByteStride;
             std::uint8_t normalByteStride;
             std::uint8_t tangentByteStride;
-            char padding[1];
+            std::uint8_t colorByteStride;
             std::uint32_t materialIndex;
         };
 
@@ -447,7 +447,9 @@ namespace vk_gltf_viewer::gltf {
                         }
                         primitiveInfo.texcoordsInfo.attributeInfos[index] = getAttributeBufferInfo();
                     }
-                    // TODO: COLOR_<i> attribute processing.
+                    else if (attributeName == "COLOR_0"sv) {
+                        primitiveInfo.colorInfo.emplace(getAttributeBufferInfo(), getNumComponents(accessor.type));
+                    }
                 }
             }
 

--- a/interface/gltf/AssetPrimitiveInfo.cppm
+++ b/interface/gltf/AssetPrimitiveInfo.cppm
@@ -8,6 +8,7 @@ namespace vk_gltf_viewer::gltf {
     struct AssetPrimitiveInfo {
         struct IndexBufferInfo { vk::DeviceSize offset; vk::IndexType type; };
         struct AttributeBufferInfo { vk::DeviceAddress address; std::uint8_t byteStride; };
+        struct ColorAttributeBufferInfo final : AttributeBufferInfo { std::uint8_t numComponent; };
         struct IndexedAttributeBufferInfos { vk::DeviceAddress pMappingBuffer; std::vector<AttributeBufferInfo> attributeInfos; };
 
         std::uint16_t index;
@@ -18,6 +19,7 @@ namespace vk_gltf_viewer::gltf {
         std::optional<AttributeBufferInfo> normalInfo;
         std::optional<AttributeBufferInfo> tangentInfo;
         IndexedAttributeBufferInfos texcoordsInfo;
+        std::optional<ColorAttributeBufferInfo> colorInfo;
         glm::dvec3 min;
         glm::dvec3 max;
     };

--- a/interface/shader_selector/mask_depth_frag.cppm
+++ b/interface/shader_selector/mask_depth_frag.cppm
@@ -1,0 +1,23 @@
+export module vk_gltf_viewer:shader_selector.mask_depth_frag;
+
+import std;
+export import fastgltf;
+import :shader.mask_depth_frag;
+import :helpers.type_map;
+
+namespace vk_gltf_viewer::shader_selector {
+    export
+    [[nodiscard]] std::span<const unsigned int> mask_depth_frag(bool hasBaseColorTexture, bool hasColorAlphaAttribute) {
+        constexpr type_map hasBaseColorTextureMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        constexpr type_map hasColorAlphaAttributeMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
+            return shader::mask_depth_frag<Is...>;
+        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAlphaAttributeMap.get_variant(hasColorAlphaAttribute));
+    }
+}

--- a/interface/shader_selector/mask_depth_vert.cppm
+++ b/interface/shader_selector/mask_depth_vert.cppm
@@ -1,0 +1,23 @@
+export module vk_gltf_viewer:shader_selector.mask_depth_vert;
+
+import std;
+export import fastgltf;
+import :shader.mask_depth_vert;
+import :helpers.type_map;
+
+namespace vk_gltf_viewer::shader_selector {
+    export
+    [[nodiscard]] std::span<const unsigned int> mask_depth_vert(bool hasBaseColorTexture, bool hasColorAlphaAttribute) {
+        constexpr type_map hasBaseColorTextureMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        constexpr type_map hasColorAlphaAttributeMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
+            return shader::mask_depth_vert<Is...>;
+        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAlphaAttributeMap.get_variant(hasColorAlphaAttribute));
+    }
+}

--- a/interface/shader_selector/mask_jump_flood_seed_frag.cppm
+++ b/interface/shader_selector/mask_jump_flood_seed_frag.cppm
@@ -1,0 +1,23 @@
+export module vk_gltf_viewer:shader_selector.mask_jump_flood_seed_frag;
+
+import std;
+export import fastgltf;
+import :shader.mask_jump_flood_seed_frag;
+import :helpers.type_map;
+
+namespace vk_gltf_viewer::shader_selector {
+    export
+    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_frag(bool hasBaseColorTexture, bool hasColorAlphaAttribute) {
+        constexpr type_map hasBaseColorTextureMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        constexpr type_map hasColorAlphaAttributeMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
+            return shader::mask_jump_flood_seed_frag<Is...>;
+        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAlphaAttributeMap.get_variant(hasColorAlphaAttribute));
+    }
+}

--- a/interface/shader_selector/mask_jump_flood_seed_vert.cppm
+++ b/interface/shader_selector/mask_jump_flood_seed_vert.cppm
@@ -1,0 +1,23 @@
+export module vk_gltf_viewer:shader_selector.mask_jump_flood_seed_vert;
+
+import std;
+export import fastgltf;
+import :shader.mask_jump_flood_seed_vert;
+import :helpers.type_map;
+
+namespace vk_gltf_viewer::shader_selector {
+    export
+    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_vert(bool hasBaseColorTexture, bool hasColorAlphaAttribute) {
+        constexpr type_map hasBaseColorTextureMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        constexpr type_map hasColorAlphaAttributeMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
+            return shader::mask_jump_flood_seed_vert<Is...>;
+        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAlphaAttributeMap.get_variant(hasColorAlphaAttribute));
+    }
+}

--- a/interface/shader_selector/primitive_frag.cppm
+++ b/interface/shader_selector/primitive_frag.cppm
@@ -6,13 +6,17 @@ import :shader.primitive_frag;
 import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
-    [[nodiscard]] std::span<const unsigned int> primitive_frag(std::uint8_t texcoordCount, bool fragmentShaderGeneratedTBN, fastgltf::AlphaMode alphaMode) {
+    [[nodiscard]] std::span<const unsigned int> primitive_frag(std::uint8_t texcoordCount, bool hasColorAttribute, bool fragmentShaderGeneratedTBN, fastgltf::AlphaMode alphaMode) {
         constexpr type_map texcoordCountMap {
             make_type_map_entry<std::integral_constant<int, 0>, std::uint8_t>(0),
             make_type_map_entry<std::integral_constant<int, 1>, std::uint8_t>(1),
             make_type_map_entry<std::integral_constant<int, 2>, std::uint8_t>(2),
             make_type_map_entry<std::integral_constant<int, 3>, std::uint8_t>(3),
             make_type_map_entry<std::integral_constant<int, 4>, std::uint8_t>(4),
+        };
+        constexpr type_map hasColorAttributeMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
         };
         constexpr type_map fragmentShaderGeneratedTBNMap {
             make_type_map_entry<std::integral_constant<int, 0>>(false),
@@ -25,6 +29,6 @@ namespace vk_gltf_viewer::shader_selector {
         };
         return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
             return shader::primitive_frag<Is...>;
-        }, texcoordCountMap.get_variant(texcoordCount), fragmentShaderGeneratedTBNMap.get_variant(fragmentShaderGeneratedTBN), alphaModeMap.get_variant(alphaMode));
+        }, texcoordCountMap.get_variant(texcoordCount), hasColorAttributeMap.get_variant(hasColorAttribute), fragmentShaderGeneratedTBNMap.get_variant(fragmentShaderGeneratedTBN), alphaModeMap.get_variant(alphaMode));
     }
 }

--- a/interface/shader_selector/primitive_vert.cppm
+++ b/interface/shader_selector/primitive_vert.cppm
@@ -5,7 +5,7 @@ import :shader.primitive_vert;
 import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
-    [[nodiscard]] std::span<const unsigned int> primitive_vert(std::uint8_t texcoordCount, bool fragmentShaderGeneratedTBN) {
+    [[nodiscard]] std::span<const unsigned int> primitive_vert(std::uint8_t texcoordCount, bool hasColorAttribute, bool fragmentShaderGeneratedTBN) {
         constexpr type_map texcoordCountMap {
             make_type_map_entry<std::integral_constant<int, 0>, std::uint8_t>(0),
             make_type_map_entry<std::integral_constant<int, 1>, std::uint8_t>(1),
@@ -13,12 +13,16 @@ namespace vk_gltf_viewer::shader_selector {
             make_type_map_entry<std::integral_constant<int, 3>, std::uint8_t>(3),
             make_type_map_entry<std::integral_constant<int, 4>, std::uint8_t>(4),
         };
+        constexpr type_map hasColorAttributeMap {
+            make_type_map_entry<std::integral_constant<int, 0>, std::uint8_t>(0),
+            make_type_map_entry<std::integral_constant<int, 1>, std::uint8_t>(1),
+        };
         constexpr type_map fragmentShaderGeneratedTBNMap {
             make_type_map_entry<std::integral_constant<int, 0>>(false),
             make_type_map_entry<std::integral_constant<int, 1>>(true),
         };
         return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
             return shader::primitive_vert<Is...>;
-        }, texcoordCountMap.get_variant(texcoordCount), fragmentShaderGeneratedTBNMap.get_variant(fragmentShaderGeneratedTBN));
+        }, texcoordCountMap.get_variant(texcoordCount), hasColorAttributeMap.get_variant(hasColorAttribute), fragmentShaderGeneratedTBNMap.get_variant(fragmentShaderGeneratedTBN));
     }
 }

--- a/interface/shader_selector/unlit_primitive_frag.cppm
+++ b/interface/shader_selector/unlit_primitive_frag.cppm
@@ -7,8 +7,12 @@ import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> unlit_primitive_frag(bool hasBaseColorTexture, fastgltf::AlphaMode alphaMode) {
+    [[nodiscard]] std::span<const unsigned int> unlit_primitive_frag(bool hasBaseColorTexture, bool hasColorAttribute, fastgltf::AlphaMode alphaMode) {
         constexpr type_map hasBaseColorTextureMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        constexpr type_map hasColorAttributeMap {
             make_type_map_entry<std::integral_constant<int, 0>>(false),
             make_type_map_entry<std::integral_constant<int, 1>>(true),
         };
@@ -19,6 +23,6 @@ namespace vk_gltf_viewer::shader_selector {
         };
         return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
             return shader::unlit_primitive_frag<Is...>;
-        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), alphaModeMap.get_variant(alphaMode));
+        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAttributeMap.get_variant(hasColorAttribute), alphaModeMap.get_variant(alphaMode));
     }
 }

--- a/interface/shader_selector/unlit_primitive_vert.cppm
+++ b/interface/shader_selector/unlit_primitive_vert.cppm
@@ -1,0 +1,23 @@
+export module vk_gltf_viewer:shader_selector.unlit_primitive_vert;
+
+import std;
+export import fastgltf;
+import :shader.unlit_primitive_vert;
+import :helpers.type_map;
+
+namespace vk_gltf_viewer::shader_selector {
+    export
+    [[nodiscard]] std::span<const unsigned int> unlit_primitive_vert(bool hasBaseColorTexture, bool hasColorAttribute) {
+        constexpr type_map hasBaseColorTextureMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        constexpr type_map hasColorAttributeMap {
+            make_type_map_entry<std::integral_constant<int, 0>>(false),
+            make_type_map_entry<std::integral_constant<int, 1>>(true),
+        };
+        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
+            return shader::unlit_primitive_vert<Is...>;
+        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAttributeMap.get_variant(hasColorAttribute));
+    }
+}

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -4,8 +4,8 @@ import std;
 import vku;
 import :shader.depth_vert;
 import :shader.depth_frag;
-import :shader.mask_depth_vert;
-import :shader.mask_depth_frag;
+import :shader_selector.mask_depth_vert;
+import :shader_selector.mask_depth_frag;
 export import :vulkan.pl.PrimitiveNoShading;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -43,22 +43,19 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     [[nodiscard]] vk::raii::Pipeline createMaskDepthRenderer(
         const vk::raii::Device &device,
         const pl::PrimitiveNoShading &pipelineLayout,
-        bool hasBaseColorTexture
+        bool hasBaseColorTexture,
+        bool hasColorAlphaAttribute
     ) {
         return { device, nullptr, vk::StructureChain {
             vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
                     vku::Shader {
-                        hasBaseColorTexture
-                            ? std::span<const std::uint32_t> { shader::mask_depth_vert<1> }
-                            : std::span<const std::uint32_t> { shader::mask_depth_vert<0> },
+                        shader_selector::mask_depth_vert(hasBaseColorTexture, hasColorAlphaAttribute),
                         vk::ShaderStageFlagBits::eVertex,
                     },
                     vku::Shader {
-                        hasBaseColorTexture
-                            ? std::span<const std::uint32_t> { shader::mask_depth_frag<1> }
-                            : std::span<const std::uint32_t> { shader::mask_depth_frag<0> },
+                        shader_selector::mask_depth_frag(hasBaseColorTexture, hasColorAlphaAttribute),
                         vk::ShaderStageFlagBits::eFragment,
                     }).get(),
                 *pipelineLayout, 1, true)

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -4,8 +4,8 @@ import std;
 import vku;
 import :shader.jump_flood_seed_vert;
 import :shader.jump_flood_seed_frag;
-import :shader.mask_jump_flood_seed_vert;
-import :shader.mask_jump_flood_seed_frag;
+import :shader_selector.mask_jump_flood_seed_vert;
+import :shader_selector.mask_jump_flood_seed_frag;
 export import :vulkan.pl.PrimitiveNoShading;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
@@ -43,22 +43,19 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     [[nodiscard]] vk::raii::Pipeline createMaskJumpFloodSeedRenderer(
         const vk::raii::Device &device,
         const pl::PrimitiveNoShading &pipelineLayout,
-        bool hasBaseColorTexture
+        bool hasBaseColorTexture,
+        bool hasColorAlphaAttribute
     ) {
         return { device, nullptr, vk::StructureChain {
             vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
                     vku::Shader {
-                        hasBaseColorTexture
-                            ? std::span<const std::uint32_t> { shader::mask_jump_flood_seed_vert<1> }
-                            : std::span<const std::uint32_t> { shader::mask_jump_flood_seed_vert<0> },
+                        shader_selector::mask_jump_flood_seed_vert(hasBaseColorTexture, hasColorAlphaAttribute),
                         vk::ShaderStageFlagBits::eVertex,
                     },
                     vku::Shader {
-                        hasBaseColorTexture
-                            ? std::span<const std::uint32_t> { shader::mask_jump_flood_seed_frag<1> }
-                            : std::span<const std::uint32_t> { shader::mask_jump_flood_seed_frag<0> },
+                        shader_selector::mask_jump_flood_seed_frag(hasBaseColorTexture, hasColorAlphaAttribute),
                         vk::ShaderStageFlagBits::eFragment,
                     }).get(),
                 *pipelineLayout, 1, true)

--- a/shaders/mask_depth.frag
+++ b/shaders/mask_depth.frag
@@ -8,10 +8,19 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
+#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
+
 layout (location = 0) flat in uint inNodeIndex;
 layout (location = 1) flat in uint inMaterialIndex;
+#if HAS_VARIADIC_IN
+layout (location = 2) in FRAG_VARIADIC_IN {
 #if HAS_BASE_COLOR_TEXTURE
-layout (location = 2) in vec2 inBaseColorTexcoord;
+    vec2 baseColorTexcoord;
+#endif
+#if HAS_COLOR_ALPHA_ATTRIBUTE
+    float colorAlpha;
+#endif
+} variadic_in;
 #endif
 
 layout (location = 0) out uint outNodeIndex;
@@ -24,7 +33,10 @@ layout (set = 0, binding = 2) uniform sampler2D textures[];
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;
 #if HAS_BASE_COLOR_TEXTURE
-    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord).a;
+    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], variadic_in.baseColorTexcoord).a;
+#endif
+#if HAS_COLOR_ALPHA_ATTRIBUTE
+    baseColorAlpha *= variadic_in.colorAlpha;
 #endif
     if (baseColorAlpha < MATERIAL.alphaCutoff) discard;
 

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -11,14 +11,24 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
+#define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
+
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer FloatRef { float data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
 layout (location = 0) flat out uint outNodeIndex;
 layout (location = 1) flat out uint outMaterialIndex;
+#if HAS_VARIADIC_OUT
+layout (location = 2) out VS_VARIADIC_OUT {
 #if HAS_BASE_COLOR_TEXTURE
-layout (location = 2) out vec2 outBaseColorTexcoord;
+    vec2 baseColorTexcoord;
+#endif
+#if HAS_COLOR_ALPHA_ATTRIBUTE
+    float colorAlpha;
+#endif
+} variadic_out;
 #endif
 
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
@@ -40,6 +50,10 @@ layout (push_constant) uniform PushConstant {
 // Functions.
 // --------------------
 
+float getFloat(uint64_t address) {
+    return FloatRef(address).data;
+}
+
 vec3 getVec3(uint64_t address){
     return Vec3Ref(address).data;
 }
@@ -59,7 +73,10 @@ void main(){
     outNodeIndex = NODE_INDEX;
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE
-    outBaseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
+    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
+#endif
+#if HAS_COLOR_ALPHA_ATTRIBUTE
+    variadic_out.colorAlpha = getFloat(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 12);
 #endif
 
     vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -8,9 +8,18 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
+#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
+
 layout (location = 0) flat in uint inMaterialIndex;
+#if HAS_VARIADIC_IN
+layout (location = 1) in FRAG_VARIDIC_IN {
 #if HAS_BASE_COLOR_TEXTURE
-layout (location = 1) in vec2 inBaseColorTexcoord;
+    vec2 baseColorTexcoord;
+#endif
+#if HAS_COLOR_ALPHA_ATTRIBUTE
+    float colorAlpha;
+#endif
+} variadic_in;
 #endif
 
 layout (location = 0) out uvec2 outCoordinate;
@@ -23,7 +32,10 @@ layout (set = 0, binding = 2) uniform sampler2D textures[];
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;
 #if HAS_BASE_COLOR_TEXTURE
-    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], inBaseColorTexcoord).a;
+    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], variadic_in.baseColorTexcoord).a;
+#endif
+#if HAS_COLOR_ALPHA_ATTRIBUTE
+    baseColorAlpha *= variadic_in.colorAlpha;
 #endif
     if (baseColorAlpha < MATERIAL.alphaCutoff) discard;
 

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -11,6 +11,10 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
+#define HAS_VARIADIC_OUT !FRAGMENT_SHADER_GENERATED_TBN || TEXCOORD_COUNT >= 1 || HAS_COLOR_ATTRIBUTE
+
+layout (constant_id = 0) const uint COLOR_COMPONENT_COUNT = 0;
+
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
@@ -18,19 +22,28 @@ layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer N
 
 layout (location = 0) out vec3 outPosition;
 layout (location = 1) flat out uint outMaterialIndex;
+#if HAS_VARIADIC_OUT
+layout (location = 2) out VS_VARIADIC_OUT {
+#if !FRAGMENT_SHADER_GENERATED_TBN
+    mat3 tbn;
+#endif
+
 #if TEXCOORD_COUNT == 1
-layout (location = 2) out vec2 outTexcoord;
+    vec2 texcoord;
 #elif TEXCOORD_COUNT == 2
-layout (location = 2) out mat2 outTexcoords;
+    mat2 texcoords;
 #elif TEXCOORD_COUNT == 3
-layout (location = 2) out mat3x2 outTexcoords;
+    mat3x2 texcoords;
 #elif TEXCOORD_COUNT == 4
-layout (location = 2) out mat4x2 outTexcoords;
+    mat4x2 texcoords;
 #elif TEXCOORD_COUNT >= 5
 #error "Maximum texcoord count exceeded."
 #endif
-#if !FRAGMENT_SHADER_GENERATED_TBN
-layout (location = TEXCOORD_COUNT + 2) out mat3 outTBN;
+
+#if HAS_COLOR_ATTRIBUTE
+    vec4 color;
+#endif
+} variadic_out;
 #endif
 
 layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
@@ -74,29 +87,44 @@ vec2 getTexcoord(uint texcoordIndex){
 }
 #endif
 
+#if HAS_COLOR_ATTRIBUTE
+vec4 getColor() {
+    if (COLOR_COMPONENT_COUNT == 4) {
+        return Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data;
+    }
+    else {
+        return vec4(Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data, 1.0);
+    }
+}
+#endif
+
 void main(){
     vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
     outPosition = (TRANSFORM * vec4(inPosition, 1.0)).xyz;
 
     outMaterialIndex = MATERIAL_INDEX;
 
-#if TEXCOORD_COUNT == 1
-    outTexcoord = getTexcoord(0);
-#elif TEXCOORD_COUNT >= 2
-    for (uint i = 0; i < TEXCOORD_COUNT; i++){
-        outTexcoords[i] = getTexcoord(i);
-    }
-#endif
-
 #if !FRAGMENT_SHADER_GENERATED_TBN
     vec3 inNormal = getVec3(PRIMITIVE.pNormalBuffer + int(PRIMITIVE.normalByteStride) * gl_VertexIndex);
-    outTBN[2] = normalize(mat3(TRANSFORM) * inNormal); // N
+    variadic_out.tbn[2] = normalize(mat3(TRANSFORM) * inNormal); // N
 
     if (int(MATERIAL.normalTextureIndex) != -1){
         vec4 inTangent = getVec4(PRIMITIVE.pTangentBuffer + int(PRIMITIVE.tangentByteStride) * gl_VertexIndex);
-        outTBN[0] = normalize(mat3(TRANSFORM) * inTangent.xyz); // T
-        outTBN[1] = cross(outTBN[2], outTBN[0]) * -inTangent.w; // B
+        variadic_out.tbn[0] = normalize(mat3(TRANSFORM) * inTangent.xyz); // T
+        variadic_out.tbn[1] = cross(variadic_out.tbn[2], variadic_out.tbn[0]) * -inTangent.w; // B
     }
+#endif
+
+#if TEXCOORD_COUNT == 1
+    variadic_out.texcoord = getTexcoord(0);
+#elif TEXCOORD_COUNT >= 2
+    for (uint i = 0; i < TEXCOORD_COUNT; i++){
+        variadic_out.texcoords[i] = getTexcoord(i);
+    }
+#endif
+
+#if HAS_COLOR_ATTRIBUTE
+    variadic_out.color = getColor();
 #endif
 
     gl_Position = pc.projectionView * vec4(outPosition, 1.0);

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -37,11 +37,11 @@ struct Primitive {
     uint64_t pNormalBuffer;
     uint64_t pTangentBuffer;
     IndexedAttributeMappingInfos texcoordAttributeMappingInfos;
-    IndexedAttributeMappingInfos colorAttributeMappingInfos;
+    uint64_t pColorBuffer;
     uint8_t positionByteStride;
     uint8_t normalByteStride;
     uint8_t tangentByteStride;
-    uint8_t padding;
+    uint8_t colorByteStride;
     uint materialIndex;
 };
 

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -11,13 +11,26 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
+#define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ATTRIBUTE
+
+layout (constant_id = 0) const uint COLOR_COMPONENT_COUNT = 0;
+
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 64) readonly buffer Node { mat4 transforms[]; };
 
 layout (location = 0) flat out uint outMaterialIndex;
+#if HAS_VARIADIC_OUT
+layout (location = 1) out VS_VARIADIC_OUT {
 #if HAS_BASE_COLOR_TEXTURE
-layout (location = 1) out vec2 outBaseColorTexcoord;
+    vec2 baseColorTexcoord;
+#endif
+
+#if HAS_COLOR_ATTRIBUTE
+    vec4 color;
+#endif
+} variadic_out;
 #endif
 
 layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
@@ -55,12 +68,27 @@ vec2 getTexcoord(uint texcoordIndex){
 }
 #endif
 
+#if HAS_COLOR_ATTRIBUTE
+vec4 getColor() {
+    if (COLOR_COMPONENT_COUNT == 4) {
+        return Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data;
+    }
+    else {
+        return vec4(Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data, 1.0);
+    }
+}
+#endif
+
 void main(){
     vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
 
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE
-    outBaseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
+    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
+#endif
+
+#if HAS_COLOR_ATTRIBUTE
+    variadic_out.color = getColor();
 #endif
 
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);


### PR DESCRIPTION
Support `TEXCOORD_0` attribute. This affect to:
- Multiply vertex color to the base color in primitive rendering shader.
- Multiply vertex color alpha to the base color alpha in `alphaMode=MASK` primitive's depth prepass and jump flood seed shader, which follows the three.js, Google Filament and Cesium renderer's convention (looks like Babylon.js does not respect this).