### PR TITLE
Support for normalized attribute accessor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The extensions and feature used in this application are quite common in the mode
 - Device Features
   - `VkPhysicalDeviceFeatures`
     - `samplerAnistropy`
+    - `shaderInt16`
     - `shaderInt64`
     - `multiDrawIndirect`
     - `shaderStorageImageWriteWithoutFormat`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Followings are not supported:
 - Primitive Type except for `TRIANGLES`.
 - Animation.
 - Sparse accessors (indices accessor is supported).
-- Normalized accessors.
 
 ## Performance
 

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -123,7 +123,9 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return primitiveInfo.texcoordsInfo.attributeInfos.at(textureInfo.texCoordIndex).componentType;
                     }),
-                    .colorComponentCount = primitiveInfo.colorInfo.transform([](const auto &info) { return info.numComponent; }),
+                    .colorComponentCountAndType = primitiveInfo.colorInfo.transform([](const auto &info) {
+                        return std::pair { info.numComponent, info.componentType };
+                    }),
                     .alphaMode = material.alphaMode,
                 });
             }
@@ -132,7 +134,9 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                     .texcoordComponentTypes = primitiveInfo.texcoordsInfo.attributeInfos | std::views::transform([](const auto &info) {
                         return info.componentType;
                     }) | std::ranges::to<boost::container::static_vector<fastgltf::ComponentType, 4>>(),
-                    .colorComponentCount = primitiveInfo.colorInfo.transform([](const auto &info) { return info.numComponent; }),
+                    .colorComponentCountAndType = primitiveInfo.colorInfo.transform([](const auto &info) {
+                        return std::pair { info.numComponent, info.componentType };
+                    }),
                     .fragmentShaderGeneratedTBN = !primitiveInfo.normalInfo.has_value(),
                     .alphaMode = material.alphaMode,
                 });
@@ -144,7 +148,9 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                 .texcoordComponentTypes = primitiveInfo.texcoordsInfo.attributeInfos | std::views::transform([](const auto &info) {
                     return info.componentType;
                 }) | std::ranges::to<boost::container::static_vector<fastgltf::ComponentType, 4>>(),
-                .colorComponentCount = primitiveInfo.colorInfo.transform([](const auto &info) { return info.numComponent; }),
+                .colorComponentCountAndType = primitiveInfo.colorInfo.transform([](const auto &info) {
+                    return std::pair { info.numComponent, info.componentType };
+                }),
                 .fragmentShaderGeneratedTBN = !primitiveInfo.normalInfo.has_value(),
             });
         }
@@ -166,7 +172,10 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return primitiveInfo.texcoordsInfo.attributeInfos.at(textureInfo.texCoordIndex).componentType;
                     }),
-                    .hasColorAlphaAttribute = primitiveInfo.colorInfo.transform([](const auto &info) { return info.numComponent == 4; }).value_or(false),
+                    .colorAlphaComponentType = primitiveInfo.colorInfo.and_then([](const auto &info) {
+                        // Alpha value exists only if COLOR_0 is Vec4 type.
+                        return value_if(info.numComponent == 4, info.componentType);
+                    }),
                 });
             }
             else {
@@ -195,7 +204,10 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return primitiveInfo.texcoordsInfo.attributeInfos.at(textureInfo.texCoordIndex).componentType;
                     }),
-                    .hasColorAlphaAttribute = primitiveInfo.colorInfo.transform([](const auto &info) { return info.numComponent == 4; }).value_or(false),
+                    .colorAlphaComponentType = primitiveInfo.colorInfo.and_then([](const auto &info) {
+                        // Alpha value exists only if COLOR_0 is Vec4 type.
+                        return value_if(info.numComponent == 4, info.componentType);
+                    }),
                 });
             }
             else {

--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -26,6 +26,7 @@ constexpr std::array optionalExtensions {
 
 constexpr vk::PhysicalDeviceFeatures requiredFeatures = vk::PhysicalDeviceFeatures{}
     .setSamplerAnisotropy(true)
+    .setShaderInt16(true)
     .setShaderInt64(true)
     .setMultiDrawIndirect(true)
     .setShaderStorageImageWriteWithoutFormat(true)
@@ -97,6 +98,7 @@ auto vk_gltf_viewer::vulkan::Gpu::selectPhysicalDevice(const vk::raii::Instance 
         const vk::PhysicalDeviceVulkan11Features &vulkan11Features = availableFeatures.get<vk::PhysicalDeviceVulkan11Features>();
         const vk::PhysicalDeviceVulkan12Features &vulkan12Features = availableFeatures.get<vk::PhysicalDeviceVulkan12Features>();
         if (!features.samplerAnisotropy ||
+            !features.shaderInt16 ||
             !features.shaderInt64 ||
             !features.multiDrawIndirect ||
             !features.shaderStorageImageWriteWithoutFormat ||
@@ -186,14 +188,7 @@ auto vk_gltf_viewer::vulkan::Gpu::createDevice() -> vk::raii::Device {
             {},
             extensions,
         },
-        vk::PhysicalDeviceFeatures2 {
-            vk::PhysicalDeviceFeatures{}
-                .setSamplerAnisotropy(true)
-                .setShaderInt64(true)
-                .setMultiDrawIndirect(true)
-                .setShaderStorageImageWriteWithoutFormat(true)
-                .setIndependentBlend(true),
-        },
+        vk::PhysicalDeviceFeatures2 { requiredFeatures },
         vk::PhysicalDeviceVulkan11Features{}
             .setShaderDrawParameters(true)
             .setStorageBuffer16BitAccess(true)

--- a/interface/gltf/AssetGpuBuffers.cppm
+++ b/interface/gltf/AssetGpuBuffers.cppm
@@ -362,7 +362,6 @@ namespace vk_gltf_viewer::gltf {
 
                     // Check accessor validity.
                     if (accessor.sparse) throw AssetProcessError::SparseAttributeBufferAccessor;
-                    if (accessor.normalized) throw AssetProcessError::NormalizedAttributeBufferAccessor;
 
                     attributeBufferViewIndices.emplace(accessor.bufferViewIndex.value());
                 }
@@ -417,6 +416,7 @@ namespace vk_gltf_viewer::gltf {
                         return {
                             .address = bufferDeviceAddressMappings.at(*accessor.bufferViewIndex) + accessor.byteOffset,
                             .byteStride = static_cast<std::uint8_t>(byteStride),
+                            .componentType = accessor.componentType,
                         };
                     };
 

--- a/interface/gltf/AssetPrimitiveInfo.cppm
+++ b/interface/gltf/AssetPrimitiveInfo.cppm
@@ -1,13 +1,14 @@
 export module vk_gltf_viewer:gltf.AssetPrimitiveInfo;
 
 import std;
-export import vulkan_hpp;
+export import fastgltf;
 export import glm;
+export import vulkan_hpp;
 
 namespace vk_gltf_viewer::gltf {
     struct AssetPrimitiveInfo {
         struct IndexBufferInfo { vk::DeviceSize offset; vk::IndexType type; };
-        struct AttributeBufferInfo { vk::DeviceAddress address; std::uint8_t byteStride; };
+        struct AttributeBufferInfo { vk::DeviceAddress address; std::uint8_t byteStride; fastgltf::ComponentType componentType; };
         struct ColorAttributeBufferInfo final : AttributeBufferInfo { std::uint8_t numComponent; };
         struct IndexedAttributeBufferInfos { vk::DeviceAddress pMappingBuffer; std::vector<AttributeBufferInfo> attributeInfos; };
 

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -32,14 +32,14 @@ namespace vk_gltf_viewer::vulkan {
             std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
             bool hasColorAlphaAttribute;
 
-            [[nodiscard]] std::partial_ordering operator<=>(const MaskDepthPipelineKey&) const noexcept = default;
+            [[nodiscard]] bool operator==(const MaskDepthPipelineKey&) const noexcept = default;
         };
 
         struct MaskJumpFloodSeedPipelineKey {
             std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
             bool hasColorAlphaAttribute;
 
-            [[nodiscard]] std::partial_ordering operator<=>(const MaskJumpFloodSeedPipelineKey&) const noexcept = default;
+            [[nodiscard]] bool operator==(const MaskJumpFloodSeedPipelineKey&) const noexcept = default;
         };
 
         struct PrimitivePipelineKey {

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -1,5 +1,6 @@
 module;
 
+#include <boost/container/static_vector.hpp>
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vk_gltf_viewer:vulkan.SharedData;
@@ -28,34 +29,34 @@ namespace vk_gltf_viewer::vulkan {
 
     public:
         struct MaskDepthPipelineKey {
-            bool hasBaseColorTexture;
+            std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
             bool hasColorAlphaAttribute;
 
             [[nodiscard]] std::partial_ordering operator<=>(const MaskDepthPipelineKey&) const noexcept = default;
         };
 
         struct MaskJumpFloodSeedPipelineKey {
-            bool hasBaseColorTexture;
+            std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
             bool hasColorAlphaAttribute;
 
             [[nodiscard]] std::partial_ordering operator<=>(const MaskJumpFloodSeedPipelineKey&) const noexcept = default;
         };
 
         struct PrimitivePipelineKey {
-            std::uint8_t texcoordCount;
+            boost::container::static_vector<fastgltf::ComponentType, 4> texcoordComponentTypes;
             std::optional<std::uint32_t> colorComponentCount;
             bool fragmentShaderGeneratedTBN;
             fastgltf::AlphaMode alphaMode;
 
-            [[nodiscard]] std::partial_ordering operator<=>(const PrimitivePipelineKey&) const noexcept = default;
+            [[nodiscard]] bool operator==(const PrimitivePipelineKey&) const noexcept = default;
         };
 
         struct UnlitPrimitivePipelineKey {
-            bool hasBaseColorTexture;
+            std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
             std::optional<std::uint32_t> colorComponentCount;
             fastgltf::AlphaMode alphaMode;
 
-            [[nodiscard]] std::partial_ordering operator<=>(const UnlitPrimitivePipelineKey&) const noexcept = default;
+            [[nodiscard]] bool operator==(const UnlitPrimitivePipelineKey&) const noexcept = default;
         };
 
         // --------------------
@@ -139,7 +140,10 @@ namespace vk_gltf_viewer::vulkan {
 
         [[nodiscard]] vk::Pipeline getMaskDepthRenderer(const MaskDepthPipelineKey &key) const {
             return ranges::try_emplace_if_not_exists(maskDepthPipelines, key, [&]() {
-                return createMaskDepthRenderer(gpu.device, primitiveNoShadingPipelineLayout, key.hasBaseColorTexture, key.hasColorAlphaAttribute);
+                return createMaskDepthRenderer(
+                    gpu.device, primitiveNoShadingPipelineLayout,
+                    key.baseColorTexcoordComponentType,
+                    key.hasColorAlphaAttribute);
             }).first->second;
         }
 
@@ -152,7 +156,10 @@ namespace vk_gltf_viewer::vulkan {
 
         [[nodiscard]] vk::Pipeline getMaskJumpFloodSeedRenderer(const MaskJumpFloodSeedPipelineKey &key) const {
             return ranges::try_emplace_if_not_exists(maskJumpFloodSeedPipelines, key, [&]() {
-                return createMaskJumpFloodSeedRenderer(gpu.device, primitiveNoShadingPipelineLayout, key.hasBaseColorTexture, key.hasColorAlphaAttribute);
+                return createMaskJumpFloodSeedRenderer(
+                    gpu.device, primitiveNoShadingPipelineLayout,
+                    key.baseColorTexcoordComponentType,
+                    key.hasColorAlphaAttribute);
             }).first->second;
         }
 
@@ -160,7 +167,7 @@ namespace vk_gltf_viewer::vulkan {
             return ranges::try_emplace_if_not_exists(primitivePipelines, key, [&]() {
                 return createPrimitiveRenderer(
                     gpu.device, primitivePipelineLayout, sceneRenderPass,
-                    key.texcoordCount,
+                    key.texcoordComponentTypes,
                     key.colorComponentCount,
                     key.fragmentShaderGeneratedTBN,
                     key.alphaMode);
@@ -171,7 +178,7 @@ namespace vk_gltf_viewer::vulkan {
             return ranges::try_emplace_if_not_exists(unlitPrimitivePipelines, key, [&]() {
                 return createUnlitPrimitiveRenderer(
                     gpu.device, primitivePipelineLayout, sceneRenderPass,
-                    key.hasBaseColorTexture,
+                    key.baseColorTexcoordComponentType,
                     key.colorComponentCount,
                     key.alphaMode);
             }).first->second;

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -30,21 +30,21 @@ namespace vk_gltf_viewer::vulkan {
     public:
         struct MaskDepthPipelineKey {
             std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
-            bool hasColorAlphaAttribute;
+            std::optional<fastgltf::ComponentType> colorAlphaComponentType;
 
             [[nodiscard]] bool operator==(const MaskDepthPipelineKey&) const noexcept = default;
         };
 
         struct MaskJumpFloodSeedPipelineKey {
             std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
-            bool hasColorAlphaAttribute;
+            std::optional<fastgltf::ComponentType> colorAlphaComponentType;
 
             [[nodiscard]] bool operator==(const MaskJumpFloodSeedPipelineKey&) const noexcept = default;
         };
 
         struct PrimitivePipelineKey {
             boost::container::static_vector<fastgltf::ComponentType, 4> texcoordComponentTypes;
-            std::optional<std::uint32_t> colorComponentCount;
+            std::optional<std::pair<std::uint32_t, fastgltf::ComponentType>> colorComponentCountAndType;
             bool fragmentShaderGeneratedTBN;
             fastgltf::AlphaMode alphaMode;
 
@@ -53,7 +53,7 @@ namespace vk_gltf_viewer::vulkan {
 
         struct UnlitPrimitivePipelineKey {
             std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
-            std::optional<std::uint32_t> colorComponentCount;
+            std::optional<std::pair<std::uint32_t, fastgltf::ComponentType>> colorComponentCountAndType;
             fastgltf::AlphaMode alphaMode;
 
             [[nodiscard]] bool operator==(const UnlitPrimitivePipelineKey&) const noexcept = default;
@@ -143,7 +143,7 @@ namespace vk_gltf_viewer::vulkan {
                 return createMaskDepthRenderer(
                     gpu.device, primitiveNoShadingPipelineLayout,
                     key.baseColorTexcoordComponentType,
-                    key.hasColorAlphaAttribute);
+                    key.colorAlphaComponentType);
             }).first->second;
         }
 
@@ -159,7 +159,7 @@ namespace vk_gltf_viewer::vulkan {
                 return createMaskJumpFloodSeedRenderer(
                     gpu.device, primitiveNoShadingPipelineLayout,
                     key.baseColorTexcoordComponentType,
-                    key.hasColorAlphaAttribute);
+                    key.colorAlphaComponentType);
             }).first->second;
         }
 
@@ -168,7 +168,7 @@ namespace vk_gltf_viewer::vulkan {
                 return createPrimitiveRenderer(
                     gpu.device, primitivePipelineLayout, sceneRenderPass,
                     key.texcoordComponentTypes,
-                    key.colorComponentCount,
+                    key.colorComponentCountAndType,
                     key.fragmentShaderGeneratedTBN,
                     key.alphaMode);
             }).first->second;
@@ -179,7 +179,7 @@ namespace vk_gltf_viewer::vulkan {
                 return createUnlitPrimitiveRenderer(
                     gpu.device, primitivePipelineLayout, sceneRenderPass,
                     key.baseColorTexcoordComponentType,
-                    key.colorComponentCount,
+                    key.colorComponentCountAndType,
                     key.alphaMode);
             }).first->second;
         }

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <cstddef>
+
 export module vk_gltf_viewer:vulkan.pipeline.DepthRenderer;
 
 import std;
@@ -43,19 +47,31 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     [[nodiscard]] vk::raii::Pipeline createMaskDepthRenderer(
         const vk::raii::Device &device,
         const pl::PrimitiveNoShading &pipelineLayout,
-        bool hasBaseColorTexture,
+        const std::optional<fastgltf::ComponentType> &baseColorTexcoordComponentType,
         bool hasColorAlphaAttribute
     ) {
+        struct VertexShaderSpecializationData {
+            std::uint32_t texcoordComponentType = 5126; // FLOAT
+        } vertexShaderSpecializationData{};
+
+        if (baseColorTexcoordComponentType) {
+            vertexShaderSpecializationData.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
+        }
+
         return { device, nullptr, vk::StructureChain {
             vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
                     vku::Shader {
-                        shader_selector::mask_depth_vert(hasBaseColorTexture, hasColorAlphaAttribute),
+                        shader_selector::mask_depth_vert(baseColorTexcoordComponentType.has_value(), hasColorAlphaAttribute),
                         vk::ShaderStageFlagBits::eVertex,
+                        vku::unsafeAddress(vk::SpecializationInfo {
+                            vku::unsafeProxy(vk::SpecializationMapEntry { 0, offsetof(VertexShaderSpecializationData, texcoordComponentType), sizeof(VertexShaderSpecializationData::texcoordComponentType) }),
+                            vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
+                        }),
                     },
                     vku::Shader {
-                        shader_selector::mask_depth_frag(hasBaseColorTexture, hasColorAlphaAttribute),
+                        shader_selector::mask_depth_frag(baseColorTexcoordComponentType.has_value(), hasColorAlphaAttribute),
                         vk::ShaderStageFlagBits::eFragment,
                     }).get(),
                 *pipelineLayout, 1, true)

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -48,14 +48,19 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         const vk::raii::Device &device,
         const pl::PrimitiveNoShading &pipelineLayout,
         const std::optional<fastgltf::ComponentType> &baseColorTexcoordComponentType,
-        bool hasColorAlphaAttribute
+        const std::optional<fastgltf::ComponentType> &colorAlphaComponentType
     ) {
         struct VertexShaderSpecializationData {
             std::uint32_t texcoordComponentType = 5126; // FLOAT
+            std::uint32_t colorComponentType = 5126; // FLOAT
         } vertexShaderSpecializationData{};
 
         if (baseColorTexcoordComponentType) {
             vertexShaderSpecializationData.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
+        }
+
+        if (colorAlphaComponentType) {
+            vertexShaderSpecializationData.colorComponentType = getGLComponentType(*colorAlphaComponentType);
         }
 
         return { device, nullptr, vk::StructureChain {
@@ -63,15 +68,30 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 createPipelineStages(
                     device,
                     vku::Shader {
-                        shader_selector::mask_depth_vert(baseColorTexcoordComponentType.has_value(), hasColorAlphaAttribute),
+                        shader_selector::mask_depth_vert(
+                            baseColorTexcoordComponentType.has_value(),
+                            colorAlphaComponentType.has_value()),
                         vk::ShaderStageFlagBits::eVertex,
                         vku::unsafeAddress(vk::SpecializationInfo {
-                            vku::unsafeProxy(vk::SpecializationMapEntry { 0, offsetof(VertexShaderSpecializationData, texcoordComponentType), sizeof(VertexShaderSpecializationData::texcoordComponentType) }),
+                            vku::unsafeProxy({
+                                vk::SpecializationMapEntry {
+                                    0,
+                                    offsetof(VertexShaderSpecializationData, texcoordComponentType),
+                                    sizeof(VertexShaderSpecializationData::texcoordComponentType),
+                                },
+                                vk::SpecializationMapEntry {
+                                    0,
+                                    offsetof(VertexShaderSpecializationData, colorComponentType),
+                                    sizeof(VertexShaderSpecializationData::colorComponentType),
+                                },
+                            }),
                             vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
                         }),
                     },
                     vku::Shader {
-                        shader_selector::mask_depth_frag(baseColorTexcoordComponentType.has_value(), hasColorAlphaAttribute),
+                        shader_selector::mask_depth_frag(
+                            baseColorTexcoordComponentType.has_value(),
+                            colorAlphaComponentType.has_value()),
                         vk::ShaderStageFlagBits::eFragment,
                     }).get(),
                 *pipelineLayout, 1, true)

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <cstddef>
+
 export module vk_gltf_viewer:vulkan.pipeline.JumpFloodSeedRenderer;
 
 import std;
@@ -7,6 +11,8 @@ import :shader.jump_flood_seed_frag;
 import :shader_selector.mask_jump_flood_seed_vert;
 import :shader_selector.mask_jump_flood_seed_frag;
 export import :vulkan.pl.PrimitiveNoShading;
+
+#define LIFT(...) [&](auto &&...xs) { return __VA_ARGS__(FWD(xs)...); }
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     [[nodiscard]] vk::raii::Pipeline createJumpFloodSeedRenderer(
@@ -43,19 +49,31 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     [[nodiscard]] vk::raii::Pipeline createMaskJumpFloodSeedRenderer(
         const vk::raii::Device &device,
         const pl::PrimitiveNoShading &pipelineLayout,
-        bool hasBaseColorTexture,
+        const std::optional<fastgltf::ComponentType> &baseColorTexcoordComponentType,
         bool hasColorAlphaAttribute
     ) {
+        struct VertexShaderSpecializationData {
+            std::uint32_t texcoordComponentType = 5126; // FLOAT
+        } vertexShaderSpecializationData{};
+
+        if (baseColorTexcoordComponentType) {
+            vertexShaderSpecializationData.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
+        }
+
         return { device, nullptr, vk::StructureChain {
             vku::getDefaultGraphicsPipelineCreateInfo(
                 createPipelineStages(
                     device,
                     vku::Shader {
-                        shader_selector::mask_jump_flood_seed_vert(hasBaseColorTexture, hasColorAlphaAttribute),
+                        shader_selector::mask_jump_flood_seed_vert(baseColorTexcoordComponentType.has_value(), hasColorAlphaAttribute),
                         vk::ShaderStageFlagBits::eVertex,
+                        vku::unsafeAddress(vk::SpecializationInfo {
+                            vku::unsafeProxy(vk::SpecializationMapEntry { 0, offsetof(VertexShaderSpecializationData, texcoordComponentType), sizeof(VertexShaderSpecializationData::texcoordComponentType) }),
+                            vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
+                        }),
                     },
                     vku::Shader {
-                        shader_selector::mask_jump_flood_seed_frag(hasBaseColorTexture, hasColorAlphaAttribute),
+                        shader_selector::mask_jump_flood_seed_frag(baseColorTexcoordComponentType.has_value(), hasColorAlphaAttribute),
                         vk::ShaderStageFlagBits::eFragment,
                     }).get(),
                 *pipelineLayout, 1, true)

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -1,6 +1,9 @@
 module;
 
 #include <cassert>
+#include <cstddef>
+
+#include <boost/container/static_vector.hpp>
 
 export module vk_gltf_viewer:vulkan.pipeline.PrimitiveRenderer;
 
@@ -18,35 +21,72 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         const vk::raii::Device &device,
         const pl::Primitive &pipelineLayout,
         const rp::Scene &sceneRenderPass,
-        std::uint32_t texcoordCount,
+        const boost::container::static_vector<fastgltf::ComponentType, 4> &texcoordComponentTypes,
         const std::optional<std::uint8_t> &colorComponentCount,
         bool fragmentShaderGeneratedTBN,
         fastgltf::AlphaMode alphaMode
     ) {
-        static constexpr std::array vertexShaderSpecializationMapEntries {
-            vk::SpecializationMapEntry { 0, 0, sizeof(std::uint32_t) },
-        };
+        struct VertexShaderSpecializationData {
+            std::uint32_t packedTexcoordComponentTypes = 0x06060606; // [FLOAT, FLOAT, FLOAT, FLOAT]
+            std::uint8_t colorComponentCount = 0;
+        } vertexShaderSpecializationData{};
 
-        std::array vertexShaderSpecializationData { 0U };
+        for (auto [i, componentType] : texcoordComponentTypes | ranges::views::enumerate) {
+            assert(ranges::one_of(componentType, fastgltf::ComponentType::UnsignedByte, fastgltf::ComponentType::UnsignedShort, fastgltf::ComponentType::Float));
+
+            /* Change the i-th byte (from LSB) to the componentType - fastgltf::ComponentType::Byte, which can be
+             * represented by the 1-byte integer.
+             *
+             * fastgltf::ComponentType::Byte - fastgltf::ComponentType::Byte = 0
+             * fastgltf::ComponentType::UnsignedByte - fastgltf::ComponentType::Byte = 1
+             * fastgltf::ComponentType::Short - fastgltf::ComponentType::Byte = 2
+             * fastgltf::ComponentType::UnsignedShort - fastgltf::ComponentType::Byte = 3
+             * fastgltf::ComponentType::Int - fastgltf::ComponentType::Byte = 4
+             * fastgltf::ComponentType::UnsignedInt - fastgltf::ComponentType::Byte = 5
+             * fastgltf::ComponentType::Float - fastgltf::ComponentType::Byte = 6
+             * fastgltf::ComponentType::Double - fastgltf::ComponentType::Byte = 10
+             */
+
+            // Step 1: clear the i-th byte (=[8*(i+1):8*i] bits)
+            vertexShaderSpecializationData.packedTexcoordComponentTypes &= ~(0xFFU << (8 * i));
+
+            // Step 2: set the i-th byte to the componentType - fastgltf::ComponentType::Byte
+            vertexShaderSpecializationData.packedTexcoordComponentTypes
+                |= (getGLComponentType(componentType) - getGLComponentType(fastgltf::ComponentType::Byte)) << (8 * i);
+        }
+
         if (colorComponentCount) {
             assert(ranges::one_of(*colorComponentCount, 3, 4));
-            get<0>(vertexShaderSpecializationData) = *colorComponentCount;
+            vertexShaderSpecializationData.colorComponentCount = *colorComponentCount;
         }
+
+        static constexpr std::array vertexShaderSpecializationMapEntries {
+            vk::SpecializationMapEntry {
+                0,
+                offsetof(VertexShaderSpecializationData, packedTexcoordComponentTypes),
+                sizeof(VertexShaderSpecializationData::packedTexcoordComponentTypes),
+            },
+            vk::SpecializationMapEntry {
+                1,
+                offsetof(VertexShaderSpecializationData, colorComponentCount),
+                sizeof(VertexShaderSpecializationData::colorComponentCount),
+            },
+        };
 
         const vk::SpecializationInfo vertexShaderSpecializationInfo {
             vertexShaderSpecializationMapEntries,
-            vk::ArrayProxyNoTemporaries<const std::uint32_t> { vertexShaderSpecializationData },
+            vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
         };
 
         const vku::RefHolder pipelineStages = createPipelineStages(
             device,
             vku::Shader {
-                shader_selector::primitive_vert(texcoordCount, colorComponentCount.has_value(), fragmentShaderGeneratedTBN),
+                shader_selector::primitive_vert(texcoordComponentTypes.size(), colorComponentCount.has_value(), fragmentShaderGeneratedTBN),
                 vk::ShaderStageFlagBits::eVertex,
                 &vertexShaderSpecializationInfo,
             },
             vku::Shader {
-                shader_selector::primitive_frag(texcoordCount, colorComponentCount.has_value(), fragmentShaderGeneratedTBN, alphaMode),
+                shader_selector::primitive_frag(texcoordComponentTypes.size(), colorComponentCount.has_value(), fragmentShaderGeneratedTBN, alphaMode),
                 vk::ShaderStageFlagBits::eFragment,
             });
 

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -1,6 +1,7 @@
 module;
 
 #include <cassert>
+#include <cstddef>
 
 export module vk_gltf_viewer:vulkan.pipeline.UnlitPrimitiveRenderer;
 
@@ -18,34 +19,51 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         const vk::raii::Device &device,
         const pl::Primitive &layout,
         const rp::Scene &sceneRenderPass,
-        bool hasBaseColorTexture,
+        const std::optional<fastgltf::ComponentType> &baseColorTexcoordComponentType,
         const std::optional<std::uint8_t> &colorComponentCount,
         fastgltf::AlphaMode alphaMode
     ) {
-        static constexpr std::array vertexShaderSpecializationMapEntries {
-            vk::SpecializationMapEntry { 0, 0, sizeof(std::uint32_t) },
-        };
+        struct VertexShaderSpecializationData {
+            std::uint32_t texcoordComponentType = 5126; // FLOAT
+            std::uint8_t colorComponentCount = 0;
+        } vertexShaderSpecializationData{};
 
-        std::array vertexShaderSpecializationData { 0U };
+        if (baseColorTexcoordComponentType) {
+            vertexShaderSpecializationData.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
+        }
+
         if (colorComponentCount) {
             assert(ranges::one_of(*colorComponentCount, 3, 4));
-            get<0>(vertexShaderSpecializationData) = *colorComponentCount;
+            vertexShaderSpecializationData.colorComponentCount = *colorComponentCount;
         }
+
+        static constexpr std::array vertexShaderSpecializationMapEntries {
+            vk::SpecializationMapEntry {
+                0,
+                offsetof(VertexShaderSpecializationData, texcoordComponentType),
+                sizeof(VertexShaderSpecializationData::texcoordComponentType),
+             },
+            vk::SpecializationMapEntry {
+                1,
+                offsetof(VertexShaderSpecializationData, colorComponentCount),
+                sizeof(VertexShaderSpecializationData::colorComponentCount),
+            },
+        };
 
         const vk::SpecializationInfo vertexShaderSpecializationInfo {
             vertexShaderSpecializationMapEntries,
-            vk::ArrayProxyNoTemporaries<const std::uint32_t> { vertexShaderSpecializationData },
+            vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
         };
 
         const vku::RefHolder pipelineStages = createPipelineStages(
             device,
             vku::Shader {
-                shader_selector::unlit_primitive_vert(hasBaseColorTexture, colorComponentCount.has_value()),
+                shader_selector::unlit_primitive_vert(baseColorTexcoordComponentType.has_value(), colorComponentCount.has_value()),
                 vk::ShaderStageFlagBits::eVertex,
                 &vertexShaderSpecializationInfo,
             },
             vku::Shader {
-                shader_selector::unlit_primitive_frag(hasBaseColorTexture, colorComponentCount.has_value(), alphaMode),
+                shader_selector::unlit_primitive_frag(baseColorTexcoordComponentType.has_value(), colorComponentCount.has_value(), alphaMode),
                 vk::ShaderStageFlagBits::eFragment,
             });
 

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -30,13 +30,13 @@ layout (push_constant) uniform PushConstant {
 // Functions.
 // --------------------
 
-vec3 getVec3(uint64_t address){
-    return Vec3Ref(address).data;
+vec3 getPosition() {
+    return Vec3Ref(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex).data;
 }
 
 void main(){
     outNodeIndex = NODE_INDEX;
 
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getPosition();
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -28,11 +28,11 @@ layout (push_constant) uniform PushConstant {
 // Functions.
 // --------------------
 
-vec3 getVec3(uint64_t address){
-    return Vec3Ref(address).data;
+vec3 getPosition() {
+    return Vec3Ref(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex).data;
 }
 
 void main(){
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getPosition();
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -15,8 +15,11 @@
 #define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
 
 layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 5126; // FLOAT
+layout (constant_id = 1) const uint COLOR_COMPONENT_TYPE = 5126; // FLOAT
 
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer Uint8Ref { uint8_t data; };
 layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec2Ref { u8vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer Uint16Ref { uint16_t data; };
 layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec2Ref { u16vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer FloatRef { float data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
@@ -78,7 +81,15 @@ vec2 getTexcoord(uint texcoordIndex){
 
 #if HAS_COLOR_ALPHA_ATTRIBUTE
 float getColorAlpha() {
-    return FloatRef(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 12).data;
+    switch (COLOR_COMPONENT_TYPE) {
+    case 5121U: // UNSIGNED BYTE
+        return float(Uint8Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 3).data) / 255.0;
+    case 5123U: // UNSIGNED SHORT
+        return float(Uint16Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 6).data) / 65535.0;
+    case 5126U: // FLOAT
+        return FloatRef(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 12).data;
+    }
+    return 1.0;
 }
 #endif
 

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -4,6 +4,7 @@
 #extension GL_EXT_buffer_reference : require
 #extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
 #extension GL_EXT_shader_8bit_storage : require
 
@@ -13,6 +14,10 @@
 
 #define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
 
+layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 5126; // FLOAT
+
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec2Ref { u8vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec2Ref { u16vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer FloatRef { float data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
@@ -57,7 +62,17 @@ vec3 getPosition() {
 #if HAS_BASE_COLOR_TEXTURE
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return Vec2Ref(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex).data;
+    uint64_t fetchAddress = mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex;
+
+    switch (TEXCOORD_COMPONENT_TYPE) {
+    case 5121U: // UNSIGNED BYTE
+        return vec2(U8Vec2Ref(fetchAddress).data) / 255.0;
+    case 5123U: // UNSIGNED SHORT
+        return vec2(U16Vec2Ref(fetchAddress).data) / 65535.0;
+    case 5126U: // FLOAT
+        return Vec2Ref(fetchAddress).data;
+    }
+    return vec2(0.0);
 }
 #endif
 

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -50,22 +50,20 @@ layout (push_constant) uniform PushConstant {
 // Functions.
 // --------------------
 
-float getFloat(uint64_t address) {
-    return FloatRef(address).data;
-}
-
-vec3 getVec3(uint64_t address){
-    return Vec3Ref(address).data;
+vec3 getPosition() {
+    return Vec3Ref(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex).data;
 }
 
 #if HAS_BASE_COLOR_TEXTURE
-vec2 getVec2(uint64_t address){
-    return Vec2Ref(address).data;
-}
-
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return getVec2(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex);
+    return Vec2Ref(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex).data;
+}
+#endif
+
+#if HAS_COLOR_ALPHA_ATTRIBUTE
+float getColorAlpha() {
+    return FloatRef(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 12).data;
 }
 #endif
 
@@ -76,9 +74,9 @@ void main(){
     variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
 #endif
 #if HAS_COLOR_ALPHA_ATTRIBUTE
-    variadic_out.colorAlpha = getFloat(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 12);
+    variadic_out.colorAlpha = getColorAlpha();
 #endif
 
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getPosition();
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -49,22 +49,20 @@ layout (push_constant, std430) uniform PushConstant {
 // Functions.
 // --------------------
 
-float getFloat(uint64_t address) {
-    return FloatRef(address).data;
-}
-
-vec3 getVec3(uint64_t address){
-    return Vec3Ref(address).data;
+vec3 getPosition() {
+    return Vec3Ref(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex).data;
 }
 
 #if HAS_BASE_COLOR_TEXTURE
-vec2 getVec2(uint64_t address){
-    return Vec2Ref(address).data;
-}
-
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return getVec2(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex);
+    return Vec2Ref(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex).data;
+}
+#endif
+
+#if HAS_COLOR_ALPHA_ATTRIBUTE
+float getColorAlpha() {
+    return FloatRef(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 12).data;
 }
 #endif
 
@@ -74,9 +72,9 @@ void main(){
     variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
 #endif
 #if HAS_COLOR_ALPHA_ATTRIBUTE
-    variadic_out.colorAlpha = getFloat(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 12);
+    variadic_out.colorAlpha = getColorAlpha();
 #endif
 
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getPosition();
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -15,8 +15,11 @@
 #define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
 
 layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 5126; // FLOAT
+layout (constant_id = 1) const uint COLOR_COMPONENT_TYPE = 5126; // FLOAT
 
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer Uint8Ref { uint8_t data; };
 layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec2Ref { u8vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer Uint16Ref { uint16_t data; };
 layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec2Ref { u16vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer FloatRef { float data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
@@ -77,7 +80,15 @@ vec2 getTexcoord(uint texcoordIndex){
 
 #if HAS_COLOR_ALPHA_ATTRIBUTE
 float getColorAlpha() {
-    return FloatRef(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 12).data;
+    switch (COLOR_COMPONENT_TYPE) {
+    case 5121U: // UNSIGNED BYTE
+        return float(Uint8Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 3).data) / 255.0;
+    case 5123U: // UNSIGNED SHORT
+        return float(Uint16Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 6).data) / 65535.0;
+    case 5126U: // FLOAT
+        return FloatRef(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex + 12).data;
+    }
+    return 1.0;
 }
 #endif
 

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -4,6 +4,7 @@
 #extension GL_EXT_buffer_reference : require
 #extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
 #extension GL_EXT_shader_8bit_storage : require
 
@@ -13,6 +14,10 @@
 
 #define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
 
+layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 5126; // FLOAT
+
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec2Ref { u8vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec2Ref { u16vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer FloatRef { float data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
@@ -56,7 +61,17 @@ vec3 getPosition() {
 #if HAS_BASE_COLOR_TEXTURE
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return Vec2Ref(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex).data;
+    uint64_t fetchAddress = mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex;
+
+    switch (TEXCOORD_COMPONENT_TYPE) {
+    case 5121U: // UNSIGNED BYTE
+        return vec2(U8Vec2Ref(fetchAddress).data) / 255.0;
+    case 5123U: // UNSIGNED SHORT
+        return vec2(U16Vec2Ref(fetchAddress).data) / 65535.0;
+    case 5126U: // FLOAT
+        return Vec2Ref(fetchAddress).data;
+    }
+    return vec2(0.0);
 }
 #endif
 

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -4,6 +4,7 @@
 #extension GL_EXT_buffer_reference : require
 #extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
 #extension GL_EXT_shader_8bit_storage : require
 
@@ -13,8 +14,11 @@
 
 #define HAS_VARIADIC_OUT !FRAGMENT_SHADER_GENERATED_TBN || TEXCOORD_COUNT >= 1 || HAS_COLOR_ATTRIBUTE
 
-layout (constant_id = 0) const uint COLOR_COMPONENT_COUNT = 0;
+layout (constant_id = 0) const uint PACKED_TEXCOORD_COMPONENT_TYPES = 0x06060606; // [FLOAT, FLOAT, FLOAT, FLOAT]
+layout (constant_id = 1) const uint8_t COLOR_COMPONENT_COUNT = uint8_t(0);
 
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec2Ref { u8vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec2Ref { u16vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
@@ -83,13 +87,23 @@ vec4 getTangent() {
 #if TEXCOORD_COUNT >= 1
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return Vec2Ref(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex).data;
+    uint64_t fetchAddress = mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex;
+
+    switch ((PACKED_TEXCOORD_COMPONENT_TYPES >> (8U * texcoordIndex)) & 0xFFU) {
+    case 1U: // UNSIGNED BYTE
+        return vec2(U8Vec2Ref(fetchAddress).data) / 255.0;
+    case 3U: // UNSIGNED SHORT
+        return vec2(U16Vec2Ref(fetchAddress).data) / 65535.0;
+    case 6U: // FLOAT
+        return Vec2Ref(fetchAddress).data;
+    }
+    return vec2(0.0);
 }
 #endif
 
 #if HAS_COLOR_ATTRIBUTE
 vec4 getColor() {
-    if (COLOR_COMPONENT_COUNT == 4) {
+    if (COLOR_COMPONENT_COUNT == uint8_t(4)) {
         return Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data;
     }
     else {

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -66,24 +66,24 @@ layout (push_constant, std430) uniform PushConstant {
 // Functions.
 // --------------------
 
-vec3 getVec3(uint64_t address){
-    return Vec3Ref(address).data;
+vec3 getPosition() {
+    return Vec3Ref(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex).data;
 }
 
 #if !FRAGMENT_SHADER_GENERATED_TBN
-vec4 getVec4(uint64_t address){
-    return Vec4Ref(address).data;
+vec3 getNormal() {
+    return Vec3Ref(PRIMITIVE.pNormalBuffer + int(PRIMITIVE.normalByteStride) * gl_VertexIndex).data;
+}
+
+vec4 getTangent() {
+    return Vec4Ref(PRIMITIVE.pTangentBuffer + int(PRIMITIVE.tangentByteStride) * gl_VertexIndex).data;
 }
 #endif
 
 #if TEXCOORD_COUNT >= 1
-vec2 getVec2(uint64_t address){
-    return Vec2Ref(address).data;
-}
-
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return getVec2(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex);
+    return Vec2Ref(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex).data;
 }
 #endif
 
@@ -99,17 +99,17 @@ vec4 getColor() {
 #endif
 
 void main(){
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getPosition();
     outPosition = (TRANSFORM * vec4(inPosition, 1.0)).xyz;
 
     outMaterialIndex = MATERIAL_INDEX;
 
 #if !FRAGMENT_SHADER_GENERATED_TBN
-    vec3 inNormal = getVec3(PRIMITIVE.pNormalBuffer + int(PRIMITIVE.normalByteStride) * gl_VertexIndex);
+    vec3 inNormal = getNormal();
     variadic_out.tbn[2] = normalize(mat3(TRANSFORM) * inNormal); // N
 
     if (int(MATERIAL.normalTextureIndex) != -1){
-        vec4 inTangent = getVec4(PRIMITIVE.pTangentBuffer + int(PRIMITIVE.tangentByteStride) * gl_VertexIndex);
+        vec4 inTangent = getTangent();
         variadic_out.tbn[0] = normalize(mat3(TRANSFORM) * inTangent.xyz); // T
         variadic_out.tbn[1] = cross(variadic_out.tbn[2], variadic_out.tbn[0]) * -inTangent.w; // B
     }

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -16,9 +16,14 @@
 
 layout (constant_id = 0) const uint PACKED_TEXCOORD_COMPONENT_TYPES = 0x06060606; // [FLOAT, FLOAT, FLOAT, FLOAT]
 layout (constant_id = 1) const uint8_t COLOR_COMPONENT_COUNT = uint8_t(0);
+layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 5126; // FLOAT
 
 layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec2Ref { u8vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec3Ref { u8vec3 data; };
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec4Ref { u8vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec2Ref { u16vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec3Ref { u16vec3 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec4Ref { u16vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
@@ -104,11 +109,26 @@ vec2 getTexcoord(uint texcoordIndex){
 #if HAS_COLOR_ATTRIBUTE
 vec4 getColor() {
     if (COLOR_COMPONENT_COUNT == uint8_t(4)) {
-        return Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data;
+        switch (COLOR_COMPONENT_TYPE) {
+        case 5121U: // UNSIGNED BYTE
+            return vec4(U8Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data) / 255.0;
+        case 5123U: // UNSIGNED SHORT
+            return vec4(U16Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data) / 65535.0;
+        case 5126U: // FLOAT
+            return Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data;
+        }
     }
     else {
-        return vec4(Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data, 1.0);
+        switch (COLOR_COMPONENT_TYPE) {
+        case 5121U: // UNSIGNED BYTE
+            return vec4(vec3(U8Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data) / 255.0, 1.0);
+        case 5123U: // UNSIGNED SHORT
+            return vec4(vec3(U16Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data) / 65535.0, 1.0);
+        case 5126U: // FLOAT
+            return vec4(Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data, 1.0);
+        }
     }
+    return vec4(1.0);
 }
 #endif
 

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -16,9 +16,14 @@
 
 layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 5126; // FLOAT
 layout (constant_id = 1) const uint8_t COLOR_COMPONENT_COUNT = uint8_t(0);
+layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 5126; // FLOAT
 
 layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec2Ref { u8vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec3Ref { u8vec3 data; };
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec4Ref { u8vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec2Ref { u16vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec3Ref { u16vec3 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec4Ref { u16vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
@@ -81,11 +86,26 @@ vec2 getTexcoord(uint texcoordIndex){
 #if HAS_COLOR_ATTRIBUTE
 vec4 getColor() {
     if (COLOR_COMPONENT_COUNT == uint8_t(4)) {
-        return Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data;
+        switch (COLOR_COMPONENT_TYPE) {
+        case 5121U: // UNSIGNED BYTE
+            return vec4(U8Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data) / 255.0;
+        case 5123U: // UNSIGNED SHORT
+            return vec4(U16Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data) / 65535.0;
+        case 5126U: // FLOAT
+            return Vec4Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data;
+        }
     }
     else {
-        return vec4(Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data, 1.0);
+        switch (COLOR_COMPONENT_TYPE) {
+        case 5121U: // UNSIGNED BYTE
+            return vec4(vec3(U8Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data) / 255.0, 1.0);
+        case 5123U: // UNSIGNED SHORT
+            return vec4(vec3(U16Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data) / 65535.0, 1.0);
+        case 5126U: // FLOAT
+            return vec4(Vec3Ref(PRIMITIVE.pColorBuffer + int(PRIMITIVE.colorByteStride) * gl_VertexIndex).data, 1.0);
+        }
     }
+    return vec4(1.0);
 }
 #endif
 

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -53,18 +53,14 @@ layout (push_constant, std430) uniform PushConstant {
 // Functions.
 // --------------------
 
-vec3 getVec3(uint64_t address){
-    return Vec3Ref(address).data;
+vec3 getPosition() {
+    return Vec3Ref(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex).data;
 }
 
 #if HAS_BASE_COLOR_TEXTURE
-vec2 getVec2(uint64_t address){
-    return Vec2Ref(address).data;
-}
-
 vec2 getTexcoord(uint texcoordIndex){
     IndexedAttributeMappingInfo mappingInfo = PRIMITIVE.texcoordAttributeMappingInfos.data[texcoordIndex];
-    return getVec2(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex);
+    return Vec2Ref(mappingInfo.bytesPtr + int(mappingInfo.stride) * gl_VertexIndex).data;
 }
 #endif
 
@@ -80,7 +76,7 @@ vec4 getColor() {
 #endif
 
 void main(){
-    vec3 inPosition = getVec3(PRIMITIVE.pPositionBuffer + int(PRIMITIVE.positionByteStride) * gl_VertexIndex);
+    vec3 inPosition = getPosition();
 
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE


### PR DESCRIPTION
Added support for `TEXCOORD_<i>` and `COLOR_0` of various accessor types (`UNSIGNED_BYTE`, `UNSIGNED_SHORT` and `FLOAT`). Accessor's native type is used for vertex pulling and type conversion is done in the vertex shader.

*glTF-Asset-Generator* repository's [Mesh_PrimitiveAttribute](https://github.com/KhronosGroup/glTF-Asset-Generator/tree/main/Output/Positive/Mesh_PrimitiveAttribute) and [Mesh_PrimitiveVertexColor](https://github.com/KhronosGroup/glTF-Asset-Generator/tree/main/Output/Positive/Mesh_PrimitiveVertexColor) are used for the conformance test and all succeeded.