### PR TITLE
Implemented KHR_texture_transform extension.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/sampler/BrdfLutSampler.cppm
         interface/vulkan/sampler/CubemapSampler.cppm
         interface/vulkan/sampler/SingleTexelSampler.cppm
+        interface/vulkan/shader_type/TextureTransform.cppm
         interface/vulkan/SharedData.cppm
         interface/vulkan/specialization_constants/SpecializationMap.cppm
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/sampler/CubemapSampler.cppm
         interface/vulkan/sampler/SingleTexelSampler.cppm
         interface/vulkan/SharedData.cppm
+        interface/vulkan/specialization_constants/SpecializationMap.cppm
 )
 target_link_libraries(vk-gltf-viewer PRIVATE
     Boost::container

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ target_sources(vk-gltf-viewer PRIVATE
         extlibs/module-ports/imgui/imgui.internal.cppm
         extlibs/module-ports/imgui/imgui.vulkan.cppm
         extlibs/module-ports/ImGuizmo.cppm
+        extlibs/reflect.cppm
         interface/mod.cppm
         interface/AppState.cppm
         interface/control/AppWindow.cppm

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Blazingly fast[^1] Vulkan glTF viewer.
   - [`KHR_materials_unlit`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_unlit) for lighting independent material shading
   - [`KHR_materials_variants`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_variants)
   - [`KHR_texture_basisu`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_basisu) for BC7 GPU compression texture decoding
+  - [`KHR_texture_transform`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform)
   - [`EXT_mesh_gpu_instancing`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing) for instancing multiple meshes with the same geometry
 - Use 4x MSAA by default.
 - Support HDR and EXR skybox.

--- a/extlibs/reflect.cppm
+++ b/extlibs/reflect.cppm
@@ -1,0 +1,1307 @@
+// <!--
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Kris Jusiak <kris@jusiak.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+export module reflect;
+
+import std;
+
+#ifndef REFLECT_ENUM_MIN
+#define REFLECT_ENUM_MIN 0
+#endif
+
+#ifndef REFLECT_ENUM_MAX
+#define REFLECT_ENUM_MAX 128
+#endif
+
+namespace {
+template<bool Cond> struct REFLECT_FWD_LIKE { template<class T> using type = std::remove_reference_t<T>&&; };
+template<> struct REFLECT_FWD_LIKE<true> { template<class T> using type = std::remove_reference_t<T>&; };
+} // to speed up compilation times
+
+#define REFLECT_FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+#define REFLECT_FWD_LIKE(T, ...) static_cast<typename ::REFLECT_FWD_LIKE<::std::is_lvalue_reference_v<T>>::template type<decltype(__VA_ARGS__)>>(__VA_ARGS__)
+struct  REFLECT_STRUCT { void* MEMBER; enum class ENUM { VALUE }; }; // has to be in the global namespace
+
+namespace reflect::inline v1_2_4 {
+namespace detail {
+template<class T> extern const T ext{};
+struct any { template<class T> operator T() const noexcept; };
+template<class T> struct any_except_base_of { template<class U> requires (not std::is_base_of_v<U, T>) operator U() const noexcept; };
+template<auto...> struct auto_ { constexpr explicit(false) auto_(auto&&...) noexcept { } };
+template<class T> struct ref { T& ref_; };
+template<class T> ref(T&) -> ref<T>;
+
+template<std::size_t N>
+constexpr auto nth_pack_element_impl = []<auto... Ns>(std::index_sequence<Ns...>) -> decltype(auto) {
+  return [](auto_<Ns>&&..., auto&& nth, auto&&...) -> decltype(auto) { return REFLECT_FWD(nth); };
+}(std::make_index_sequence<N>{});
+
+template<std::size_t N, class...Ts> requires (N < sizeof...(Ts))
+[[nodiscard]] constexpr decltype(auto) nth_pack_element(Ts&&...args) noexcept {
+  return nth_pack_element_impl<N>(REFLECT_FWD(args)...);
+}
+
+template<auto...  Vs> [[nodiscard]] constexpr auto function_name() noexcept -> std::string_view { return std::source_location::current().function_name(); }
+template<class... Ts> [[nodiscard]] constexpr auto function_name() noexcept -> std::string_view { return std::source_location::current().function_name(); }
+
+template<class T>
+struct type_name_info {
+  static constexpr auto name = function_name<int>();
+  static constexpr auto begin = name.find("int");
+  static constexpr auto end = name.substr(begin+std::size(std::string_view{"int"}));
+};
+
+template<class T> requires std::is_class_v<T>
+struct type_name_info<T> {
+  static constexpr auto name = function_name<REFLECT_STRUCT>();
+  static constexpr auto begin = name.find("REFLECT_STRUCT");
+  static constexpr auto end = name.substr(begin+std::size(std::string_view{"REFLECT_STRUCT"}));
+};
+
+template<class T> requires std::is_enum_v<T>
+struct type_name_info<T> {
+  static constexpr auto name = function_name<REFLECT_STRUCT::ENUM>();
+  static constexpr auto begin = name.find("REFLECT_STRUCT::ENUM");
+  static constexpr auto end = name.substr(begin+std::size(std::string_view{"REFLECT_STRUCT::ENUM"}));
+};
+
+struct enum_name_info {
+  static constexpr auto name = function_name<REFLECT_STRUCT::ENUM::VALUE>();
+  static constexpr auto begin = name.find("REFLECT_STRUCT::ENUM::VALUE");
+  static constexpr auto end = std::size(name)-(name.find("REFLECT_STRUCT::ENUM::VALUE")+std::size(std::string_view{"REFLECT_STRUCT::ENUM::VALUE"}));
+};
+
+struct member_name_info {
+  static constexpr auto name = function_name<ref{ext<REFLECT_STRUCT>.MEMBER}>();
+  static constexpr auto begin = name[name.find("MEMBER")-1];
+  static constexpr auto end = name.substr(name.find("MEMBER")+std::size(std::string_view{"MEMBER"}));
+};
+}  // namespace detail
+
+template<class T, std::size_t Size>
+struct fixed_string {
+  constexpr explicit(false) fixed_string(const T* str) {
+    for (decltype(Size) i{}; i < Size; ++i) { data[i] = str[i]; }
+    data[Size] = T();
+  }
+  [[nodiscard]] constexpr auto operator<=>(const fixed_string&) const = default;
+  [[nodiscard]] constexpr explicit(false) operator std::string_view() const { return {std::data(data), Size}; }
+  [[nodiscard]] constexpr auto size() const { return Size; }
+  T data[Size + 1u];
+};
+template<class T, std::size_t Capacity, std::size_t Size = Capacity-1> fixed_string(const T (&str)[Capacity]) -> fixed_string<T, Size>;
+
+namespace detail {
+template<class T, std::size_t Bases = 0u, class... Ts> requires std::is_aggregate_v<T>
+[[nodiscard]] constexpr auto size() -> std::size_t {
+  if constexpr (requires { T{Ts{}...}; } and not requires { T{Ts{}..., detail::any{}}; }) {
+    return sizeof...(Ts) - Bases;
+  } else if constexpr (Bases == sizeof...(Ts) and requires { T{Ts{}...}; } and not requires { T{Ts{}..., detail::any_except_base_of<T>{}}; }) {
+    return size<T, Bases + 1u, Ts..., detail::any>();
+  } else {
+    return size<T, Bases, Ts..., detail::any>();
+  }
+}
+} // namespace detail
+
+export template<class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr auto size() -> std::size_t {
+  return detail::size<std::remove_cvref_t<T>>();
+}
+
+export template<class T> requires std::is_aggregate_v<T>
+[[nodiscard]] constexpr auto size(const T&) -> std::size_t {
+  return detail::size<T>();
+}
+
+namespace detail {
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&&,   std::integral_constant<std::size_t, 0>) noexcept { return REFLECT_FWD(fn)(); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 1>) noexcept { auto&& [_1] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 2>) noexcept { auto&& [_1, _2] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 3>) noexcept { auto&& [_1, _2, _3] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 4>) noexcept { auto&& [_1, _2, _3, _4] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 5>) noexcept { auto&& [_1, _2, _3, _4, _5] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 6>) noexcept { auto&& [_1, _2, _3, _4, _5, _6] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 7>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 8>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 9>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 10>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 11>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 12>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 13>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 14>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 15>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 16>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 17>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 18>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 19>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 20>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 21>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 22>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 23>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 24>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 25>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 26>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 27>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 28>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 29>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 30>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 31>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 32>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 33>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 34>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 35>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 36>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 37>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 38>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 39>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 40>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 41>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 42>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 43>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 44>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 45>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 46>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 47>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 48>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 49>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 50>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 51>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 52>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 53>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 54>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 55>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 56>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55), REFLECT_FWD_LIKE(T, _56)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 57>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55), REFLECT_FWD_LIKE(T, _56), REFLECT_FWD_LIKE(T, _57)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 58>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55), REFLECT_FWD_LIKE(T, _56), REFLECT_FWD_LIKE(T, _57), REFLECT_FWD_LIKE(T, _58)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 59>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55), REFLECT_FWD_LIKE(T, _56), REFLECT_FWD_LIKE(T, _57), REFLECT_FWD_LIKE(T, _58), REFLECT_FWD_LIKE(T, _59)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 60>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55), REFLECT_FWD_LIKE(T, _56), REFLECT_FWD_LIKE(T, _57), REFLECT_FWD_LIKE(T, _58), REFLECT_FWD_LIKE(T, _59), REFLECT_FWD_LIKE(T, _60)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 61>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55), REFLECT_FWD_LIKE(T, _56), REFLECT_FWD_LIKE(T, _57), REFLECT_FWD_LIKE(T, _58), REFLECT_FWD_LIKE(T, _59), REFLECT_FWD_LIKE(T, _60), REFLECT_FWD_LIKE(T, _61)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 62>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55), REFLECT_FWD_LIKE(T, _56), REFLECT_FWD_LIKE(T, _57), REFLECT_FWD_LIKE(T, _58), REFLECT_FWD_LIKE(T, _59), REFLECT_FWD_LIKE(T, _60), REFLECT_FWD_LIKE(T, _61), REFLECT_FWD_LIKE(T, _62)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 63>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55), REFLECT_FWD_LIKE(T, _56), REFLECT_FWD_LIKE(T, _57), REFLECT_FWD_LIKE(T, _58), REFLECT_FWD_LIKE(T, _59), REFLECT_FWD_LIKE(T, _60), REFLECT_FWD_LIKE(T, _61), REFLECT_FWD_LIKE(T, _62), REFLECT_FWD_LIKE(T, _63)); }
+template<class Fn, class T> [[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, std::integral_constant<std::size_t, 64>) noexcept { auto&& [_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63, _64] = REFLECT_FWD(t); return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, _1), REFLECT_FWD_LIKE(T, _2), REFLECT_FWD_LIKE(T, _3), REFLECT_FWD_LIKE(T, _4), REFLECT_FWD_LIKE(T, _5), REFLECT_FWD_LIKE(T, _6), REFLECT_FWD_LIKE(T, _7), REFLECT_FWD_LIKE(T, _8), REFLECT_FWD_LIKE(T, _9), REFLECT_FWD_LIKE(T, _10), REFLECT_FWD_LIKE(T, _11), REFLECT_FWD_LIKE(T, _12), REFLECT_FWD_LIKE(T, _13), REFLECT_FWD_LIKE(T, _14), REFLECT_FWD_LIKE(T, _15), REFLECT_FWD_LIKE(T, _16), REFLECT_FWD_LIKE(T, _17), REFLECT_FWD_LIKE(T, _18), REFLECT_FWD_LIKE(T, _19), REFLECT_FWD_LIKE(T, _20), REFLECT_FWD_LIKE(T, _21), REFLECT_FWD_LIKE(T, _22), REFLECT_FWD_LIKE(T, _23), REFLECT_FWD_LIKE(T, _24), REFLECT_FWD_LIKE(T, _25), REFLECT_FWD_LIKE(T, _26), REFLECT_FWD_LIKE(T, _27), REFLECT_FWD_LIKE(T, _28), REFLECT_FWD_LIKE(T, _29), REFLECT_FWD_LIKE(T, _30), REFLECT_FWD_LIKE(T, _31), REFLECT_FWD_LIKE(T, _32), REFLECT_FWD_LIKE(T, _33), REFLECT_FWD_LIKE(T, _34), REFLECT_FWD_LIKE(T, _35), REFLECT_FWD_LIKE(T, _36), REFLECT_FWD_LIKE(T, _37), REFLECT_FWD_LIKE(T, _38), REFLECT_FWD_LIKE(T, _39), REFLECT_FWD_LIKE(T, _40), REFLECT_FWD_LIKE(T, _41), REFLECT_FWD_LIKE(T, _42), REFLECT_FWD_LIKE(T, _43), REFLECT_FWD_LIKE(T, _44), REFLECT_FWD_LIKE(T, _45), REFLECT_FWD_LIKE(T, _46), REFLECT_FWD_LIKE(T, _47), REFLECT_FWD_LIKE(T, _48), REFLECT_FWD_LIKE(T, _49), REFLECT_FWD_LIKE(T, _50), REFLECT_FWD_LIKE(T, _51), REFLECT_FWD_LIKE(T, _52), REFLECT_FWD_LIKE(T, _53), REFLECT_FWD_LIKE(T, _54), REFLECT_FWD_LIKE(T, _55), REFLECT_FWD_LIKE(T, _56), REFLECT_FWD_LIKE(T, _57), REFLECT_FWD_LIKE(T, _58), REFLECT_FWD_LIKE(T, _59), REFLECT_FWD_LIKE(T, _60), REFLECT_FWD_LIKE(T, _61), REFLECT_FWD_LIKE(T, _62), REFLECT_FWD_LIKE(T, _63), REFLECT_FWD_LIKE(T, _64)); }
+} // namespace detail
+
+export template<class Fn, class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr decltype(auto) visit(Fn&& fn, T&& t, auto...) noexcept {
+  #if (__cpp_structured_bindings >= 202601L)
+    auto&& [... ts] = REFLECT_FWD(t);
+    return REFLECT_FWD(fn)(REFLECT_FWD_LIKE(T, ts)...);
+  #else
+    return detail::visit(REFLECT_FWD(fn), REFLECT_FWD(t), std::integral_constant<std::size_t, size<std::remove_cvref_t<T>>()>{});
+  #endif
+}
+
+export template<class T>
+[[nodiscard]] constexpr auto type_name() noexcept -> std::string_view {
+  using type_name_info = detail::type_name_info<std::remove_pointer_t<std::remove_cvref_t<T>>>;
+  constexpr std::string_view function_name = detail::function_name<std::remove_pointer_t<std::remove_cvref_t<T>>>();
+  constexpr std::string_view qualified_type_name = function_name.substr(type_name_info::begin, function_name.find(type_name_info::end)-type_name_info::begin);
+  constexpr std::string_view tmp_type_name = qualified_type_name.substr(0, qualified_type_name.find_first_of("<", 1));
+  constexpr std::string_view type_name = tmp_type_name.substr(tmp_type_name.find_last_of("::")+1);
+  static_assert(std::size(type_name) > 0u);
+  if (std::is_constant_evaluated()) {
+    return type_name;
+  } else {
+    return [&] {
+      static constexpr const auto name = fixed_string<std::remove_cvref_t<decltype(type_name[0])>, std::size(type_name)>{std::data(type_name)};
+      return std::string_view{name};
+    }();
+  }
+}
+
+export template<class T>
+[[nodiscard]] constexpr auto type_name(T&&) noexcept -> std::string_view { return type_name<std::remove_cvref_t<T>>(); }
+
+export template<class E>
+[[nodiscard]] constexpr auto to_underlying(const E e) noexcept {
+  return static_cast<std::underlying_type_t<E>>(e);
+}
+
+namespace detail {
+template<auto V> consteval const auto& data() { return V.data; }
+template<class T, std::size_t Size>
+struct static_vector {
+  constexpr static_vector() = default;
+  constexpr auto push_back(const T& value) { values_[size_++] = value; }
+  [[nodiscard]] constexpr const auto& operator[](auto i) const { return values_[i]; }
+  [[nodiscard]] constexpr auto begin() const { return &values_[0]; }
+  [[nodiscard]] constexpr auto end() const { return &values_[0] + size_; }
+  [[nodiscard]] constexpr auto size() const { return size_; }
+  [[nodiscard]] constexpr auto empty() const { return not size_; }
+  [[nodiscard]] constexpr auto capacity() const { return Size; }
+  std::array<T, Size> values_{};
+  std::size_t size_{};
+};
+template<class E, auto N> requires std::is_enum_v<E>
+[[nodiscard]] constexpr auto enum_name() {
+  constexpr auto fn_name = function_name<static_cast<E>(N)>();
+  constexpr auto name = fn_name.substr(enum_name_info::begin, std::size(fn_name)-enum_name_info::end-enum_name_info::begin);
+  constexpr auto enum_name = name.substr(name.find_last_of("::")+1);
+  static_assert(std::size(enum_name) > 0u);
+  return data<fixed_string<std::remove_cvref_t<decltype(enum_name[0])>, std::size(enum_name)>{std::data(enum_name)}>();
+}
+#if defined(__clang__)
+#if (__clang_major__ > 15) and (__clang_major__ < 19)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
+#endif
+template<class E, auto Min, auto Max> requires (std::is_enum_v<E> and Max > Min)
+inline constexpr auto enum_cases = []<auto... Ns>(std::index_sequence<Ns...>) {
+  static_vector<std::underlying_type_t<E>, sizeof...(Ns)> cases{};
+  ([&] {
+    if constexpr (requires { function_name<static_cast<E>(Ns+Min)>(); }) {
+      const auto fn_name = function_name<static_cast<E>(Ns+Min)>();
+      const auto name = fn_name.substr(enum_name_info::begin, std::size(fn_name)-enum_name_info::end-enum_name_info::begin);
+      const auto enum_name = name.substr(name.find_last_of("::")+1);
+      if (enum_name.find(")") == std::string_view::npos) {
+        cases.push_back(std::underlying_type_t<E>(Ns+Min));
+      }
+    }
+  }(), ...);
+  return cases;
+}(std::make_index_sequence<Max-Min+1/*inclusive*/>{});
+#if (__clang_major__ > 15) and (__clang_major__ < 19)
+  #pragma clang diagnostic pop
+#endif
+#else
+template<class E, auto Min, auto Max> requires (std::is_enum_v<E> and Max > Min)
+inline constexpr auto enum_cases = []<auto... Ns>(std::index_sequence<Ns...>) {
+  const auto names = function_name<static_cast<E>(Ns+Min)...>();
+  const auto begin = enum_name_info::begin;
+  const auto end = std::size(names) - enum_name_info::end;
+  static_vector<std::underlying_type_t<E>, sizeof...(Ns)> cases{};
+  std::underlying_type_t<E> index{};
+  auto valid = true;
+  for (auto i = begin; i < end; ++i) {
+    if (names[i] == '(' and names[i+1] != ')') {
+      valid = false;
+    } else if (names[i] == ' ') {
+      valid = true;
+    } else if (names[i] == ',' or i == end-1) {
+      if (valid) { cases.push_back(index+Min); }
+      ++index;
+      valid = true;
+    }
+  }
+  return cases;
+}(std::make_index_sequence<Max-Min+1/*inclusive*/>{});
+#endif
+} // namespace detail
+
+export template<class E> requires std::is_enum_v<E> consteval auto enum_min(const E) -> int { return REFLECT_ENUM_MIN; }
+export template<class E, class T = std::underlying_type_t<E>> requires std::is_enum_v<E> consteval auto enum_max(const E) -> int {
+  return std::numeric_limits<T>::max() < REFLECT_ENUM_MAX ? std::numeric_limits<T>::max() : REFLECT_ENUM_MAX;
+}
+
+template<class E, int Min = enum_min(E{}), int Max = enum_max(E{}), auto enum_cases = detail::enum_cases<E, Min, Max>>
+inline constexpr auto enumerators = []<auto... Ns>(std::index_sequence<Ns...>) {
+  return std::array{std::pair{enum_cases[Ns], detail::enum_name<E, enum_cases[Ns]>()}...};
+}(std::make_index_sequence<enum_cases.size()>{});
+
+export template<class E, fixed_string unknown = "", auto Min = enum_min(E{}), auto Max = enum_max(E{})>
+  requires (std::is_enum_v<E> and Max > Min)
+[[nodiscard]] constexpr auto enum_name(const E e) noexcept -> std::string_view {
+  if constexpr (constexpr auto cases = enumerators<E, Min, Max>; std::empty(cases)) {
+    return unknown;
+  } else {
+    const auto switch_case = [&]<std::size_t I = 0u>(auto switch_case, const auto value) -> std::string_view {
+      if constexpr (I == std::size(cases)) {
+        return unknown;
+      } else {
+        switch (value) {
+          default:             return switch_case.template operator()<I + 1u>(switch_case, value);
+          case cases[I].first: return cases[I].second;
+        }
+      }
+    };
+    return switch_case(switch_case, to_underlying(e));
+  }
+}
+
+export template<class T>
+[[nodiscard]] constexpr auto type_id() -> std::size_t {
+  std::size_t result{};
+  for (const auto c : type_name<T>()) { (result ^= c) <<= 1; }
+  return result;
+}
+
+export template<class T>
+[[nodiscard]] constexpr auto type_id(const T&) noexcept -> std::size_t { return type_id<T>(); }
+
+export template<std::size_t N, class T> requires (std::is_aggregate_v<std::remove_cvref_t<T>> and N < size<T>())
+[[nodiscard]] constexpr auto member_name() noexcept -> std::string_view {
+  constexpr std::string_view function_name = detail::function_name<visit([](auto&&... args) { return detail::ref{detail::nth_pack_element<N>(REFLECT_FWD(args)...)}; }, detail::ext<std::remove_cvref_t<T>>)>();
+  constexpr std::string_view tmp_member_name = function_name.substr(0, function_name.find(detail::member_name_info::end));
+  constexpr std::string_view member_name = tmp_member_name.substr(tmp_member_name.find_last_of(detail::member_name_info::begin)+1);
+  static_assert(std::size(member_name) > 0u);
+  if (std::is_constant_evaluated()) {
+    return member_name;
+  } else {
+    return [&] {
+      static constexpr const auto name = fixed_string<std::remove_cvref_t<decltype(member_name[0])>, std::size(member_name)>{std::data(member_name)};
+      return std::string_view{name};
+    }();
+  }
+}
+
+export template<std::size_t N, class T> requires (std::is_aggregate_v<T> and N < size<T>())
+[[nodiscard]] constexpr auto member_name(const T&) noexcept -> std::string_view {
+  return member_name<N, T>();
+}
+
+export template<std::size_t N, class T> requires (std::is_aggregate_v<std::remove_cvref_t<T>> and N < size<std::remove_cvref_t<T>>())
+[[nodiscard]] constexpr decltype(auto) get(T&& t) noexcept {
+  return visit([](auto&&... args) -> decltype(auto) { return detail::nth_pack_element<N>(REFLECT_FWD(args)...); }, REFLECT_FWD(t));
+}
+
+template<std::size_t N, class T> requires (std::is_aggregate_v<T> and N < size<T>())
+using member_type = std::remove_cvref_t<decltype(reflect::get<N>(std::declval<T&&>()))>;
+
+namespace detail {
+template<class T, auto Name>
+inline constexpr bool has_member_name_impl = []<auto... Ns>(std::index_sequence<Ns...>) {
+  return ((Name == member_name<Ns, T>()) or ...);
+}(std::make_index_sequence<size<T>()>{});
+
+template<class T, fixed_string Name>
+[[nodiscard]] consteval auto diagnose_member_name() {
+  constexpr std::string_view prefix = "`";
+  constexpr std::string_view type = type_name<T>();
+  if constexpr (size<T>()) {
+    constexpr std::string_view infix1 = "` has no data member named `";
+    constexpr std::string_view incorrect = Name;
+    constexpr std::string_view infix2 = "`. Did you mean `";
+    constexpr std::string_view correct = [] {
+      constexpr auto distance = [](std::string_view correct) {
+        constexpr std::string_view incorrect = Name;
+        std::array<std::size_t, incorrect.size() + 1> prev;
+        std::array<std::size_t, incorrect.size() + 1> curr{};
+        for (decltype(prev.size()) i{}; i < prev.size(); ++i) prev[i] = i;
+        for (decltype(correct.size()) i{}; i < correct.size(); ++i) {
+          curr[0] = i + 1;
+          for (decltype(incorrect.size()) j{}; j < incorrect.size(); ++j) {
+            const auto del = prev[j + 1] + 1;
+            const auto ins = curr[j] + 1;
+            const auto sub = prev[j] + (correct[i] != incorrect[j]);
+            const auto min_del_ins = del < ins ? del : ins;
+            curr[j + 1] = min_del_ins < sub ? min_del_ins : sub;
+          }
+          auto temp = curr;
+          curr = prev;
+          prev = temp;
+        }
+        return prev.back();
+      };
+      const auto member_names = []<auto... Ns>(std::index_sequence<Ns...>) {
+        return std::array<std::string_view, sizeof...(Ns)>{member_name<Ns, T>()...};
+      }(std::make_index_sequence<size<T>()>{});
+      auto closest_name = member_names[0];
+      auto min_distance = distance(closest_name);
+      for (decltype(member_names.size()) n{1}; n < member_names.size(); ++n) {
+        const auto nth_member_name = member_names[n];
+        const auto nth_distance = distance(nth_member_name);
+        if (nth_distance < min_distance) {
+          closest_name = nth_member_name;
+          min_distance = nth_distance;
+        }
+      }
+      return closest_name;
+    }();
+    constexpr std::string_view suffix = "`?";
+    char message[prefix.size() + type.size() + infix1.size() + incorrect.size() + infix2.size() + correct.size() + suffix.size() + 1];
+    auto out = message;
+    for (const auto c : prefix) *out++ = c;
+    for (const auto c : type) *out++ = c;
+    for (const auto c : infix1) *out++ = c;
+    for (const auto c : incorrect) *out++ = c;
+    for (const auto c : infix2) *out++ = c;
+    for (const auto c : correct) *out++ = c;
+    for (const auto c : suffix) *out++ = c;
+    *out = '\0';
+    return fixed_string{message};
+  } else {
+    constexpr std::string_view suffix = "` has no data members.";
+    char message[prefix.size() + type.size() + suffix.size() + 1];
+    auto out = message;
+    for (const auto c : prefix) *out++ = c;
+    for (const auto c : type) *out++ = c;
+    for (const auto c : suffix) *out++ = c;
+    *out = '\0';
+    return fixed_string{message};
+  }
+}
+
+template<auto Message>
+struct print { static constexpr auto value = false; };
+template<class TMessage>
+concept diagnosis = TMessage::value;
+template<class T, auto Name>
+concept member_name_diagnosis = diagnosis<print<diagnose_member_name<T, Name>()>>;
+} // namespace detail
+
+export template<class T, fixed_string Name>
+concept has_member_name = detail::has_member_name_impl<std::remove_cvref_t<T>, Name> or detail::member_name_diagnosis<std::remove_cvref_t<T>, Name>;
+
+export template<fixed_string Name, class T>
+  requires (std::is_aggregate_v<std::remove_cvref_t<T>> and has_member_name<std::remove_cvref_t<T>, Name>)
+constexpr decltype(auto) get(T&& t) noexcept {
+  return visit([](auto&&... args) -> decltype(auto) {
+    constexpr auto index = []<auto... Ns>(std::index_sequence<Ns...>){
+      return (((std::string_view{Name} == member_name<Ns, std::remove_cvref_t<T>>()) ? Ns : decltype(Ns){}) + ...);
+    }(std::make_index_sequence<size<std::remove_cvref_t<T>>()>{});
+    return detail::nth_pack_element<index>(REFLECT_FWD(args)...);
+  }, REFLECT_FWD(t));
+}
+
+export template<template<class...> class R, class T>
+  requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr auto to(T&& t) noexcept {
+   if constexpr (std::is_lvalue_reference_v<decltype(t)>) {
+    return visit([](auto&&... args) { return R<decltype(REFLECT_FWD(args))...>{REFLECT_FWD(args)...}; }, t);
+  } else {
+    return visit([](auto&&... args) { return R{REFLECT_FWD(args)...}; }, t);
+  }
+}
+
+export template<fixed_string... Members, class TSrc, class TDst>
+  requires (std::is_aggregate_v<TSrc> and std::is_aggregate_v<TDst>)
+constexpr auto copy(const TSrc& src, TDst& dst) noexcept -> void {
+  constexpr auto contains = []([[maybe_unused]] const auto name) {
+    return sizeof...(Members) == 0u or ((name == std::string_view{Members}) or ...);
+  };
+  auto dst_view = to<std::tuple>(dst);
+  [&]<auto... Ns>(std::index_sequence<Ns...>) {
+    ([&] {
+      if constexpr (contains(member_name<Ns, TDst>()) and requires { std::get<Ns>(dst_view) = get<fixed_string<std::remove_cvref_t<decltype(member_name<Ns, TDst>()[0])>, std::size(member_name<Ns, TDst>())>(std::data(member_name<Ns, TDst>()))>(src); }) {
+        std::get<Ns>(dst_view) = get<fixed_string<std::remove_cvref_t<decltype(member_name<Ns, TDst>()[0])>, std::size(member_name<Ns, TDst>())>(std::data(member_name<Ns, TDst>()))>(src);
+      }
+    }(), ...);
+  }(std::make_index_sequence<size<TDst>()>{});
+}
+
+export template<class R, class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr auto to(T&& t) noexcept {
+  R r{};
+  copy(REFLECT_FWD(t), r);
+  return r;
+}
+
+export template<std::size_t N, class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr auto size_of() -> std::size_t {
+  return sizeof(std::remove_cvref_t<decltype(get<N>(detail::ext<T>))>);
+}
+
+export template<std::size_t N, class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr auto size_of(T&&) -> std::size_t {
+  return size_of<N, std::remove_cvref_t<T>>();
+}
+
+export template<std::size_t N, class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr auto align_of() -> std::size_t {
+  return alignof(std::remove_cvref_t<decltype(get<N>(detail::ext<T>))>);
+}
+
+export template<std::size_t N, class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr auto align_of(T&&) -> std::size_t {
+  return align_of<N, std::remove_cvref_t<T>>();
+}
+
+export template<std::size_t N, class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr auto offset_of() -> std::size_t {
+  if constexpr (not N) {
+    return {};
+  } else {
+    constexpr auto offset = offset_of<N-1, T>() + size_of<N-1, T>();
+    constexpr auto alignment = std::min(alignof(T), align_of<N, T>());
+    constexpr auto padding = offset % alignment;
+    return offset + padding;
+  }
+}
+
+export template<std::size_t N, class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+[[nodiscard]] constexpr auto offset_of(T&&) -> std::size_t {
+  return offset_of<N, std::remove_cvref_t<T>>();
+}
+
+export template<class T, class Fn> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+constexpr auto for_each(Fn&& fn) -> void {
+  [&]<auto... Ns>(std::index_sequence<Ns...>) {
+    (REFLECT_FWD(fn)(std::integral_constant<decltype(Ns), Ns>{}), ...);
+  }(std::make_index_sequence<reflect::size<std::remove_cvref_t<T>>()>{});
+}
+
+export template<class Fn, class T> requires std::is_aggregate_v<std::remove_cvref_t<T>>
+constexpr auto for_each(Fn&& fn, T&&) -> void {
+  [&]<auto... Ns>(std::index_sequence<Ns...>) {
+    (REFLECT_FWD(fn)(std::integral_constant<decltype(Ns), Ns>{}), ...);
+  }(std::make_index_sequence<reflect::size<std::remove_cvref_t<T>>()>{});
+}
+} // namespace reflect
+#undef REFLECT_FWD_LIKE
+#undef REFLECT_FWD
+
+#ifndef NTEST
+namespace reflect::test {
+struct empty { };
+struct foo { using type = int; enum E { }; };
+template<class T> struct optional {
+  constexpr optional() = default;
+  constexpr optional(T t) : t{t} { }
+  T t{};
+};
+struct bar { };
+template<class T> struct foo_t { };
+namespace ns::inline v1 { template<auto...> struct bar_v { }; } // ns
+enum e {
+  _141 = 141,
+  _142 = 142,
+};
+enum e1 { e1a };
+enum class e2 : std::uint8_t { e2a, e2b };
+enum e3 { e3a, e3b, e3c, };
+enum class e4 : std::int32_t { e4a, e4b = 5, e4c, e4d = 2, };
+consteval auto enum_min(e) { return e::_141; }
+consteval auto enum_max(e) { return e::_142; }
+void failed();
+inline constexpr auto expect = [](bool cond) { if (not cond) { failed(); } };
+} // reflect::test
+
+static_assert(([] {
+  using namespace reflect;
+  using test::expect;
+
+  // nth_pack_element
+  {
+    using reflect::detail::nth_pack_element;
+
+    static_assert(1 == nth_pack_element<0>(1));
+    static_assert(1 == nth_pack_element<0>(1, 2));
+    static_assert(2 == nth_pack_element<1>(1, 2));
+    static_assert('a' == nth_pack_element<0>('a', 1, true));
+    static_assert(1 == nth_pack_element<1>('a', 1, true));
+    static_assert(true == nth_pack_element<2>('a', 1, true));
+
+    {
+      [[maybe_unused]] int a{};
+      static_assert(std::is_same_v<int&, decltype(nth_pack_element<0>(a))>);
+    }
+
+    {
+      [[maybe_unused]] const int a{};
+      static_assert(std::is_same_v<const int&, decltype(nth_pack_element<0>(a))>);
+    }
+
+    {
+      [[maybe_unused]] int a{};
+      static_assert(std::is_same_v<int&&, decltype(nth_pack_element<0>(static_cast<int&&>(a)))>);
+    }
+
+    {
+      [[maybe_unused]] const int a{};
+      static_assert(std::is_same_v<const int&&, decltype(nth_pack_element<0>(static_cast<const int&&>(a)))>);
+    }
+  }
+
+  // fixed_string
+  {
+    static_assert(0u == std::size(fixed_string{""}));
+    static_assert(fixed_string{""} == fixed_string{""});
+    static_assert(std::string_view{""} == std::string_view{fixed_string{""}});
+    static_assert(3u == std::size(fixed_string{"foo"}));
+    static_assert(std::string_view{"foo"} == std::string_view{fixed_string{"foo"}});
+    static_assert(fixed_string{"foo"} == fixed_string{"foo"});
+  }
+
+  // size
+  {
+    struct empty {};
+    struct one { int a; };
+    struct two { int a; reflect::test::optional<int> o; };
+    struct empty_with_base : empty {};
+    struct one_with_base : empty { int a; };
+    struct two_with_base : empty { int a; reflect::test::optional<int> o; };
+    struct base {};
+    struct empty_with_bases : empty, base {};
+    struct one_with_bases : empty, base { int a; };
+    struct two_with_bases : empty, base { int a; reflect::test::optional<int> o; };
+    struct two_with_base_member : empty, base { int a; base b; };
+
+    static_assert(0 == size<empty>());
+    static_assert(0 == size(empty{}));
+    static_assert(1 == size<one>());
+    static_assert(1 == size(one{}));
+    static_assert(2 == size<two>());
+    static_assert(2 == size(two{}));
+    static_assert(0 == size<empty_with_base>());
+    static_assert(0 == size(empty_with_base{}));
+    static_assert(1 == size<one_with_base>());
+    static_assert(1 == size(one_with_base{}));
+    static_assert(2 == size<two_with_base>());
+    static_assert(2 == size(two_with_base{}));
+    static_assert(0 == size<empty_with_bases>());
+    static_assert(0 == size(empty_with_bases{}));
+    static_assert(1 == size<one_with_bases>());
+    static_assert(1 == size(one_with_bases{}));
+    static_assert(2 == size<two_with_bases>());
+    static_assert(2 == size(two_with_bases{}));
+    static_assert(2 == size<two_with_base_member>());
+    static_assert(2 == size(two_with_base_member{}));
+    static_assert(0 == size<const empty>());
+    static_assert(1 == size<const one>());
+    static_assert(2 == size<const two>());
+    static_assert(0 == size<const empty_with_base>());
+    static_assert(1 == size<const one_with_base>());
+    static_assert(2 == size<const two_with_base>());
+    static_assert(0 == size<const empty_with_bases>());
+    static_assert(1 == size<const one_with_bases>());
+    static_assert(2 == size<const two_with_bases>());
+    static_assert(2 == size<const two_with_base_member>());
+
+    struct non_standard_layout {
+     private:
+        int _1{};
+     public:
+        int _2{};
+    };
+
+    struct S {
+      double _1;
+      non_standard_layout _2;
+      float _3;
+    };
+
+    static_assert(3 == size<S>());
+
+    constexpr auto test = []<class T> {
+      struct S { T _1; T _2; int _3; T _4; };
+      struct S5_0 { int _1; int _2; int _3; int _4; T _5; };
+      struct S5_1 { T _1; int _2; int _3; int _4; int _5; };
+      struct S5_2 { int _1; int _2; T _3; int _4; int _5; };
+      struct S5_3 { int _1; int _2; T _3; int _4; T _5; };
+      struct S5_4 { T _1; T _2; T _3; T _4; T _5; };
+      struct S6 { T _1; T _2; T _3; T _4; T _5;  T _6;};
+
+      static_assert(4 == size<S>());
+      static_assert(5 == size<S5_0>());
+      static_assert(5 == size<S5_1>());
+      static_assert(5 == size<S5_2>());
+      static_assert(5 == size<S5_3>());
+      static_assert(5 == size<S5_4>());
+      static_assert(6 == size<S6>());
+    };
+
+    {
+      struct T {
+        T() = default;
+        T(T&&) = default;
+        T(const T&) = delete;
+        T& operator=(T&&) = default;
+        T& operator=(const T&) = delete;
+      };
+      test.template operator()<T>();
+    }
+
+    {
+      struct T {
+        T() = default;
+        T(T&&) = default;
+        T(const T&) = delete;
+        T& operator=(T&&) = default;
+        T& operator=(const T&) = delete;
+      };
+      test.template operator()<T>();
+    }
+
+    {
+      struct T {
+        T(T&&) = default;
+        T(const T&) = delete;
+        T& operator=(T&&) = default;
+        T& operator=(const T&) = delete;
+      };
+      test.template operator()<T>();
+    }
+
+    {
+      struct T { T(int) { } };
+      test.template operator()<T>();
+    }
+
+    struct bf {
+      unsigned int _1: 1;
+      unsigned int _2: 1;
+      unsigned int _3: 1;
+      unsigned int _4: 1;
+      unsigned int _5: 1;
+      unsigned int _6: 1;
+    };
+
+    static_assert(6 == size<bf>());
+
+    struct {
+      int _1;
+      int _2;
+    } anonymous;
+
+    static_assert(2 == size(anonymous));
+  }
+
+  // visit
+  {
+    struct empty {};
+    static_assert(0 == visit([]([[maybe_unused]] auto&&... args) { return sizeof...(args); }, empty{}));
+
+    struct one { int a; };
+    static_assert(1 == visit([]([[maybe_unused]] auto&&... args) { return sizeof...(args); }, one{}));
+
+    struct two { int a; int b; };
+    static_assert(2 == visit([]([[maybe_unused]] auto&&... args) { return sizeof...(args); }, two{}));
+  }
+
+  // type_name
+  {
+    struct local {};
+
+    static_assert(std::string_view{"void"} == type_name<void>());
+    static_assert(std::string_view{"int"} == type_name<int>());
+    static_assert(std::string_view{"empty"} == type_name<reflect::test::empty>());
+    static_assert(std::string_view{"empty"} == type_name(reflect::test::empty{}));
+    static_assert(std::string_view{"foo"} == type_name<reflect::test::foo>());
+    static_assert(std::string_view{"foo"} == type_name(reflect::test::foo{}));
+    static_assert(std::string_view{"bar"} == type_name<reflect::test::bar>());
+    static_assert(std::string_view{"bar"} == type_name(reflect::test::bar{}));
+    static_assert(std::string_view{"foo_t"} == type_name<reflect::test::foo_t<void>>());
+    static_assert(std::string_view{"foo_t"} == type_name<reflect::test::foo_t<int>>());
+    static_assert(std::string_view{"foo_t"} == type_name<reflect::test::foo_t<reflect::test::ns::bar_v<42>>>());
+    static_assert(std::string_view{"bar_v"} == type_name<reflect::test::ns::bar_v<42>>());
+    static_assert(std::string_view{"bar_v"} == type_name<reflect::test::ns::bar_v<>>());
+    static_assert(std::string_view{"int"} == type_name(reflect::test::foo::type{}));
+    static_assert(std::string_view{"E"} == type_name(reflect::test::foo::E{}));
+    static_assert(std::string_view{"local"} == type_name<local>());
+    static_assert(std::string_view{"local"} == type_name(local{}));
+  }
+
+  // type_id
+  {
+    static_assert(type_id<reflect::test::bar>() != type_id(reflect::test::foo{}));
+    static_assert(type_id<int>() != type_id(reflect::test::foo{}));
+    static_assert(type_id<int>() != type_id<void>());
+    static_assert(type_id<void>() != type_id<int>());
+    static_assert(type_id<void>() == type_id<void>());
+    static_assert(type_id<int>() == type_id<int>());
+    static_assert(type_id<int>() == type_id<int&>());
+    static_assert(type_id<const int&>() == type_id<int&>());
+    static_assert(type_id<void*>() == type_id<void>());
+    static_assert(type_id<void*>() == type_id<void>());
+    static_assert(type_id<reflect::test::foo>() == type_id(reflect::test::foo{}));
+    static_assert(type_id<reflect::test::bar>() == type_id(reflect::test::bar{}));
+  }
+
+  #ifndef _MSC_VER
+  // enumerators
+  {
+    static_assert(1u == enumerators<reflect::test::e1, 0, 1>.size());
+    static_assert(0u == enumerators<reflect::test::e1, 0, 1>[0].first);
+
+    static_assert(2u == enumerators<reflect::test::e2, 0, 2>.size());
+    static_assert(std::uint8_t(0) == enumerators<reflect::test::e2, 0, 2>[0].first);
+    static_assert(std::uint8_t(1) == enumerators<reflect::test::e2, 0, 2>[1].first);
+
+    static_assert(3u == enumerators<reflect::test::e3, 0, 3>.size());
+    static_assert(0u == enumerators<reflect::test::e3, 0, 3>[0].first);
+    static_assert(1u == enumerators<reflect::test::e3, 0, 3>[1].first);
+    static_assert(2u == enumerators<reflect::test::e3, 0, 3>[2].first);
+
+    static_assert(4u == enumerators<reflect::test::e4, 0, 6>.size());
+    static_assert(0 == enumerators<reflect::test::e4, 0, 6>[0].first);
+    static_assert(2 == enumerators<reflect::test::e4, 0, 6>[1].first);
+    static_assert(5 == enumerators<reflect::test::e4, 0, 6>[2].first);
+    static_assert(6 == enumerators<reflect::test::e4, 0, 6>[3].first);
+  }
+  #endif
+
+  // enum_name
+  {
+      enum class foobar {
+        foo = 1, bar = 2
+      };
+
+      enum mask : unsigned char {
+        a = 0b00,
+        b = 0b01,
+        c = 0b10,
+      };
+
+      enum sparse {
+        _128 = 128,
+        _130 = 130,
+      };
+
+      enum class negative {
+        unknown = -1,
+        A = 0,
+        B = 1,
+      };
+
+      static_assert([](const auto e) { return requires { enum_name<foobar,"",1,2>(e); }; }(foobar::foo));
+      static_assert([](const auto e) { return requires { enum_name<mask,"",1,2>(e); }; }(mask::a));
+      static_assert(not [](const auto e) { return requires { enum_name<foobar,"",1,2>(e); }; }(0));
+      static_assert(not [](const auto e) { return requires { enum_name<int,"",1,2>(e); }; }(0));
+      static_assert(not [](const auto e) { return requires { enum_name<int,"",1,2>(e); }; }(42u));
+
+      static_assert(std::string_view{""} == enum_name<foobar,"",1,2>(static_cast<foobar>(42)));
+      static_assert(std::string_view{"unknown"} == enum_name<foobar,"unknown",1,2>(static_cast<foobar>(42)));
+
+      const auto e = foobar::foo;
+      static_assert(std::string_view{"foo"} == enum_name<foobar,"",1,2>(e));
+
+      static_assert(std::string_view{"foo"} == enum_name<foobar,"",1,2>(foobar::foo));
+      static_assert(std::string_view{"bar"} == enum_name<foobar,"",1,2>(foobar::bar));
+
+      static_assert(std::string_view{"a"} == enum_name<mask,"",0,2>(mask::a));
+      static_assert(std::string_view{"b"} == enum_name<mask,"",0,2>(mask::b));
+      static_assert(std::string_view{"c"} == enum_name<mask,"",0,2>(mask::c));
+
+      static_assert(std::string_view{"_128"} == enum_name<sparse,"",128,130>(sparse::_128));
+      static_assert(std::string_view{"_130"} == enum_name<sparse,"",128,130>(sparse::_130));
+
+      static_assert(std::string_view{"unknown"} == enum_name<negative,"<>",-1, 1>(negative::unknown));
+      static_assert(std::string_view{"A"} == enum_name<negative,"<>",-1, 1>(negative::A));
+      static_assert(std::string_view{"B"} == enum_name<negative,"<>",-1, 1>(negative::B));
+      static_assert(std::string_view{"<>"} == enum_name<negative,"<>",-1, 1>(static_cast<negative>(-42)));
+
+      static_assert(std::string_view{"_141"} == enum_name<reflect::test::e>(reflect::test::e::_141));
+      static_assert(std::string_view{"_142"} == enum_name<reflect::test::e>(reflect::test::e::_142));
+  }
+
+  // member_name
+  {
+    struct foo { int i; bool b; void* bar{}; };
+
+    static_assert(std::string_view{"i"} == member_name<0, foo>());
+    static_assert(std::string_view{"i"} == member_name<0>(foo{}));
+
+    static_assert(std::string_view{"b"} == member_name<1, foo>());
+    static_assert(std::string_view{"b"} == member_name<1>(foo{}));
+
+    static_assert(std::string_view{"bar"} == member_name<2, foo>());
+    static_assert(std::string_view{"bar"} == member_name<2>(foo{}));
+  }
+
+  // get [by index]
+  {
+    struct foo { int i; bool b; };
+
+    {
+      constexpr auto f = foo{.i=42, .b=true};
+
+      static_assert([]<auto N> { return requires { get<N>(f); }; }.template operator()<0>());
+      static_assert([]<auto N> { return requires { get<N>(f); }; }.template operator()<1>());
+      static_assert(not []<auto N> { return requires { get<N>(f); }; }.template operator()<2>());
+
+      static_assert(42 == get<0>(f));
+      static_assert(true == get<1>(f));
+    }
+
+    {
+      {
+        auto f = foo{};
+        auto value = get<0>(f);
+        static_assert(std::is_same_v<decltype(value), int>);
+      }
+
+      {
+        auto value = get<0>(foo{});
+        static_assert(std::is_same_v<decltype(value), int>);
+      }
+
+      {
+        auto f = foo{};
+        auto& lvalue = get<0>(f);
+        static_assert(std::is_same_v<decltype(lvalue), int&>);
+      }
+
+      {
+        static_assert(std::is_same_v<decltype(get<0>(foo{})), int&&>);
+      }
+    }
+  }
+
+  // member_type
+  {
+    struct foo{ int i; float j; bool k; };
+
+    static_assert(std::is_same_v<int, member_type<0, foo>>);
+    static_assert(std::is_same_v<float, member_type<1, foo>>);
+    static_assert(std::is_same_v<bool, member_type<2, foo>>);
+  }
+
+  // has_member_name
+  {
+    struct foo { int bar; };
+    static_assert(has_member_name<foo, "bar">);
+    static_assert(not has_member_name<foo, "baz">);
+    static_assert(not has_member_name<foo, "BAR">);
+    static_assert(not has_member_name<foo, "">);
+  }
+
+  // diagnose_member_name
+  {
+    struct foo { bool flag; int bar; };
+    static_assert(detail::diagnose_member_name<foo, "">() == "`foo` has no data member named ``. Did you mean `bar`?");
+    static_assert(detail::diagnose_member_name<foo, "ba">() == "`foo` has no data member named `ba`. Did you mean `bar`?");
+    static_assert(detail::diagnose_member_name<foo, "fl">() == "`foo` has no data member named `fl`. Did you mean `flag`?");
+    static_assert(detail::diagnose_member_name<foo, "baz">() == "`foo` has no data member named `baz`. Did you mean `bar`?");
+    static_assert(detail::diagnose_member_name<foo, "lag">() == "`foo` has no data member named `lag`. Did you mean `flag`?");
+
+    struct empty {};
+    static_assert(detail::diagnose_member_name<empty, "any">() == "`empty` has no data members.");
+  }
+
+  // get [by name]
+  {
+    struct foo { int i; bool b; };
+
+    {
+      constexpr auto f = foo{.i=42, .b=true};
+
+      static_assert([]<fixed_string Name> { return requires { get<Name>(f); }; }.template operator()<"i">());
+      static_assert([]<fixed_string Name> { return requires { get<Name>(f); }; }.template operator()<"b">());
+      static_assert(not []<fixed_string Name> { return requires { get<Name>(f); }; }.template operator()<"unknown">());
+
+      static_assert(42 == get<"i">(f));
+      static_assert(true == get<"b">(f));
+    }
+
+    {
+      {
+        auto f = foo{};
+        auto value = get<"i">(f);
+        static_assert(std::is_same_v<decltype(value), int>);
+      }
+
+      {
+        auto value = get<"i">(foo{});
+        static_assert(std::is_same_v<decltype(value), int>);
+      }
+
+      {
+        auto f = foo{};
+        auto& lvalue = get<"i">(f);
+        static_assert(std::is_same_v<decltype(lvalue), int&>);
+      }
+
+      {
+        static_assert(std::is_same_v<decltype(get<"i">(foo{})), int&&>);
+      }
+    }
+  }
+
+  // to
+  {
+    struct foo { int a; int b; };
+
+    {
+      constexpr auto t = to<std::tuple>(foo{.a=4, .b=2});
+      static_assert(4 == std::get<0>(t));
+      static_assert(2 == std::get<1>(t));
+    }
+
+    {
+      auto f = foo{.a=4, .b=2};
+      auto t = to<std::tuple>(f);
+      std::get<0>(t) *= 10;
+      f.b = 42;
+      expect(40 == std::get<0>(t) and 40 == f.a);
+      expect(42 == std::get<1>(t) and 42 == f.b);
+    }
+
+    {
+      const auto f = foo{.a=4, .b=2};
+      auto t = to<std::tuple>(f);
+      expect(f.a == std::get<0>(t));
+      expect(f.b == std::get<1>(t));
+    }
+  }
+
+  // copy
+  {
+    struct foo {
+      int a{};
+      int b{};
+    };
+
+    struct bar {
+      int a{};
+      int b{};
+    };
+
+    const auto f = foo{.a=1, .b=2};
+
+    {
+      bar b{};
+      b.b = 42;
+      copy<"a">(f, b);
+      expect(b.a == f.a);
+      expect(42 == b.b);
+    }
+
+    {
+      bar b{};
+      b.b = 42;
+      copy<"a", "b">(f, b);
+      expect(b.a == f.a);
+      expect(b.b == f.b);
+    }
+
+    {
+      bar b{};
+      b.a = 42;
+      copy<"b">(f, b);
+      expect(42 == b.a);
+      expect(b.b == f.b);
+    }
+
+    {
+      bar b{};
+      copy<"c">(f, b); // ignores
+      expect(0 == b.a);
+      expect(0 == b.b);
+    }
+
+    {
+      bar b{};
+      copy<"a", "c", "b">(f, b); // copies a, b; ignores c
+      expect(b.a == f.a);
+      expect(b.b == f.b);
+    }
+
+    {
+      bar b{};
+      copy(f, b);
+      expect(b.a == f.a);
+      expect(b.b == f.b);
+    }
+
+    {
+      bar b{.a=4, .b=2};
+      copy(f, b); // overwrites members
+      expect(b.a == f.a);
+      expect(b.b == f.b);
+    }
+
+    struct baz {
+      int a{};
+      int c{};
+    };
+
+    {
+      baz b{};
+      b.c = 42;
+      copy(f, b);
+      expect(b.a == f.a);
+      expect(42 == b.c);
+    }
+  }
+
+  // to [struct]
+  {
+    struct foo {
+      int a{};
+      int b{};
+    };
+
+    struct bar {
+      int a{};
+      int b{};
+    };
+
+    {
+      constexpr auto b = to<bar>(foo{.a=4, .b=2});
+      static_assert(4 == b.a);
+      static_assert(2 == b.b);
+    }
+
+    {
+      auto f = foo{.a=4, .b=2};
+      auto b = to<bar>(f);
+      f.a = 42;
+      expect(42 == f.a);
+      expect(4 == b.a);
+      expect(2 == b.b);
+    }
+
+    {
+      const auto f = foo{.a=4, .b=2};
+      const auto b = to<bar>(f);
+      expect(4 == b.a);
+      expect(2 == b.b);
+    }
+
+    struct baz {
+      int a{};
+      int c{};
+    };
+
+    {
+      auto f = foo{.a=4, .b=2};
+      auto b = to<bar>(f);
+      b.a = 1;
+      expect(1 == b.a and 4 == f.a);
+      expect(2 == b.b and 2 == f.b);
+    }
+
+    {
+      const auto b = to<baz>(foo{.a=4, .b=2});
+      expect(4 == b.a and 0 == b.c);
+    }
+
+    struct foobar {
+      int a{};
+      enum e : int { } b; // strong type, type conversion disabled
+    };
+
+    {
+      const auto fb = to<foobar>(foo{.a=4, .b=2});
+      expect(4 == fb.a and 0 == fb.b);
+    }
+  }
+
+  // size_of
+  {
+    struct s {
+      float a;
+      char b;
+      char bb;
+      int c;
+    };
+
+    static_assert(sizeof(float) == size_of<0, s>());
+    static_assert(sizeof(char) == size_of<1, s>());
+    static_assert(sizeof(char) == size_of<2, s>());
+    static_assert(sizeof(int) == size_of<3, s>());
+  }
+
+  // align_of
+  {
+    struct s {
+      float a;
+      char b;
+      char bb;
+      int c;
+    };
+
+    static_assert(alignof(float) == align_of<0, s>());
+    static_assert(alignof(char) == align_of<1, s>());
+    static_assert(alignof(char) == align_of<2, s>());
+    static_assert(alignof(int) == align_of<3, s>());
+  }
+
+  // offset_of
+  {
+    struct s {
+      float a;
+      char b;
+      char bb;
+      int c;
+    };
+
+    #pragma pack(push, 1)
+    struct s2 {
+      float a;
+      char b;
+      char bb;
+      int c;
+      double d;
+      char e;
+    };
+    #pragma pack(pop)
+
+    struct a {
+      int i;
+      int j;
+    };
+
+    struct b {
+      int i;
+      int k;
+    };
+
+    struct al {
+      char a;
+      int b;
+      char c;
+    };
+
+    static_assert(offset_of<0, a>() == 0);
+    static_assert(offset_of<1, a>() == sizeof(int));
+    static_assert(offset_of<0, b>() == 0);
+    static_assert(offset_of<1, b>() == sizeof(int));
+    static_assert(offset_of<0, s>() == 0);
+    static_assert(offset_of<1, s>() == sizeof(float));
+    static_assert(offset_of<2, s>() == sizeof(float) + sizeof(char));
+    static_assert(offset_of<3, s>() == alignof(s)*2);
+    static_assert(offset_of<0, s2>() == 0);
+    static_assert(offset_of<1, s2>() == sizeof(float));
+    static_assert(offset_of<2, s2>() == sizeof(float) + sizeof(char));
+    static_assert(offset_of<3, s2>() == sizeof(float) + sizeof(char) + sizeof(char));
+    static_assert(offset_of<4, s2>() == sizeof(float) + sizeof(char) + sizeof(char) + sizeof(int));
+    static_assert(offset_of<5, s2>() == sizeof(float) + sizeof(char) + sizeof(char) + sizeof(int) + sizeof(double));
+    static_assert(offset_of<0, al>() == 0);
+    static_assert(offset_of<1, al>() == sizeof(char)*2);
+    static_assert(offset_of<2, al>() == sizeof(char)*2 + sizeof(int));
+  }
+
+  // for_each
+  {
+    struct foo { short _1; int _2; } f{._1=1, ._2=2};
+
+    std::array<std::size_t, size(f)> size_of{};
+    std::array<std::size_t, size(f)> align_of{};
+    std::array<std::size_t, size(f)> offset_of{};
+    std::array<std::string_view, size(f)> name{};
+    std::array<std::string_view, size(f)> type{};
+    std::array<std::common_type_t<short, int>, size(f)> value{};
+
+    auto i = 0;
+    for_each([&](auto I) {
+      size_of[i] = reflect::size_of<I>(f);
+      align_of[i] = reflect::align_of<I>(f);
+      offset_of[i] = reflect::offset_of<I>(f);
+      name[i] = reflect::member_name<I>(f);
+      type[i] = reflect::type_name(reflect::get<I>(f));
+      value[i] = reflect::get<I>(f);
+      ++i;
+    }, f);
+
+    expect(2 == i);
+    expect(sizeof(f._1) == size_of[0] and sizeof(f._2) == size_of[1]);
+    expect(alignof(short) == align_of[0] and alignof(int) == align_of[1]);
+    expect(0 == offset_of[0] and 4 == offset_of[1]);
+    expect(std::string_view{"_1"} == name[0] and std::string_view{"_2"} == name[1]);
+    expect(f._1 == value[0] and f._2 == value[1]);
+  }
+}(), true));
+#endif // NTEST

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -552,6 +552,11 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                 }
             });
 
+            constexpr auto texcoordOverriddenMarker = []() {
+                ImGui::SameLine();
+                ImGui::HelperMarker("(overridden)", "This value is overridden by KHR_texture_transform extension.");
+            };
+
             if (ImGui::CollapsingHeader("Physically Based Rendering")) {
                 ImGui::SeparatorText("Base Color");
                 const auto &baseColorTextureInfo = material.pbrData.baseColorTexture;
@@ -569,6 +574,17 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                         if (baseColorTextureInfo) {
                             ImGui::LabelText("Texture Index", "%zu", baseColorTextureInfo->textureIndex);
                             ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*baseColorTextureInfo));
+
+                            if (const auto &transform = baseColorTextureInfo->transform) {
+                                texcoordOverriddenMarker();
+
+                                ImGui::SeparatorText("KHR_texture_transform");
+                                ImGui::WithDisabled([&]() { // TODO
+                                    ImGui::DragFloat2("Scale", transform->uvScale.data(), 0.01f);
+                                    ImGui::DragFloat("Rotation", &transform->rotation, 0.01f);
+                                    ImGui::DragFloat2("Offset", transform->uvOffset.data(), 0.01f);
+                                });
+                            }
                         }
                     }, baseColorTextureInfo.has_value());
                 });
@@ -594,6 +610,17 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                         if (metallicRoughnessTextureInfo) {
                             ImGui::LabelText("Texture Index", "%zu", metallicRoughnessTextureInfo->textureIndex);
                             ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*metallicRoughnessTextureInfo));
+
+                            if (const auto &transform = metallicRoughnessTextureInfo->transform) {
+                                texcoordOverriddenMarker();
+
+                                ImGui::SeparatorText("KHR_texture_transform");
+                                ImGui::WithDisabled([&]() { // TODO
+                                    ImGui::DragFloat2("Scale", transform->uvScale.data(), 0.01f);
+                                    ImGui::DragFloat("Rotation", &transform->rotation, 0.01f);
+                                    ImGui::DragFloat2("Offset", transform->uvOffset.data(), 0.01f);
+                                });
+                            }
                         }
                     });
                 });
@@ -611,6 +638,17 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                         });
                         ImGui::LabelText("Texture Index", "%zu", textureInfo->textureIndex);
                         ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*textureInfo));
+
+                        if (const auto &transform = textureInfo->transform) {
+                            texcoordOverriddenMarker();
+
+                            ImGui::SeparatorText("KHR_texture_transform");
+                            ImGui::WithDisabled([&]() { // TODO
+                                ImGui::DragFloat2("Scale", transform->uvScale.data(), 0.01f);
+                                ImGui::DragFloat("Rotation", &transform->rotation, 0.01f);
+                                ImGui::DragFloat2("Offset", transform->uvOffset.data(), 0.01f);
+                            });
+                        }
                     });
                 });
             }
@@ -627,6 +665,17 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                         });
                         ImGui::LabelText("Texture Index", "%zu", textureInfo->textureIndex);
                         ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*textureInfo));
+
+                        if (const auto &transform = textureInfo->transform) {
+                            texcoordOverriddenMarker();
+
+                            ImGui::SeparatorText("KHR_texture_transform");
+                            ImGui::WithDisabled([&]() { // TODO
+                                ImGui::DragFloat2("Scale", transform->uvScale.data(), 0.01f);
+                                ImGui::DragFloat("Rotation", &transform->rotation, 0.01f);
+                                ImGui::DragFloat2("Offset", transform->uvOffset.data(), 0.01f);
+                            });
+                        }
                     });
                 });
             }
@@ -647,6 +696,17 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                         if (textureInfo) {
                             ImGui::LabelText("Texture Index", "%zu", textureInfo->textureIndex);
                             ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*textureInfo));
+
+                            if (const auto &transform = textureInfo->transform) {
+                                texcoordOverriddenMarker();
+
+                                ImGui::SeparatorText("KHR_texture_transform");
+                                ImGui::WithDisabled([&]() { // TODO
+                                    ImGui::DragFloat2("Scale", transform->uvScale.data(), 0.01f);
+                                    ImGui::DragFloat("Rotation", &transform->rotation, 0.01f);
+                                    ImGui::DragFloat2("Offset", transform->uvOffset.data(), 0.01f);
+                                });
+                            }
                         }
                     }, textureInfo.has_value());
                 });
@@ -701,7 +761,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::sceneHierarchy(
 
         ImGui::Checkbox("Merge single child nodes", &mergeSingleChildNodes);
         ImGui::SameLine();
-        ImGui::HelperMarker("If all nested nodes have only one child, they will be shown as a single node (with combined name).");
+        ImGui::HelperMarker("(?)", "If all nested nodes have only one child, they will be shown as a single node (with combined name).");
 
         if (bool tristateVisibility = holds_alternative<std::vector<std::optional<bool>>>(visibilities);
             ImGui::Checkbox("Use tristate visibility", &tristateVisibility)) {
@@ -709,6 +769,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::sceneHierarchy(
         }
         ImGui::SameLine();
         ImGui::HelperMarker(
+            "(?)",
             "If all children of a node are visible, the node will be checked. "
             "If all children are hidden, the node will be unchecked. "
             "If some children are visible and some are hidden, the node will be in an indeterminate state.");
@@ -974,7 +1035,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::nodeInspector(
 
                     constexpr auto noAffectHelperMarker = []() {
                         ImGui::SameLine();
-                        ImGui::HelperMarker("This property will not affect to the actual rendering, as it is calculated from the actual viewport size.");
+                        ImGui::HelperMarker("(?)", "This property will not affect to the actual rendering, as it is calculated from the actual viewport size.");
                     };
 
                     visit(fastgltf::visitor {
@@ -1140,7 +1201,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::inputControl(
                 tasks.emplace_back(std::in_place_type<task::TightenNearFarPlane>);
             }
             ImGui::SameLine();
-            ImGui::HelperMarker("Near/Far plane will be automatically tightened to fit the scene bounding box.");
+            ImGui::HelperMarker("(?)", "Near/Far plane will be automatically tightened to fit the scene bounding box.");
 
             ImGui::WithDisabled([&]() {
                 ImGui::DragFloatRange2("Near/Far", &camera.zMin, &camera.zMax, 1.f, 1e-6f, 1e-6f, "%.2e", nullptr, ImGuiSliderFlags_Logarithmic);
@@ -1148,7 +1209,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::inputControl(
 
             ImGui::Checkbox("Use Frustum Culling", &useFrustumCulling);
             ImGui::SameLine();
-            ImGui::HelperMarker("The primitives outside the camera frustum will be culled.");
+            ImGui::HelperMarker("(?)", "The primitives outside the camera frustum will be culled.");
         }
 
         if (ImGui::CollapsingHeader("Node selection")) {

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -568,7 +568,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                         });
                         if (baseColorTextureInfo) {
                             ImGui::LabelText("Texture Index", "%zu", baseColorTextureInfo->textureIndex);
-                            ImGui::LabelText("Texture Coordinate", "%zu", baseColorTextureInfo->texCoordIndex);
+                            ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*baseColorTextureInfo));
                         }
                     }, baseColorTextureInfo.has_value());
                 });
@@ -593,7 +593,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                         });
                         if (metallicRoughnessTextureInfo) {
                             ImGui::LabelText("Texture Index", "%zu", metallicRoughnessTextureInfo->textureIndex);
-                            ImGui::LabelText("Texture Coordinate", "%zu", metallicRoughnessTextureInfo->texCoordIndex);
+                            ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*metallicRoughnessTextureInfo));
                         }
                     });
                 });
@@ -610,7 +610,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                             }
                         });
                         ImGui::LabelText("Texture Index", "%zu", textureInfo->textureIndex);
-                        ImGui::LabelText("Texture Coordinate", "%zu", textureInfo->texCoordIndex);
+                        ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*textureInfo));
                     });
                 });
             }
@@ -626,7 +626,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                             }
                         });
                         ImGui::LabelText("Texture Index", "%zu", textureInfo->textureIndex);
-                        ImGui::LabelText("Texture Coordinate", "%zu", textureInfo->texCoordIndex);
+                        ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*textureInfo));
                     });
                 });
             }
@@ -646,7 +646,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                         });
                         if (textureInfo) {
                             ImGui::LabelText("Texture Index", "%zu", textureInfo->textureIndex);
-                            ImGui::LabelText("Texture Coordinate", "%zu", textureInfo->texCoordIndex);
+                            ImGui::LabelText("Texture Coordinate", "%zu", getTexcoordIndex(*textureInfo));
                         }
                     }, textureInfo.has_value());
                 });

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -132,10 +132,12 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
             else {
                 constexpr auto fetchTextureTransform = [](const fastgltf::TextureInfo &textureInfo) {
                     if (textureInfo.transform) {
-                        return textureInfo.transform->rotation != 0.f ? TextureTransform::Type::All : TextureTransform::Type::ScaleAndOffset;
+                        return textureInfo.transform->rotation != 0.f
+                            ? PrimitiveRendererSpecialization::TextureTransform::All
+                            : PrimitiveRendererSpecialization::TextureTransform::ScaleAndOffset;
                     }
                     else {
-                        return TextureTransform::Type::None;
+                        return PrimitiveRendererSpecialization::TextureTransform::None;
                     }
                 };
 
@@ -147,23 +149,21 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         return std::pair { info.numComponent, info.componentType };
                     }),
                     .fragmentShaderGeneratedTBN = !primitiveInfo.normalInfo.has_value(),
-                    .textureTransform = {
-                        .baseColor = material.pbrData.baseColorTexture
-                            .transform(fetchTextureTransform)
-                            .value_or(TextureTransform::Type::None),
-                        .metallicRoughness = material.pbrData.metallicRoughnessTexture
-                            .transform(fetchTextureTransform)
-                            .value_or(TextureTransform::Type::None),
-                        .normal = material.normalTexture
-                            .transform(fetchTextureTransform)
-                            .value_or(TextureTransform::Type::None),
-                        .occlusion = material.occlusionTexture
-                            .transform(fetchTextureTransform)
-                            .value_or(TextureTransform::Type::None),
-                        .emissive = material.emissiveTexture
-                            .transform(fetchTextureTransform)
-                            .value_or(TextureTransform::Type::None),
-                    },
+                    .baseColorTextureTransform = material.pbrData.baseColorTexture
+                        .transform(fetchTextureTransform)
+                        .value_or(PrimitiveRendererSpecialization::TextureTransform::None),
+                    .metallicRoughnessTextureTransform = material.pbrData.metallicRoughnessTexture
+                        .transform(fetchTextureTransform)
+                        .value_or(PrimitiveRendererSpecialization::TextureTransform::None),
+                    .normalTextureTransform = material.normalTexture
+                        .transform(fetchTextureTransform)
+                        .value_or(PrimitiveRendererSpecialization::TextureTransform::None),
+                    .occlusionTextureTransform = material.occlusionTexture
+                        .transform(fetchTextureTransform)
+                        .value_or(PrimitiveRendererSpecialization::TextureTransform::None),
+                    .emissiveTextureTransform = material.emissiveTexture
+                        .transform(fetchTextureTransform)
+                        .value_or(PrimitiveRendererSpecialization::TextureTransform::None),
                     .alphaMode = material.alphaMode,
                 });
             }

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -25,6 +25,12 @@ namespace vk_gltf_viewer {
         void run();
 
     private:
+        static constexpr fastgltf::Extensions SUPPORTED_EXTENSIONS
+            = fastgltf::Extensions::KHR_materials_unlit
+            | fastgltf::Extensions::KHR_materials_variants
+            | fastgltf::Extensions::KHR_texture_basisu
+            | fastgltf::Extensions::KHR_texture_transform
+            | fastgltf::Extensions::EXT_mesh_gpu_instancing;
         static constexpr std::uint32_t FRAMES_IN_FLIGHT = 2;
 
         /**
@@ -133,7 +139,7 @@ namespace vk_gltf_viewer {
         // glTF resources.
         // --------------------
 
-        fastgltf::Parser parser { fastgltf::Extensions::KHR_materials_unlit | fastgltf::Extensions::KHR_materials_variants | fastgltf::Extensions::KHR_texture_basisu | fastgltf::Extensions::EXT_mesh_gpu_instancing };
+        fastgltf::Parser parser { SUPPORTED_EXTENSIONS };
         std::optional<Gltf> gltf;
 
         // --------------------

--- a/interface/gltf/AssetGpuBuffers.cppm
+++ b/interface/gltf/AssetGpuBuffers.cppm
@@ -11,6 +11,7 @@ export import glm;
 import :gltf.algorithm.MikktSpaceInterface;
 export import :gltf.AssetPrimitiveInfo;
 export import :gltf.AssetProcessError;
+import :helpers.fastgltf;
 import :helpers.functional;
 import :helpers.ranges;
 import :helpers.type_map;
@@ -497,7 +498,7 @@ namespace vk_gltf_viewer::gltf {
                     return true;
                 }))
                 | std::views::transform(decomposer([&](const fastgltf::Primitive *pPrimitive, AssetPrimitiveInfo &primitiveInfo) {
-                    const std::size_t texcoordIndex = asset.materials[*pPrimitive->materialIndex].normalTexture->texCoordIndex;
+                    const std::size_t texcoordIndex = getTexcoordIndex(*asset.materials[*pPrimitive->materialIndex].normalTexture);
                     return std::pair<AssetPrimitiveInfo*, algorithm::MikktSpaceMesh<BufferDataAdapter>> {
                         std::piecewise_construct,
                         std::tuple { &primitiveInfo },

--- a/interface/gltf/AssetGpuBuffers.cppm
+++ b/interface/gltf/AssetGpuBuffers.cppm
@@ -133,7 +133,19 @@ namespace vk_gltf_viewer::gltf {
             float occlusionStrength = 1.f;
             glm::vec3 emissiveFactor = { 0.f, 0.f, 0.f };
             float alphaCutOff;
+            glm::mat2 baseColorTextureTransformUpperLeft2x2;
+            glm::vec2 baseColorTextureTransformOffset;
+            glm::mat2 metallicRoughnessTextureTransformUpperLeft2x2;
+            glm::vec2 metallicRoughnessTextureTransformOffset;
+            glm::mat2 normalTextureTransformUpperLeft2x2;
+            glm::vec2 normalTextureTransformOffset;
+            glm::mat2 occlusionTextureTransformUpperLeft2x2;
+            glm::vec2 occlusionTextureTransformOffset;
+            glm::mat2 emissiveTextureTransformUpperLeft2x2;
+            glm::vec2 emissiveTextureTransformOffset;
+            char padding1[8];
         };
+        static_assert(sizeof(GpuMaterial) == 192);
 
         struct GpuPrimitive {
             vk::DeviceAddress pPositionBuffer;

--- a/interface/helpers/AggregateHasher.cppm
+++ b/interface/helpers/AggregateHasher.cppm
@@ -5,72 +5,15 @@ module;
 export module vk_gltf_viewer:helpers.AggregateHasher;
 
 import std;
+import reflect;
 
-export template <std::size_t FieldCount> requires (FieldCount >= 1 && FieldCount <= 8)
-struct AggregateHasher {
+export struct AggregateHasher {
     template <typename T> requires std::is_aggregate_v<T>
     [[nodiscard]] constexpr std::size_t operator()(const T &v) const noexcept {
-        std::size_t seed = 0;
-        if constexpr (FieldCount == 1) {
-            const auto &[x1] = v;
-            boost::hash_combine(seed, x1);
-        }
-        if constexpr (FieldCount == 2) {
-            const auto &[x1, x2] = v;
-            boost::hash_combine(seed, x1);
-            boost::hash_combine(seed, x2);
-        }
-        if constexpr (FieldCount == 3) {
-            const auto &[x1, x2, x3] = v;
-            boost::hash_combine(seed, x1);
-            boost::hash_combine(seed, x2);
-            boost::hash_combine(seed, x3);
-        }
-        if constexpr (FieldCount == 4) {
-            const auto &[x1, x2, x3, x4] = v;
-            boost::hash_combine(seed, x1);
-            boost::hash_combine(seed, x2);
-            boost::hash_combine(seed, x3);
-            boost::hash_combine(seed, x4);
-        }
-        if constexpr (FieldCount == 5) {
-            const auto &[x1, x2, x3, x4, x5] = v;
-            boost::hash_combine(seed, x1);
-            boost::hash_combine(seed, x2);
-            boost::hash_combine(seed, x3);
-            boost::hash_combine(seed, x4);
-            boost::hash_combine(seed, x5);
-        }
-        if constexpr (FieldCount == 6) {
-            const auto &[x1, x2, x3, x4, x5, x6] = v;
-            boost::hash_combine(seed, x1);
-            boost::hash_combine(seed, x2);
-            boost::hash_combine(seed, x3);
-            boost::hash_combine(seed, x4);
-            boost::hash_combine(seed, x5);
-            boost::hash_combine(seed, x6);
-        }
-        if constexpr (FieldCount == 7) {
-            const auto &[x1, x2, x3, x4, x5, x6, x7] = v;
-            boost::hash_combine(seed, x1);
-            boost::hash_combine(seed, x2);
-            boost::hash_combine(seed, x3);
-            boost::hash_combine(seed, x4);
-            boost::hash_combine(seed, x5);
-            boost::hash_combine(seed, x6);
-            boost::hash_combine(seed, x7);
-        }
-        if constexpr (FieldCount == 8) {
-            const auto &[x1, x2, x3, x4, x5, x6, x7, x8] = v;
-            boost::hash_combine(seed, x1);
-            boost::hash_combine(seed, x2);
-            boost::hash_combine(seed, x3);
-            boost::hash_combine(seed, x4);
-            boost::hash_combine(seed, x5);
-            boost::hash_combine(seed, x6);
-            boost::hash_combine(seed, x7);
-            boost::hash_combine(seed, x8);
-        }
-        return seed;
+        return reflect::visit([](const auto &...fields) {
+            std::size_t seed = 0;
+            (boost::hash_combine(seed, fields), ...);
+            return seed;
+        }, v);
     }
 };

--- a/interface/helpers/fastgltf.cppm
+++ b/interface/helpers/fastgltf.cppm
@@ -253,6 +253,23 @@ namespace fastgltf {
         throw expected.error();
     }
 
+    /**
+     * @brief Get texture coordinate index from \p textureInfo, respecting KHR_texture_transform extension.
+     *
+     * Fetching texture coordinate index should not rely on \p textureInfo.texCoordIndex directly, because
+     * KHR_texture_transform extension overrides the index. Using this function is encouraged.
+     *
+     * @param textureInfo Texture info to get the texture coordinate index.
+     * @return Texture coordinate index.
+     */
+    export
+    [[nodiscard]] std::size_t getTexcoordIndex(const TextureInfo &textureInfo) noexcept {
+        if (textureInfo.transform && textureInfo.transform->texCoordIndex) {
+            return *textureInfo.transform->texCoordIndex;
+        }
+        return textureInfo.texCoordIndex;
+    }
+
 namespace math {
     /**
      * @brief Convert matrix of type \tp U to matrix of type \tp T.

--- a/interface/helpers/imgui/mod.cppm
+++ b/interface/helpers/imgui/mod.cppm
@@ -79,8 +79,8 @@ namespace ImGui {
         Text(str.data(), str.data() + str.size());
     }
 
-    export void HelperMarker(std::string_view description) {
-        TextDisabled("(?)");
+    export void HelperMarker(cpp_util::cstring_view label, std::string_view description) {
+        TextDisabled("%s", label.c_str());
         if (BeginItemTooltip()) {
             TextUnformatted(description);
             EndTooltip();

--- a/interface/helpers/type_map.cppm
+++ b/interface/helpers/type_map.cppm
@@ -2,6 +2,8 @@ export module vk_gltf_viewer:helpers.type_map;
 
 import std;
 
+#define INTEGER_SEQ(Is, N, ...) [&]<auto ...Is>(std::integer_sequence<decltype(N), Is...>) __VA_ARGS__ (std::make_integer_sequence<decltype(N), N>{})
+
 template <typename V, typename K>
 struct type_map_entry {
     K key;
@@ -41,21 +43,45 @@ export template <typename V, typename K>
 export template <typename K, typename... Vs>
 struct type_map : type_map_entry<Vs, K>...{
     [[nodiscard]] constexpr std::variant<std::type_identity<Vs>...> get_variant(K key) const {
-        return get_variant<type_map_entry<Vs, K>...>(key);
+        std::variant<std::type_identity<Vs>...> result;
+        [&, this]<std::size_t... Is>(std::index_sequence<Is...>){
+            std::ignore = ((key == type_map_entry<Vs, K>::key ? (result.template emplace<Is>(), true) : false) || ...);
+        }(std::make_index_sequence<sizeof...(Vs)>{});
+        return result;
     }
+};
 
-private:
-    template <typename Mapping, typename ...Mappings>
-    constexpr std::variant<std::type_identity<Vs>...> get_variant(K key) const {
-        if (key == Mapping::key) {
-            return std::type_identity<typename Mapping::value_type>{};
-        }
+/**
+ * @brief Convenience type map for monotonic integer sequence starting from 0.
+ *
+ * For <tt>type_map</tt> with mapping the runtime integer value to same compile time integer value, use <tt>iota_map</tt>.
+ *
+ * @code
+ * int main(int argc, char **argv) {
+ *     constexpr iota_map<3> map;
+ *     std::visit([](auto Is) {
+ *         std::array<const char*, Is> arguments;
+ *         std::copy_n(argv, arguments.size(), arguments.data());
+ *         std::println("{::?}", arguments);
+ *     }, map.get_variant(argc));
+ * }
+ *
+ * // ./main 0 1 -> print ["./main", "0", "1"]
+ * // ./main hello -> print ["./main", "hello"]
+ * // ./main 0 1 2 -> std::runtime_error { "No mapping found for the given key." } (argc > 3)
+ * @endcode
+ *
+ * @tparam Stop The stop value of the iota sequence.
+ */
+export template <auto Stop>
+struct iota_map {
+    explicit iota_map() = default;
 
-        if constexpr (sizeof...(Mappings) == 0){
-            throw std::runtime_error { "No mapping found for the given key." };
-        }
-        else {
-            return get_variant<Mappings...>(key);
-        }
+    [[nodiscard]] constexpr auto get_variant(decltype(Stop) key) const {
+        return INTEGER_SEQ(Is, Stop, {
+            std::variant<std::integral_constant<decltype(Is), Is>...> result;
+            std::ignore = ((key == Is ? (result.template emplace<Is>(), true) : false) || ...);
+            return result;
+        });
     }
 };

--- a/interface/helpers/type_map.cppm
+++ b/interface/helpers/type_map.cppm
@@ -45,7 +45,7 @@ struct type_map : type_map_entry<Vs, K>...{
     [[nodiscard]] constexpr std::variant<std::type_identity<Vs>...> get_variant(K key) const {
         std::variant<std::type_identity<Vs>...> result;
         [&, this]<std::size_t... Is>(std::index_sequence<Is...>){
-            std::ignore = ((key == type_map_entry<Vs, K>::key ? (result.template emplace<Is>(), true) : false) || ...);
+            std::ignore = ((key == static_cast<const type_map_entry<Vs, K>*>(this)->key ? (result.template emplace<Is>(), true) : false) || ...);
         }(std::make_index_sequence<sizeof...(Vs)>{});
         return result;
     }

--- a/interface/shader_selector/mask_depth_frag.cppm
+++ b/interface/shader_selector/mask_depth_frag.cppm
@@ -7,17 +7,14 @@ import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> mask_depth_frag(bool hasBaseColorTexture, bool hasColorAlphaAttribute) {
-        constexpr type_map hasBaseColorTextureMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        constexpr type_map hasColorAlphaAttributeMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
-            return shader::mask_depth_frag<Is...>;
-        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAlphaAttributeMap.get_variant(hasColorAlphaAttribute));
+    [[nodiscard]] std::span<const unsigned int> mask_depth_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ALPHA_ATTRIBUTE) {
+        constexpr iota_map<2> hasBaseColorTextureMap;
+        constexpr iota_map<2> hasColorAlphaAttributeMap;
+        return std::visit(
+            [](auto... Is) -> std::span<const unsigned int> {
+                return shader::mask_depth_frag<Is...>;
+            },
+            hasBaseColorTextureMap.get_variant(HAS_BASE_COLOR_TEXTURE),
+            hasColorAlphaAttributeMap.get_variant(HAS_COLOR_ALPHA_ATTRIBUTE));
     }
 }

--- a/interface/shader_selector/mask_depth_vert.cppm
+++ b/interface/shader_selector/mask_depth_vert.cppm
@@ -7,17 +7,14 @@ import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> mask_depth_vert(bool hasBaseColorTexture, bool hasColorAlphaAttribute) {
-        constexpr type_map hasBaseColorTextureMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        constexpr type_map hasColorAlphaAttributeMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
-            return shader::mask_depth_vert<Is...>;
-        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAlphaAttributeMap.get_variant(hasColorAlphaAttribute));
+    [[nodiscard]] std::span<const unsigned int> mask_depth_vert(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ALPHA_ATTRIBUTE) {
+        constexpr iota_map<2> hasBaseColorTextureMap;
+        constexpr iota_map<2> hasColorAlphaAttributeMap;
+        return std::visit(
+            [](auto... Is) -> std::span<const unsigned int> {
+                return shader::mask_depth_vert<Is...>;
+            },
+            hasBaseColorTextureMap.get_variant(HAS_BASE_COLOR_TEXTURE),
+            hasColorAlphaAttributeMap.get_variant(HAS_COLOR_ALPHA_ATTRIBUTE));
     }
 }

--- a/interface/shader_selector/mask_jump_flood_seed_frag.cppm
+++ b/interface/shader_selector/mask_jump_flood_seed_frag.cppm
@@ -7,17 +7,14 @@ import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_frag(bool hasBaseColorTexture, bool hasColorAlphaAttribute) {
-        constexpr type_map hasBaseColorTextureMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        constexpr type_map hasColorAlphaAttributeMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
-            return shader::mask_jump_flood_seed_frag<Is...>;
-        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAlphaAttributeMap.get_variant(hasColorAlphaAttribute));
+    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ALPHA_ATTRIBUTE) {
+        constexpr iota_map<2> hasBaseColorTextureMap;
+        constexpr iota_map<2> hasColorAlphaAttributeMap;
+        return std::visit(
+            [](auto... Is) -> std::span<const unsigned int> {
+                return shader::mask_jump_flood_seed_frag<Is...>;
+            },
+            hasBaseColorTextureMap.get_variant(HAS_BASE_COLOR_TEXTURE),
+            hasColorAlphaAttributeMap.get_variant(HAS_COLOR_ALPHA_ATTRIBUTE));
     }
 }

--- a/interface/shader_selector/mask_jump_flood_seed_vert.cppm
+++ b/interface/shader_selector/mask_jump_flood_seed_vert.cppm
@@ -7,17 +7,14 @@ import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_vert(bool hasBaseColorTexture, bool hasColorAlphaAttribute) {
-        constexpr type_map hasBaseColorTextureMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        constexpr type_map hasColorAlphaAttributeMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
-            return shader::mask_jump_flood_seed_vert<Is...>;
-        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAlphaAttributeMap.get_variant(hasColorAlphaAttribute));
+    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_vert(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ALPHA_ATTRIBUTE) {
+        constexpr iota_map<2> hasBaseColorTextureMap;
+        constexpr iota_map<2> hasColorAlphaAttributeMap;
+        return std::visit(
+            [](auto... Is) -> std::span<const unsigned int> {
+                return shader::mask_jump_flood_seed_vert<Is...>;
+            },
+            hasBaseColorTextureMap.get_variant(HAS_BASE_COLOR_TEXTURE),
+            hasColorAlphaAttributeMap.get_variant(HAS_COLOR_ALPHA_ATTRIBUTE));
     }
 }

--- a/interface/shader_selector/primitive_frag.cppm
+++ b/interface/shader_selector/primitive_frag.cppm
@@ -6,29 +6,18 @@ import :shader.primitive_frag;
 import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
-    [[nodiscard]] std::span<const unsigned int> primitive_frag(std::uint8_t texcoordCount, bool hasColorAttribute, bool fragmentShaderGeneratedTBN, fastgltf::AlphaMode alphaMode) {
-        constexpr type_map texcoordCountMap {
-            make_type_map_entry<std::integral_constant<int, 0>, std::uint8_t>(0),
-            make_type_map_entry<std::integral_constant<int, 1>, std::uint8_t>(1),
-            make_type_map_entry<std::integral_constant<int, 2>, std::uint8_t>(2),
-            make_type_map_entry<std::integral_constant<int, 3>, std::uint8_t>(3),
-            make_type_map_entry<std::integral_constant<int, 4>, std::uint8_t>(4),
-        };
-        constexpr type_map hasColorAttributeMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        constexpr type_map fragmentShaderGeneratedTBNMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        constexpr type_map alphaModeMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(fastgltf::AlphaMode::Opaque),
-            make_type_map_entry<std::integral_constant<int, 1>>(fastgltf::AlphaMode::Mask),
-            make_type_map_entry<std::integral_constant<int, 2>>(fastgltf::AlphaMode::Blend),
-        };
-        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
-            return shader::primitive_frag<Is...>;
-        }, texcoordCountMap.get_variant(texcoordCount), hasColorAttributeMap.get_variant(hasColorAttribute), fragmentShaderGeneratedTBNMap.get_variant(fragmentShaderGeneratedTBN), alphaModeMap.get_variant(alphaMode));
+    [[nodiscard]] std::span<const unsigned int> primitive_frag(int TEXCOORD_COUNT, int HAS_COLOR_ATTRIBUTE, int FRAGMENT_SHADER_GENERATED_TBN, int ALPHA_MODE) {
+        constexpr iota_map<5> texcoordCountMap;
+        constexpr iota_map<2> hasColorAttributeMap;
+        constexpr iota_map<2> fragmentShaderGeneratedTBNMap;
+        constexpr iota_map<3> alphaModeMap;
+        return std::visit(
+            [](auto ...Is) -> std::span<const unsigned int> {
+                return shader::primitive_frag<Is...>;
+            },
+            texcoordCountMap.get_variant(TEXCOORD_COUNT),
+            hasColorAttributeMap.get_variant(HAS_COLOR_ATTRIBUTE),
+            fragmentShaderGeneratedTBNMap.get_variant(FRAGMENT_SHADER_GENERATED_TBN),
+            alphaModeMap.get_variant(ALPHA_MODE));
     }
 }

--- a/interface/shader_selector/primitive_vert.cppm
+++ b/interface/shader_selector/primitive_vert.cppm
@@ -5,24 +5,16 @@ import :shader.primitive_vert;
 import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
-    [[nodiscard]] std::span<const unsigned int> primitive_vert(std::uint8_t texcoordCount, bool hasColorAttribute, bool fragmentShaderGeneratedTBN) {
-        constexpr type_map texcoordCountMap {
-            make_type_map_entry<std::integral_constant<int, 0>, std::uint8_t>(0),
-            make_type_map_entry<std::integral_constant<int, 1>, std::uint8_t>(1),
-            make_type_map_entry<std::integral_constant<int, 2>, std::uint8_t>(2),
-            make_type_map_entry<std::integral_constant<int, 3>, std::uint8_t>(3),
-            make_type_map_entry<std::integral_constant<int, 4>, std::uint8_t>(4),
-        };
-        constexpr type_map hasColorAttributeMap {
-            make_type_map_entry<std::integral_constant<int, 0>, std::uint8_t>(0),
-            make_type_map_entry<std::integral_constant<int, 1>, std::uint8_t>(1),
-        };
-        constexpr type_map fragmentShaderGeneratedTBNMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
-            return shader::primitive_vert<Is...>;
-        }, texcoordCountMap.get_variant(texcoordCount), hasColorAttributeMap.get_variant(hasColorAttribute), fragmentShaderGeneratedTBNMap.get_variant(fragmentShaderGeneratedTBN));
+    [[nodiscard]] std::span<const unsigned int> primitive_vert(int TEXCOORD_COUNT, int HAS_COLOR_ATTRIBUTE, int FRAGMENT_SHADER_GENERATED_TBN) {
+        constexpr iota_map<5> texcoordCountMap;
+        constexpr iota_map<2> hasColorAttributeMap;
+        constexpr iota_map<2> fragmentShaderGeneratedTBNMap;
+        return std::visit(
+            [](auto ...Is) -> std::span<const unsigned int> {
+                return shader::primitive_vert<Is...>;
+            },
+            texcoordCountMap.get_variant(TEXCOORD_COUNT),
+            hasColorAttributeMap.get_variant(HAS_COLOR_ATTRIBUTE),
+            fragmentShaderGeneratedTBNMap.get_variant(FRAGMENT_SHADER_GENERATED_TBN));
     }
 }

--- a/interface/shader_selector/unlit_primitive_frag.cppm
+++ b/interface/shader_selector/unlit_primitive_frag.cppm
@@ -7,22 +7,16 @@ import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> unlit_primitive_frag(bool hasBaseColorTexture, bool hasColorAttribute, fastgltf::AlphaMode alphaMode) {
-        constexpr type_map hasBaseColorTextureMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        constexpr type_map hasColorAttributeMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        constexpr type_map alphaModeMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(fastgltf::AlphaMode::Opaque),
-            make_type_map_entry<std::integral_constant<int, 1>>(fastgltf::AlphaMode::Mask),
-            make_type_map_entry<std::integral_constant<int, 2>>(fastgltf::AlphaMode::Blend),
-        };
-        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
-            return shader::unlit_primitive_frag<Is...>;
-        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAttributeMap.get_variant(hasColorAttribute), alphaModeMap.get_variant(alphaMode));
+    [[nodiscard]] std::span<const unsigned int> unlit_primitive_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ATTRIBUTE, int ALPHA_MODE) {
+        constexpr iota_map<2> hasBaseColorTextureMap;
+        constexpr iota_map<2> hasColorAttributeMap;
+        constexpr iota_map<3> alphaModeMap;
+        return std::visit(
+            [](auto... Is) -> std::span<const unsigned int> {
+                return shader::unlit_primitive_frag<Is...>;
+            },
+            hasBaseColorTextureMap.get_variant(HAS_BASE_COLOR_TEXTURE),
+            hasColorAttributeMap.get_variant(HAS_COLOR_ATTRIBUTE),
+            alphaModeMap.get_variant(ALPHA_MODE));
     }
 }

--- a/interface/shader_selector/unlit_primitive_vert.cppm
+++ b/interface/shader_selector/unlit_primitive_vert.cppm
@@ -7,17 +7,14 @@ import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> unlit_primitive_vert(bool hasBaseColorTexture, bool hasColorAttribute) {
-        constexpr type_map hasBaseColorTextureMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        constexpr type_map hasColorAttributeMap {
-            make_type_map_entry<std::integral_constant<int, 0>>(false),
-            make_type_map_entry<std::integral_constant<int, 1>>(true),
-        };
-        return std::visit([]<int... Is>(std::type_identity<std::integral_constant<int, Is>>...) -> std::span<const unsigned int> {
-            return shader::unlit_primitive_vert<Is...>;
-        }, hasBaseColorTextureMap.get_variant(hasBaseColorTexture), hasColorAttributeMap.get_variant(hasColorAttribute));
+    [[nodiscard]] std::span<const unsigned int> unlit_primitive_vert(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ATTRIBUTE) {
+        constexpr iota_map<2> hasBaseColorTextureMap;
+        constexpr iota_map<2> hasColorAttributeMap;
+        return std::visit(
+            [](auto... Is) -> std::span<const unsigned int> {
+                return shader::unlit_primitive_vert<Is...>;
+            },
+            hasBaseColorTextureMap.get_variant(HAS_BASE_COLOR_TEXTURE),
+            hasColorAttributeMap.get_variant(HAS_COLOR_ATTRIBUTE));
     }
 }

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -28,38 +28,6 @@ namespace vk_gltf_viewer::vulkan {
         const Gpu &gpu;
 
     public:
-        struct MaskDepthPipelineKey {
-            std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
-            std::optional<fastgltf::ComponentType> colorAlphaComponentType;
-
-            [[nodiscard]] bool operator==(const MaskDepthPipelineKey&) const noexcept = default;
-        };
-
-        struct MaskJumpFloodSeedPipelineKey {
-            std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
-            std::optional<fastgltf::ComponentType> colorAlphaComponentType;
-
-            [[nodiscard]] bool operator==(const MaskJumpFloodSeedPipelineKey&) const noexcept = default;
-        };
-
-        struct PrimitivePipelineKey {
-            boost::container::static_vector<fastgltf::ComponentType, 4> texcoordComponentTypes;
-            std::optional<std::pair<std::uint32_t, fastgltf::ComponentType>> colorComponentCountAndType;
-            bool fragmentShaderGeneratedTBN;
-            TextureTransform textureTransform;
-            fastgltf::AlphaMode alphaMode;
-
-            [[nodiscard]] bool operator==(const PrimitivePipelineKey&) const noexcept = default;
-        };
-
-        struct UnlitPrimitivePipelineKey {
-            std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
-            std::optional<std::pair<std::uint32_t, fastgltf::ComponentType>> colorComponentCountAndType;
-            fastgltf::AlphaMode alphaMode;
-
-            [[nodiscard]] bool operator==(const UnlitPrimitivePipelineKey&) const noexcept = default;
-        };
-
         // --------------------
         // Non-owning swapchain resources.
         // --------------------
@@ -139,12 +107,9 @@ namespace vk_gltf_viewer::vulkan {
             return *depthRenderer;
         }
 
-        [[nodiscard]] vk::Pipeline getMaskDepthRenderer(const MaskDepthPipelineKey &key) const {
-            return ranges::try_emplace_if_not_exists(maskDepthPipelines, key, [&]() {
-                return createMaskDepthRenderer(
-                    gpu.device, primitiveNoShadingPipelineLayout,
-                    key.baseColorTexcoordComponentType,
-                    key.colorAlphaComponentType);
+        [[nodiscard]] vk::Pipeline getMaskDepthRenderer(const MaskDepthRendererSpecialization &specialization) const {
+            return ranges::try_emplace_if_not_exists(maskDepthPipelines, specialization, [&]() {
+                return specialization.createPipeline(gpu.device, primitiveNoShadingPipelineLayout);
             }).first->second;
         }
 
@@ -155,34 +120,21 @@ namespace vk_gltf_viewer::vulkan {
             return *jumpFloodSeedRenderer;
         }
 
-        [[nodiscard]] vk::Pipeline getMaskJumpFloodSeedRenderer(const MaskJumpFloodSeedPipelineKey &key) const {
-            return ranges::try_emplace_if_not_exists(maskJumpFloodSeedPipelines, key, [&]() {
-                return createMaskJumpFloodSeedRenderer(
-                    gpu.device, primitiveNoShadingPipelineLayout,
-                    key.baseColorTexcoordComponentType,
-                    key.colorAlphaComponentType);
+        [[nodiscard]] vk::Pipeline getMaskJumpFloodSeedRenderer(const MaskJumpFloodSeedRendererSpecialization &specialization) const {
+            return ranges::try_emplace_if_not_exists(maskJumpFloodSeedPipelines, specialization, [&]() {
+                return specialization.createPipeline(gpu.device, primitiveNoShadingPipelineLayout);
             }).first->second;
         }
 
-        [[nodiscard]] vk::Pipeline getPrimitiveRenderer(const PrimitivePipelineKey &key) const {
-            return ranges::try_emplace_if_not_exists(primitivePipelines, key, [&]() {
-                return createPrimitiveRenderer(
-                    gpu.device, primitivePipelineLayout, sceneRenderPass,
-                    key.texcoordComponentTypes,
-                    key.colorComponentCountAndType,
-                    key.fragmentShaderGeneratedTBN,
-                    key.textureTransform,
-                    key.alphaMode);
+        [[nodiscard]] vk::Pipeline getPrimitiveRenderer(const PrimitiveRendererSpecialization &specialization) const {
+            return ranges::try_emplace_if_not_exists(primitivePipelines, specialization, [&]() {
+                return specialization.createPipeline(gpu.device, primitivePipelineLayout, sceneRenderPass);
             }).first->second;
         }
 
-        [[nodiscard]] vk::Pipeline getUnlitPrimitiveRenderer(const UnlitPrimitivePipelineKey &key) const {
-            return ranges::try_emplace_if_not_exists(unlitPrimitivePipelines, key, [&]() {
-                return createUnlitPrimitiveRenderer(
-                    gpu.device, primitivePipelineLayout, sceneRenderPass,
-                    key.baseColorTexcoordComponentType,
-                    key.colorComponentCountAndType,
-                    key.alphaMode);
+        [[nodiscard]] vk::Pipeline getUnlitPrimitiveRenderer(const UnlitPrimitiveRendererSpecialization &specialization) const {
+            return ranges::try_emplace_if_not_exists(unlitPrimitivePipelines, specialization, [&]() {
+                return specialization.createPipeline(gpu.device, primitivePipelineLayout, sceneRenderPass);
             }).first->second;
         }
 
@@ -228,11 +180,11 @@ namespace vk_gltf_viewer::vulkan {
 
         // glTF primitive rendering pipelines.
         mutable std::optional<vk::raii::Pipeline> depthRenderer;
-        mutable std::unordered_map<MaskDepthPipelineKey, vk::raii::Pipeline, AggregateHasher> maskDepthPipelines;
+        mutable std::unordered_map<MaskDepthRendererSpecialization, vk::raii::Pipeline, AggregateHasher> maskDepthPipelines;
         mutable std::optional<vk::raii::Pipeline> jumpFloodSeedRenderer;
-        mutable std::unordered_map<MaskJumpFloodSeedPipelineKey, vk::raii::Pipeline, AggregateHasher> maskJumpFloodSeedPipelines;
-        mutable std::unordered_map<PrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher> primitivePipelines;
-        mutable std::unordered_map<UnlitPrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher> unlitPrimitivePipelines;
+        mutable std::unordered_map<MaskJumpFloodSeedRendererSpecialization, vk::raii::Pipeline, AggregateHasher> maskJumpFloodSeedPipelines;
+        mutable std::unordered_map<PrimitiveRendererSpecialization, vk::raii::Pipeline, AggregateHasher> primitivePipelines;
+        mutable std::unordered_map<UnlitPrimitiveRendererSpecialization, vk::raii::Pipeline, AggregateHasher> unlitPrimitivePipelines;
 
         [[nodiscard]] std::variant<ag::Swapchain, std::reference_wrapper<ag::Swapchain>> getImGuiSwapchainAttachmentGroup() {
             if (gpu.supportSwapchainMutableFormat) {

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -228,11 +228,11 @@ namespace vk_gltf_viewer::vulkan {
 
         // glTF primitive rendering pipelines.
         mutable std::optional<vk::raii::Pipeline> depthRenderer;
-        mutable std::unordered_map<MaskDepthPipelineKey, vk::raii::Pipeline, AggregateHasher<2>> maskDepthPipelines;
+        mutable std::unordered_map<MaskDepthPipelineKey, vk::raii::Pipeline, AggregateHasher> maskDepthPipelines;
         mutable std::optional<vk::raii::Pipeline> jumpFloodSeedRenderer;
-        mutable std::unordered_map<MaskJumpFloodSeedPipelineKey, vk::raii::Pipeline, AggregateHasher<2>> maskJumpFloodSeedPipelines;
-        mutable std::unordered_map<PrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher<5>> primitivePipelines;
-        mutable std::unordered_map<UnlitPrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher<3>> unlitPrimitivePipelines;
+        mutable std::unordered_map<MaskJumpFloodSeedPipelineKey, vk::raii::Pipeline, AggregateHasher> maskJumpFloodSeedPipelines;
+        mutable std::unordered_map<PrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher> primitivePipelines;
+        mutable std::unordered_map<UnlitPrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher> unlitPrimitivePipelines;
 
         [[nodiscard]] std::variant<ag::Swapchain, std::reference_wrapper<ag::Swapchain>> getImGuiSwapchainAttachmentGroup() {
             if (gpu.supportSwapchainMutableFormat) {

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -46,6 +46,7 @@ namespace vk_gltf_viewer::vulkan {
             boost::container::static_vector<fastgltf::ComponentType, 4> texcoordComponentTypes;
             std::optional<std::pair<std::uint32_t, fastgltf::ComponentType>> colorComponentCountAndType;
             bool fragmentShaderGeneratedTBN;
+            TextureTransform textureTransform;
             fastgltf::AlphaMode alphaMode;
 
             [[nodiscard]] bool operator==(const PrimitivePipelineKey&) const noexcept = default;
@@ -170,6 +171,7 @@ namespace vk_gltf_viewer::vulkan {
                     key.texcoordComponentTypes,
                     key.colorComponentCountAndType,
                     key.fragmentShaderGeneratedTBN,
+                    key.textureTransform,
                     key.alphaMode);
             }).first->second;
         }
@@ -229,7 +231,7 @@ namespace vk_gltf_viewer::vulkan {
         mutable std::unordered_map<MaskDepthPipelineKey, vk::raii::Pipeline, AggregateHasher<2>> maskDepthPipelines;
         mutable std::optional<vk::raii::Pipeline> jumpFloodSeedRenderer;
         mutable std::unordered_map<MaskJumpFloodSeedPipelineKey, vk::raii::Pipeline, AggregateHasher<2>> maskJumpFloodSeedPipelines;
-        mutable std::unordered_map<PrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher<4>> primitivePipelines;
+        mutable std::unordered_map<PrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher<5>> primitivePipelines;
         mutable std::unordered_map<UnlitPrimitivePipelineKey, vk::raii::Pipeline, AggregateHasher<3>> unlitPrimitivePipelines;
 
         [[nodiscard]] std::variant<ag::Swapchain, std::reference_wrapper<ag::Swapchain>> getImGuiSwapchainAttachmentGroup() {

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -1,7 +1,3 @@
-module;
-
-#include <cstddef>
-
 export module vk_gltf_viewer:vulkan.pipeline.DepthRenderer;
 
 import std;
@@ -11,8 +7,94 @@ import :shader.depth_frag;
 import :shader_selector.mask_depth_vert;
 import :shader_selector.mask_depth_frag;
 export import :vulkan.pl.PrimitiveNoShading;
+import :vulkan.specialization_constants.SpecializationMap;
+
+#define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+#define LIFT(...) [&](auto &&...xs) { return __VA_ARGS__(FWD(xs)...); }
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
+    class MaskDepthRendererSpecialization {
+    public:
+        std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
+        std::optional<fastgltf::ComponentType> colorAlphaComponentType;
+
+        [[nodiscard]] bool operator==(const MaskDepthRendererSpecialization&) const = default;
+
+        [[nodiscard]] vk::raii::Pipeline createPipeline(
+            const vk::raii::Device &device,
+            const pl::PrimitiveNoShading &pipelineLayout
+        ) const {
+            return { device, nullptr, vk::StructureChain {
+                vku::getDefaultGraphicsPipelineCreateInfo(
+                    createPipelineStages(
+                        device,
+                        vku::Shader {
+                            std::apply(LIFT(shader_selector::mask_depth_vert), getVertexShaderVariants()),
+                            vk::ShaderStageFlagBits::eVertex,
+                            vku::unsafeAddress(vk::SpecializationInfo {
+                                SpecializationMap<VertexShaderSpecializationData>::value,
+                                vku::unsafeProxy(getVertexShaderSpecializationData()),
+                            }),
+                        },
+                        vku::Shader {
+                            std::apply(LIFT(shader_selector::mask_depth_frag), getFragmentShaderVariants()),
+                            vk::ShaderStageFlagBits::eFragment,
+                        }).get(),
+                    *pipelineLayout, 1, true)
+                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                        {},
+                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                    }))
+                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                        {},
+                        vku::unsafeProxy({
+                            vk::DynamicState::eViewport,
+                            vk::DynamicState::eScissor,
+                            vk::DynamicState::eCullMode,
+                        }),
+                    })),
+                vk::PipelineRenderingCreateInfo {
+                    {},
+                    vku::unsafeProxy(vk::Format::eR16Uint),
+                    vk::Format::eD32Sfloat,
+                }
+            }.get() };
+        }
+
+    private:
+        struct VertexShaderSpecializationData {
+            std::uint32_t texcoordComponentType = 5126; // FLOAT
+            std::uint32_t colorComponentType = 5126; // FLOAT
+        };
+
+        [[nodiscard]] std::array<int, 2> getVertexShaderVariants() const noexcept {
+            return {
+                baseColorTexcoordComponentType.has_value(),
+                colorAlphaComponentType.has_value(),
+            };
+        }
+
+        [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
+            VertexShaderSpecializationData result{};
+
+            if (baseColorTexcoordComponentType) {
+                result.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
+            }
+            if (colorAlphaComponentType) {
+                result.colorComponentType = getGLComponentType(*colorAlphaComponentType);
+            }
+
+            return result;
+        }
+
+        [[nodiscard]] std::array<int, 2> getFragmentShaderVariants() const noexcept {
+            return {
+                baseColorTexcoordComponentType.has_value(),
+                colorAlphaComponentType.has_value(),
+            };
+        }
+    };
+
     [[nodiscard]] vk::raii::Pipeline createDepthRenderer(
         const vk::raii::Device &device,
         const pl::PrimitiveNoShading &pipelineLayout
@@ -41,77 +123,6 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 vku::unsafeProxy(vk::Format::eR16Uint),
                 vk::Format::eD32Sfloat,
             }
-        }.get() };
-    }
-
-    [[nodiscard]] vk::raii::Pipeline createMaskDepthRenderer(
-        const vk::raii::Device &device,
-        const pl::PrimitiveNoShading &pipelineLayout,
-        const std::optional<fastgltf::ComponentType> &baseColorTexcoordComponentType,
-        const std::optional<fastgltf::ComponentType> &colorAlphaComponentType
-    ) {
-        struct VertexShaderSpecializationData {
-            std::uint32_t texcoordComponentType = 5126; // FLOAT
-            std::uint32_t colorComponentType = 5126; // FLOAT
-        } vertexShaderSpecializationData{};
-
-        if (baseColorTexcoordComponentType) {
-            vertexShaderSpecializationData.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
-        }
-
-        if (colorAlphaComponentType) {
-            vertexShaderSpecializationData.colorComponentType = getGLComponentType(*colorAlphaComponentType);
-        }
-
-        return { device, nullptr, vk::StructureChain {
-            vku::getDefaultGraphicsPipelineCreateInfo(
-                createPipelineStages(
-                    device,
-                    vku::Shader {
-                        shader_selector::mask_depth_vert(
-                            baseColorTexcoordComponentType.has_value(),
-                            colorAlphaComponentType.has_value()),
-                        vk::ShaderStageFlagBits::eVertex,
-                        vku::unsafeAddress(vk::SpecializationInfo {
-                            vku::unsafeProxy({
-                                vk::SpecializationMapEntry {
-                                    0,
-                                    offsetof(VertexShaderSpecializationData, texcoordComponentType),
-                                    sizeof(VertexShaderSpecializationData::texcoordComponentType),
-                                },
-                                vk::SpecializationMapEntry {
-                                    0,
-                                    offsetof(VertexShaderSpecializationData, colorComponentType),
-                                    sizeof(VertexShaderSpecializationData::colorComponentType),
-                                },
-                            }),
-                            vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
-                        }),
-                    },
-                    vku::Shader {
-                        shader_selector::mask_depth_frag(
-                            baseColorTexcoordComponentType.has_value(),
-                            colorAlphaComponentType.has_value()),
-                        vk::ShaderStageFlagBits::eFragment,
-                    }).get(),
-                *pipelineLayout, 1, true)
-                .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                    {},
-                    true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                }))
-                .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                    {},
-                    vku::unsafeProxy({
-                        vk::DynamicState::eViewport,
-                        vk::DynamicState::eScissor,
-                        vk::DynamicState::eCullMode,
-                    }),
-                })),
-            vk::PipelineRenderingCreateInfo {
-                    {},
-                    vku::unsafeProxy(vk::Format::eR16Uint),
-                    vk::Format::eD32Sfloat,
-                }
         }.get() };
     }
 }

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -7,6 +7,7 @@ import :shader.depth_frag;
 import :shader_selector.mask_depth_vert;
 import :shader_selector.mask_depth_frag;
 export import :vulkan.pl.PrimitiveNoShading;
+import :vulkan.shader_type.TextureTransform;
 import :vulkan.specialization_constants.SpecializationMap;
 
 #define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
@@ -17,6 +18,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
         std::optional<fastgltf::ComponentType> colorAlphaComponentType;
+        shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
 
         [[nodiscard]] bool operator==(const MaskDepthRendererSpecialization&) const = default;
 
@@ -39,6 +41,10 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                         vku::Shader {
                             std::apply(LIFT(shader_selector::mask_depth_frag), getFragmentShaderVariants()),
                             vk::ShaderStageFlagBits::eFragment,
+                            vku::unsafeAddress(vk::SpecializationInfo {
+                                SpecializationMap<FragmentShaderSpecializationData>::value,
+                                vku::unsafeProxy(getFragmentShaderSpecializationData()),
+                            }),
                         }).get(),
                     *pipelineLayout, 1, true)
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
@@ -67,6 +73,10 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             std::uint32_t colorComponentType = 5126; // FLOAT
         };
 
+        struct FragmentShaderSpecializationData {
+            std::uint32_t textureTransformType = 0x00000; // NONE
+        };
+
         [[nodiscard]] std::array<int, 2> getVertexShaderVariants() const noexcept {
             return {
                 baseColorTexcoordComponentType.has_value(),
@@ -92,6 +102,14 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 baseColorTexcoordComponentType.has_value(),
                 colorAlphaComponentType.has_value(),
             };
+        }
+
+        [[nodiscard]] FragmentShaderSpecializationData getFragmentShaderSpecializationData() const {
+            FragmentShaderSpecializationData result{};
+            if (baseColorTextureTransform != shader_type::TextureTransform::None) {
+                result.textureTransformType = static_cast<std::uint32_t>(baseColorTextureTransform);
+            }
+            return result;
         }
     };
 

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -1,7 +1,3 @@
-module;
-
-#include <cstddef>
-
 export module vk_gltf_viewer:vulkan.pipeline.JumpFloodSeedRenderer;
 
 import std;
@@ -11,10 +7,94 @@ import :shader.jump_flood_seed_frag;
 import :shader_selector.mask_jump_flood_seed_vert;
 import :shader_selector.mask_jump_flood_seed_frag;
 export import :vulkan.pl.PrimitiveNoShading;
+import :vulkan.specialization_constants.SpecializationMap;
 
+#define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 #define LIFT(...) [&](auto &&...xs) { return __VA_ARGS__(FWD(xs)...); }
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
+    class MaskJumpFloodSeedRendererSpecialization {
+    public:
+        std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
+        std::optional<fastgltf::ComponentType> colorAlphaComponentType;
+
+        [[nodiscard]] bool operator==(const MaskJumpFloodSeedRendererSpecialization&) const = default;
+
+        [[nodiscard]] vk::raii::Pipeline createPipeline(
+            const vk::raii::Device &device,
+            const pl::PrimitiveNoShading &pipelineLayout
+        ) const {
+            return { device, nullptr, vk::StructureChain {
+                vku::getDefaultGraphicsPipelineCreateInfo(
+                    createPipelineStages(
+                        device,
+                        vku::Shader {
+                            std::apply(LIFT(shader_selector::mask_jump_flood_seed_vert), getVertexShaderVariants()),
+                            vk::ShaderStageFlagBits::eVertex,
+                            vku::unsafeAddress(vk::SpecializationInfo {
+                                SpecializationMap<VertexShaderSpecializationData>::value,
+                                vku::unsafeProxy(getVertexShaderSpecializationData()),
+                            }),
+                        },
+                        vku::Shader {
+                            std::apply(LIFT(shader_selector::mask_jump_flood_seed_frag), getFragmentShaderVariants()),
+                            vk::ShaderStageFlagBits::eFragment,
+                        }).get(),
+                    *pipelineLayout, 1, true)
+                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                        {},
+                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                    }))
+                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                        {},
+                        vku::unsafeProxy({
+                            vk::DynamicState::eViewport,
+                            vk::DynamicState::eScissor,
+                            vk::DynamicState::eCullMode,
+                        }),
+                    })),
+                vk::PipelineRenderingCreateInfo {
+                    {},
+                    vku::unsafeProxy(vk::Format::eR16G16Uint),
+                    vk::Format::eD32Sfloat,
+                }
+            }.get() };
+        }
+
+    private:
+        struct VertexShaderSpecializationData {
+            std::uint32_t texcoordComponentType = 5126; // FLOAT
+            std::uint32_t colorComponentType = 5126; // FLOAT
+        };
+
+        [[nodiscard]] std::array<int, 2> getVertexShaderVariants() const noexcept {
+            return {
+                baseColorTexcoordComponentType.has_value(),
+                colorAlphaComponentType.has_value(),
+            };
+        }
+
+        [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
+            VertexShaderSpecializationData result{};
+
+            if (baseColorTexcoordComponentType) {
+                result.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
+            }
+            if (colorAlphaComponentType) {
+                result.colorComponentType = getGLComponentType(*colorAlphaComponentType);
+            }
+
+            return result;
+        }
+
+        [[nodiscard]] std::array<int, 2> getFragmentShaderVariants() const noexcept {
+            return {
+                baseColorTexcoordComponentType.has_value(),
+                colorAlphaComponentType.has_value(),
+            };
+        }
+    };
+    
     [[nodiscard]] vk::raii::Pipeline createJumpFloodSeedRenderer(
         const vk::raii::Device &device,
         const pl::PrimitiveNoShading &pipelineLayout
@@ -25,77 +105,6 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     device,
                     vku::Shader { shader::jump_flood_seed_vert, vk::ShaderStageFlagBits::eVertex },
                     vku::Shader { shader::jump_flood_seed_frag, vk::ShaderStageFlagBits::eFragment }).get(),
-                *pipelineLayout, 1, true)
-                .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                    {},
-                    true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                }))
-                .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                    {},
-                    vku::unsafeProxy({
-                        vk::DynamicState::eViewport,
-                        vk::DynamicState::eScissor,
-                        vk::DynamicState::eCullMode,
-                    }),
-                })),
-            vk::PipelineRenderingCreateInfo {
-                {},
-                vku::unsafeProxy(vk::Format::eR16G16Uint),
-                vk::Format::eD32Sfloat,
-            }
-        }.get() };
-    }
-
-    [[nodiscard]] vk::raii::Pipeline createMaskJumpFloodSeedRenderer(
-        const vk::raii::Device &device,
-        const pl::PrimitiveNoShading &pipelineLayout,
-        const std::optional<fastgltf::ComponentType> &baseColorTexcoordComponentType,
-        const std::optional<fastgltf::ComponentType> &colorAlphaComponentType
-    ) {
-        struct VertexShaderSpecializationData {
-            std::uint32_t texcoordComponentType = 5126; // FLOAT
-            std::uint32_t colorComponentType = 5126; // FLOAT
-        } vertexShaderSpecializationData{};
-
-        if (baseColorTexcoordComponentType) {
-            vertexShaderSpecializationData.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
-        }
-
-        if (colorAlphaComponentType) {
-            vertexShaderSpecializationData.colorComponentType = getGLComponentType(*colorAlphaComponentType);
-        }
-
-        return { device, nullptr, vk::StructureChain {
-            vku::getDefaultGraphicsPipelineCreateInfo(
-                createPipelineStages(
-                    device,
-                    vku::Shader {
-                        shader_selector::mask_jump_flood_seed_vert(
-                            baseColorTexcoordComponentType.has_value(),
-                            colorAlphaComponentType.has_value()),
-                        vk::ShaderStageFlagBits::eVertex,
-                        vku::unsafeAddress(vk::SpecializationInfo {
-                            vku::unsafeProxy({
-                                vk::SpecializationMapEntry {
-                                    0,
-                                    offsetof(VertexShaderSpecializationData, texcoordComponentType),
-                                    sizeof(VertexShaderSpecializationData::texcoordComponentType),
-                                },
-                                vk::SpecializationMapEntry {
-                                    0,
-                                    offsetof(VertexShaderSpecializationData, colorComponentType),
-                                    sizeof(VertexShaderSpecializationData::colorComponentType),
-                                },
-                            }),
-                            vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
-                        }),
-                    },
-                    vku::Shader {
-                        shader_selector::mask_jump_flood_seed_frag(
-                            baseColorTexcoordComponentType.has_value(),
-                            colorAlphaComponentType.has_value()),
-                        vk::ShaderStageFlagBits::eFragment,
-                    }).get(),
                 *pipelineLayout, 1, true)
                 .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                     {},

--- a/interface/vulkan/pipeline/PrefilteredmapComputer.cppm
+++ b/interface/vulkan/pipeline/PrefilteredmapComputer.cppm
@@ -1,7 +1,5 @@
 module;
 
-#include <cstddef>
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vk_gltf_viewer:vulkan.pipeline.PrefilteredmapComputer;
@@ -10,6 +8,7 @@ import std;
 import :math.extended_arithmetic;
 import :shader.prefilteredmap_comp;
 export import :vulkan.Gpu;
+import :vulkan.specialization_constants.SpecializationMap;
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class PrefilteredmapComputer {
@@ -77,10 +76,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                             : std::span<const std::uint32_t> { shader::prefilteredmap_comp<0> },
                         vk::ShaderStageFlagBits::eCompute,
                         vku::unsafeAddress(vk::SpecializationInfo {
-                            vku::unsafeProxy({
-                                vk::SpecializationMapEntry { 0, offsetof(SpecializationConstants, roughnessLevels), sizeof(SpecializationConstants::roughnessLevels) },
-                                vk::SpecializationMapEntry { 1, offsetof(SpecializationConstants, samples), sizeof(SpecializationConstants::samples) },
-                            }),
+                            SpecializationMap<SpecializationConstants>::value,
                             vk::ArrayProxyNoTemporaries<const SpecializationConstants>(specializationConstants),
                         }),
                     }).get()[0],

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -1,7 +1,6 @@
 module;
 
 #include <cassert>
-#include <cstddef>
 
 #include <boost/container/static_vector.hpp>
 #include <boost/container_hash/hash.hpp>
@@ -16,254 +15,251 @@ import :shader_selector.primitive_vert;
 import :shader_selector.primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
+import :vulkan.specialization_constants.SpecializationMap;
+
+#define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+#define LIFT(...) [&](auto &&...xs) { return __VA_ARGS__(FWD(xs)...); }
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
-    export struct TextureTransform {
-        enum class Type : std::uint8_t {
+    export class PrimitiveRendererSpecialization {
+    public:
+        enum class TextureTransform : std::uint8_t {
+            /**
+             * @brief No texture transform is performed.
+             *
+             * When the primitive's material textures don't have any KHR_texture_transform extensions, use this value to
+             * avoid the unnecessary matrix-vector multiplication in the fragment shader.
+             */
             None = 0,
+            /**
+             * @brief Texture transform has scale and offset component.
+             *
+             * This is more efficient than <tt>All</tt> because this transform can be done by multiply-and-add (MAD) operation
+             * in fragment shader.
+             */
             ScaleAndOffset = 1,
+            /**
+             * @brief Texture transform has rotation component.
+             *
+             * Avoid it if possible, because it takes more instructions than <tt>ScaleAndOffset</tt>.
+             */
             All = 2,
         };
 
-        Type baseColor = Type::None;
-        Type metallicRoughness = Type::None;
-        Type normal = Type::None;
-        Type occlusion = Type::None;
-        Type emissive = Type::None;
+        boost::container::static_vector<fastgltf::ComponentType, 4> texcoordComponentTypes;
+        std::optional<std::pair<std::uint8_t, fastgltf::ComponentType>> colorComponentCountAndType;
+        bool fragmentShaderGeneratedTBN;
+        TextureTransform baseColorTextureTransform = TextureTransform::None;
+        TextureTransform metallicRoughnessTextureTransform = TextureTransform::None;
+        TextureTransform normalTextureTransform = TextureTransform::None;
+        TextureTransform occlusionTextureTransform = TextureTransform::None;
+        TextureTransform emissiveTextureTransform = TextureTransform::None;
+        fastgltf::AlphaMode alphaMode;
 
-        [[nodiscard]] bool operator==(const TextureTransform&) const noexcept = default;
+        [[nodiscard]] bool operator==(const PrimitiveRendererSpecialization&) const noexcept = default;
 
-        // For boost::hash_combine.
-        [[nodiscard]] friend std::size_t hash_value(const TextureTransform &v) {
-            std::size_t seed = 0;
-            boost::hash_combine(seed, std::to_underlying(v.baseColor));
-            boost::hash_combine(seed, std::to_underlying(v.metallicRoughness));
-            boost::hash_combine(seed, std::to_underlying(v.normal));
-            boost::hash_combine(seed, std::to_underlying(v.occlusion));
-            boost::hash_combine(seed, std::to_underlying(v.emissive));
-            return seed;
+        [[nodiscard]] vk::raii::Pipeline createPipeline(
+            const vk::raii::Device &device,
+            const pl::Primitive &pipelineLayout,
+            const rp::Scene &sceneRenderPass
+        ) const {
+            const auto vertexShaderSpecializationData = getVertexShaderSpecializationData();
+            const auto fragmentShaderSpecializationData = getFragmentShaderSpecializationData();
+            const vku::RefHolder pipelineStages = createPipelineStages(
+                device,
+                vku::Shader {
+                    std::apply(LIFT(shader_selector::primitive_vert), getVertexShaderVariants()),
+                    vk::ShaderStageFlagBits::eVertex,
+                    vku::unsafeAddress(vk::SpecializationInfo {
+                        SpecializationMap<VertexShaderSpecializationData>::value,
+                        vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
+                    }),
+                },
+                vku::Shader {
+                    std::apply(LIFT(shader_selector::primitive_frag), getFragmentShaderVariants()),
+                    vk::ShaderStageFlagBits::eFragment,
+                    vku::unsafeAddress(vk::SpecializationInfo {
+                        SpecializationMap<FragmentShaderSpecializationData>::value,
+                        vk::ArrayProxyNoTemporaries<const FragmentShaderSpecializationData> { fragmentShaderSpecializationData },
+                    }),
+                });
+
+            switch (alphaMode) {
+                case fastgltf::AlphaMode::Opaque:
+                    return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
+                        pipelineStages.get(), *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
+                        .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                            {},
+                            true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                        }))
+                        .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                            {},
+                            vku::unsafeProxy({
+                                vk::DynamicState::eViewport,
+                                vk::DynamicState::eScissor,
+                                vk::DynamicState::eCullMode,
+                            }),
+                        }))
+                        .setRenderPass(*sceneRenderPass)
+                        .setSubpass(0)
+                    };
+                case fastgltf::AlphaMode::Mask:
+                    return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
+                        pipelineStages.get(), *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
+                        .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                            {},
+                            true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                        }))
+                        .setPMultisampleState(vku::unsafeAddress(vk::PipelineMultisampleStateCreateInfo {
+                            {},
+                            vk::SampleCountFlagBits::e4,
+                            {}, {}, {},
+                            true,
+                        }))
+                        .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                            {},
+                            vku::unsafeProxy({
+                                vk::DynamicState::eViewport,
+                                vk::DynamicState::eScissor,
+                                vk::DynamicState::eCullMode,
+                            }),
+                        }))
+                        .setRenderPass(*sceneRenderPass)
+                        .setSubpass(0)
+                    };
+                case fastgltf::AlphaMode::Blend:
+                    return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
+                        pipelineStages.get(), *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
+                        .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
+                            {},
+                            false, false,
+                            vk::PolygonMode::eFill,
+                            // Translucent objects' back faces shouldn't be culled.
+                            vk::CullModeFlagBits::eNone, {},
+                            false, {}, {}, {},
+                            1.f,
+                        }))
+                        .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                            {},
+                            // Translucent objects shouldn't interfere with the pre-rendered depth buffer. Use reverse Z.
+                            true, false, vk::CompareOp::eGreater,
+                        }))
+                        .setPColorBlendState(vku::unsafeAddress(vk::PipelineColorBlendStateCreateInfo {
+                            {},
+                            false, {},
+                            vku::unsafeProxy({
+                                vk::PipelineColorBlendAttachmentState {
+                                    true,
+                                    vk::BlendFactor::eOne, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
+                                    vk::BlendFactor::eOne, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
+                                    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA,
+                                },
+                                vk::PipelineColorBlendAttachmentState {
+                                    true,
+                                    vk::BlendFactor::eZero, vk::BlendFactor::eOneMinusSrcColor, vk::BlendOp::eAdd,
+                                    vk::BlendFactor::eZero, vk::BlendFactor::eOneMinusSrcAlpha, vk::BlendOp::eAdd,
+                                    vk::ColorComponentFlagBits::eR,
+                                },
+                            }),
+                            { 1.f, 1.f, 1.f, 1.f },
+                        }))
+                        .setRenderPass(*sceneRenderPass)
+                        .setSubpass(1)
+                    };
+            }
+            std::unreachable();
         }
-    };
 
-    [[nodiscard]] vk::raii::Pipeline createPrimitiveRenderer(
-        const vk::raii::Device &device,
-        const pl::Primitive &pipelineLayout,
-        const rp::Scene &sceneRenderPass,
-        const boost::container::static_vector<fastgltf::ComponentType, 4> &texcoordComponentTypes,
-        const std::optional<std::pair<std::uint8_t, fastgltf::ComponentType>> &colorComponentCountAndType,
-        bool fragmentShaderGeneratedTBN,
-        const TextureTransform &textureTransform,
-        fastgltf::AlphaMode alphaMode
-    ) {
-        // --------------------
-        // Vertex shader specialization constants.
-        // --------------------
-
+    private:
         struct VertexShaderSpecializationData {
             std::uint32_t packedTexcoordComponentTypes = 0x06060606; // [FLOAT, FLOAT, FLOAT, FLOAT]
             std::uint8_t colorComponentCount = 0;
             std::uint32_t colorComponentType = 5126; // FLOAT
-        } vertexShaderSpecializationData{};
-
-        for (auto [i, componentType] : texcoordComponentTypes | ranges::views::enumerate) {
-            assert(ranges::one_of(componentType, fastgltf::ComponentType::UnsignedByte, fastgltf::ComponentType::UnsignedShort, fastgltf::ComponentType::Float));
-
-            /* Change the i-th byte (from LSB) to the componentType - fastgltf::ComponentType::Byte, which can be
-             * represented by the 1-byte integer.
-             *
-             * fastgltf::ComponentType::Byte - fastgltf::ComponentType::Byte = 0
-             * fastgltf::ComponentType::UnsignedByte - fastgltf::ComponentType::Byte = 1
-             * fastgltf::ComponentType::Short - fastgltf::ComponentType::Byte = 2
-             * fastgltf::ComponentType::UnsignedShort - fastgltf::ComponentType::Byte = 3
-             * fastgltf::ComponentType::Int - fastgltf::ComponentType::Byte = 4
-             * fastgltf::ComponentType::UnsignedInt - fastgltf::ComponentType::Byte = 5
-             * fastgltf::ComponentType::Float - fastgltf::ComponentType::Byte = 6
-             * fastgltf::ComponentType::Double - fastgltf::ComponentType::Byte = 10
-             */
-
-            // Step 1: clear the i-th byte (=[8*(i+1):8*i] bits)
-            vertexShaderSpecializationData.packedTexcoordComponentTypes &= ~(0xFFU << (8 * i));
-
-            // Step 2: set the i-th byte to the componentType - fastgltf::ComponentType::Byte
-            vertexShaderSpecializationData.packedTexcoordComponentTypes
-                |= (getGLComponentType(componentType) - getGLComponentType(fastgltf::ComponentType::Byte)) << (8 * i);
-        }
-
-        if (colorComponentCountAndType) {
-            assert(ranges::one_of(colorComponentCountAndType->first, 3, 4));
-            assert(ranges::one_of(colorComponentCountAndType->second, fastgltf::ComponentType::UnsignedByte, fastgltf::ComponentType::UnsignedShort, fastgltf::ComponentType::Float));
-            vertexShaderSpecializationData.colorComponentCount = colorComponentCountAndType->first;
-            vertexShaderSpecializationData.colorComponentType = getGLComponentType(colorComponentCountAndType->second);
-        }
-
-        static constexpr std::array vertexShaderSpecializationMapEntries {
-            vk::SpecializationMapEntry {
-                0,
-                offsetof(VertexShaderSpecializationData, packedTexcoordComponentTypes),
-                sizeof(VertexShaderSpecializationData::packedTexcoordComponentTypes),
-            },
-            vk::SpecializationMapEntry {
-                1,
-                offsetof(VertexShaderSpecializationData, colorComponentCount),
-                sizeof(VertexShaderSpecializationData::colorComponentCount),
-            },
-            vk::SpecializationMapEntry {
-                2,
-                offsetof(VertexShaderSpecializationData, colorComponentType),
-                sizeof(VertexShaderSpecializationData::colorComponentType),
-            },
         };
-
-        const vk::SpecializationInfo vertexShaderSpecializationInfo {
-            vertexShaderSpecializationMapEntries,
-            vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
-        };
-
-        // --------------------
-        // Fragment shader specialization constants.
-        // --------------------
 
         struct FragmentShaderSpecializationData {
-            std::uint32_t packedTextureTransformTypes = 0x00000; // [NONE, NONE, NONE, NONE, NONE]
-        } fragmentShaderSpecializationData{};
-
-        if (textureTransform.baseColor != TextureTransform::Type::None) {
-            fragmentShaderSpecializationData.packedTextureTransformTypes &= ~0xFU;
-            fragmentShaderSpecializationData.packedTextureTransformTypes |= static_cast<std::uint32_t>(textureTransform.baseColor);
-        }
-        if (textureTransform.metallicRoughness != TextureTransform::Type::None) {
-            fragmentShaderSpecializationData.packedTextureTransformTypes &= ~0xF0U;
-            fragmentShaderSpecializationData.packedTextureTransformTypes |= static_cast<std::uint32_t>(textureTransform.metallicRoughness) << 4;
-        }
-        if (textureTransform.normal != TextureTransform::Type::None) {
-            fragmentShaderSpecializationData.packedTextureTransformTypes &= ~0xF00U;
-            fragmentShaderSpecializationData.packedTextureTransformTypes |= static_cast<std::uint32_t>(textureTransform.normal) << 8;
-        }
-        if (textureTransform.occlusion != TextureTransform::Type::None) {
-            fragmentShaderSpecializationData.packedTextureTransformTypes &= ~0xF000U;
-            fragmentShaderSpecializationData.packedTextureTransformTypes |= static_cast<std::uint32_t>(textureTransform.occlusion) << 12;
-        }
-        if (textureTransform.emissive != TextureTransform::Type::None) {
-            fragmentShaderSpecializationData.packedTextureTransformTypes &= ~0xF0000U;
-            fragmentShaderSpecializationData.packedTextureTransformTypes |= static_cast<std::uint32_t>(textureTransform.emissive) << 16;
-        }
-
-        static constexpr std::array fragmentShaderSpecializationMapEntries {
-            vk::SpecializationMapEntry {
-                0,
-                offsetof(FragmentShaderSpecializationData, packedTextureTransformTypes),
-                sizeof(FragmentShaderSpecializationData::packedTextureTransformTypes),
-            },
+            std::uint32_t packedTextureTransformTypes = 0x00000;
         };
 
-        const vk::SpecializationInfo fragmentShaderSpecializationInfo {
-            fragmentShaderSpecializationMapEntries,
-            vk::ArrayProxyNoTemporaries<const FragmentShaderSpecializationData> { fragmentShaderSpecializationData },
-        };
-
-        const vku::RefHolder pipelineStages = createPipelineStages(
-            device,
-            vku::Shader {
-                shader_selector::primitive_vert(
-                    texcoordComponentTypes.size(),
-                    colorComponentCountAndType.has_value(),
-                    fragmentShaderGeneratedTBN),
-                vk::ShaderStageFlagBits::eVertex,
-                &vertexShaderSpecializationInfo,
-            },
-            vku::Shader {
-                shader_selector::primitive_frag(
-                    texcoordComponentTypes.size(),
-                    colorComponentCountAndType.has_value(),
-                    fragmentShaderGeneratedTBN,
-                    alphaMode),
-                vk::ShaderStageFlagBits::eFragment,
-                &fragmentShaderSpecializationInfo,
-            });
-
-        switch (alphaMode) {
-            case fastgltf::AlphaMode::Opaque:
-                return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
-                    pipelineStages.get(), *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                    }))
-                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                        {},
-                        vku::unsafeProxy({
-                            vk::DynamicState::eViewport,
-                            vk::DynamicState::eScissor,
-                            vk::DynamicState::eCullMode,
-                        }),
-                    }))
-                    .setRenderPass(*sceneRenderPass)
-                    .setSubpass(0)
-                };
-            case fastgltf::AlphaMode::Mask:
-                return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
-                    pipelineStages.get(), *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                    }))
-                    .setPMultisampleState(vku::unsafeAddress(vk::PipelineMultisampleStateCreateInfo {
-                        {},
-                        vk::SampleCountFlagBits::e4,
-                        {}, {}, {},
-                        true,
-                    }))
-                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                        {},
-                        vku::unsafeProxy({
-                            vk::DynamicState::eViewport,
-                            vk::DynamicState::eScissor,
-                            vk::DynamicState::eCullMode,
-                        }),
-                    }))
-                    .setRenderPass(*sceneRenderPass)
-                    .setSubpass(0)
-                };
-            case fastgltf::AlphaMode::Blend:
-                return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
-                    pipelineStages.get(), *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
-                    .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
-                        {},
-                        false, false,
-                        vk::PolygonMode::eFill,
-                        // Translucent objects' back faces shouldn't be culled.
-                        vk::CullModeFlagBits::eNone, {},
-                        false, {}, {}, {},
-                        1.f,
-                    }))
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        // Translucent objects shouldn't interfere with the pre-rendered depth buffer. Use reverse Z.
-                        true, false, vk::CompareOp::eGreater,
-                    }))
-                    .setPColorBlendState(vku::unsafeAddress(vk::PipelineColorBlendStateCreateInfo {
-                        {},
-                        false, {},
-                        vku::unsafeProxy({
-                            vk::PipelineColorBlendAttachmentState {
-                                true,
-                                vk::BlendFactor::eOne, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
-                                vk::BlendFactor::eOne, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
-                                vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA,
-                            },
-                            vk::PipelineColorBlendAttachmentState {
-                                true,
-                                vk::BlendFactor::eZero, vk::BlendFactor::eOneMinusSrcColor, vk::BlendOp::eAdd,
-                                vk::BlendFactor::eZero, vk::BlendFactor::eOneMinusSrcAlpha, vk::BlendOp::eAdd,
-                                vk::ColorComponentFlagBits::eR,
-                            },
-                        }),
-                        { 1.f, 1.f, 1.f, 1.f },
-                    }))
-                    .setRenderPass(*sceneRenderPass)
-                    .setSubpass(1)
-                };
+        [[nodiscard]] std::array<int, 3> getVertexShaderVariants() const noexcept {
+            return {
+                static_cast<int>(texcoordComponentTypes.size()),
+                colorComponentCountAndType.has_value(),
+                fragmentShaderGeneratedTBN,
+            };
         }
-        std::unreachable();
-    }
+
+        [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
+            VertexShaderSpecializationData result{};
+
+            for (auto [i, componentType] : texcoordComponentTypes | ranges::views::enumerate) {
+                assert(ranges::one_of(componentType, fastgltf::ComponentType::UnsignedByte, fastgltf::ComponentType::UnsignedShort, fastgltf::ComponentType::Float));
+
+                /* Change the i-th byte (from LSB) to the componentType - fastgltf::ComponentType::Byte, which can be
+                 * represented by the 1-byte integer.
+                 *
+                 * fastgltf::ComponentType::Byte - fastgltf::ComponentType::Byte = 0
+                 * fastgltf::ComponentType::UnsignedByte - fastgltf::ComponentType::Byte = 1
+                 * fastgltf::ComponentType::Short - fastgltf::ComponentType::Byte = 2
+                 * fastgltf::ComponentType::UnsignedShort - fastgltf::ComponentType::Byte = 3
+                 * fastgltf::ComponentType::Int - fastgltf::ComponentType::Byte = 4
+                 * fastgltf::ComponentType::UnsignedInt - fastgltf::ComponentType::Byte = 5
+                 * fastgltf::ComponentType::Float - fastgltf::ComponentType::Byte = 6
+                 * fastgltf::ComponentType::Double - fastgltf::ComponentType::Byte = 10
+                 */
+
+                // Step 1: clear the i-th byte (=[8*(i+1):8*i] bits)
+                result.packedTexcoordComponentTypes &= ~(0xFFU << (8 * i));
+
+                // Step 2: set the i-th byte to the componentType - fastgltf::ComponentType::Byte
+                result.packedTexcoordComponentTypes
+                    |= (getGLComponentType(componentType) - getGLComponentType(fastgltf::ComponentType::Byte)) << (8 * i);
+            }
+
+            if (colorComponentCountAndType) {
+                assert(ranges::one_of(colorComponentCountAndType->first, 3, 4));
+                assert(ranges::one_of(colorComponentCountAndType->second, fastgltf::ComponentType::UnsignedByte, fastgltf::ComponentType::UnsignedShort, fastgltf::ComponentType::Float));
+                result.colorComponentCount = colorComponentCountAndType->first;
+                result.colorComponentType = getGLComponentType(colorComponentCountAndType->second);
+            }
+
+            return result;
+        }
+
+        [[nodiscard]] std::array<int, 4> getFragmentShaderVariants() const noexcept {
+            return {
+                static_cast<int>(texcoordComponentTypes.size()),
+                colorComponentCountAndType.has_value(),
+                fragmentShaderGeneratedTBN,
+                static_cast<int>(alphaMode),
+            };
+        }
+
+        [[nodiscard]] FragmentShaderSpecializationData getFragmentShaderSpecializationData() const {
+            FragmentShaderSpecializationData result{};
+
+            if (baseColorTextureTransform != TextureTransform::None) {
+                result.packedTextureTransformTypes &= ~0xFU;
+                result.packedTextureTransformTypes |= static_cast<std::uint32_t>(baseColorTextureTransform);
+            }
+            if (metallicRoughnessTextureTransform != TextureTransform::None) {
+                result.packedTextureTransformTypes &= ~0xF0U;
+                result.packedTextureTransformTypes |= static_cast<std::uint32_t>(metallicRoughnessTextureTransform) << 4;
+            }
+            if (normalTextureTransform != TextureTransform::None) {
+                result.packedTextureTransformTypes &= ~0xF00U;
+                result.packedTextureTransformTypes |= static_cast<std::uint32_t>(normalTextureTransform) << 8;
+            }
+            if (occlusionTextureTransform != TextureTransform::None) {
+                result.packedTextureTransformTypes &= ~0xF000U;
+                result.packedTextureTransformTypes |= static_cast<std::uint32_t>(occlusionTextureTransform) << 12;
+            }
+            if (emissiveTextureTransform != TextureTransform::None) {
+                result.packedTextureTransformTypes &= ~0xF0000U;
+                result.packedTextureTransformTypes |= static_cast<std::uint32_t>(emissiveTextureTransform) << 16;
+            }
+
+            return result;
+        }
+    };
 }

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -42,24 +42,28 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             const rp::Scene &sceneRenderPass
         ) const {
             const auto vertexShaderSpecializationData = getVertexShaderSpecializationData();
+            const vk::SpecializationInfo vertexShaderSpecializationInfo {
+                SpecializationMap<VertexShaderSpecializationData>::value,
+                vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
+            };
+
             const auto fragmentShaderSpecializationData = getFragmentShaderSpecializationData();
+            const vk::SpecializationInfo fragmentShaderSpecializationInfo {
+                SpecializationMap<FragmentShaderSpecializationData>::value,
+                vk::ArrayProxyNoTemporaries<const FragmentShaderSpecializationData> { fragmentShaderSpecializationData },
+            };
+
             const vku::RefHolder pipelineStages = createPipelineStages(
                 device,
                 vku::Shader {
                     std::apply(LIFT(shader_selector::primitive_vert), getVertexShaderVariants()),
                     vk::ShaderStageFlagBits::eVertex,
-                    vku::unsafeAddress(vk::SpecializationInfo {
-                        SpecializationMap<VertexShaderSpecializationData>::value,
-                        vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
-                    }),
+                    &vertexShaderSpecializationInfo,
                 },
                 vku::Shader {
                     std::apply(LIFT(shader_selector::primitive_frag), getFragmentShaderVariants()),
                     vk::ShaderStageFlagBits::eFragment,
-                    vku::unsafeAddress(vk::SpecializationInfo {
-                        SpecializationMap<FragmentShaderSpecializationData>::value,
-                        vk::ArrayProxyNoTemporaries<const FragmentShaderSpecializationData> { fragmentShaderSpecializationData },
-                    }),
+                    &fragmentShaderSpecializationInfo,
                 });
 
             switch (alphaMode) {

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -15,6 +15,7 @@ import :shader_selector.primitive_vert;
 import :shader_selector.primitive_frag;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
+export import :vulkan.shader_type.TextureTransform;
 import :vulkan.specialization_constants.SpecializationMap;
 
 #define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
@@ -23,37 +24,14 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class PrimitiveRendererSpecialization {
     public:
-        enum class TextureTransform : std::uint8_t {
-            /**
-             * @brief No texture transform is performed.
-             *
-             * When the primitive's material textures don't have any KHR_texture_transform extensions, use this value to
-             * avoid the unnecessary matrix-vector multiplication in the fragment shader.
-             */
-            None = 0,
-            /**
-             * @brief Texture transform has scale and offset component.
-             *
-             * This is more efficient than <tt>All</tt> because this transform can be done by multiply-and-add (MAD) operation
-             * in fragment shader.
-             */
-            ScaleAndOffset = 1,
-            /**
-             * @brief Texture transform has rotation component.
-             *
-             * Avoid it if possible, because it takes more instructions than <tt>ScaleAndOffset</tt>.
-             */
-            All = 2,
-        };
-
         boost::container::static_vector<fastgltf::ComponentType, 4> texcoordComponentTypes;
         std::optional<std::pair<std::uint8_t, fastgltf::ComponentType>> colorComponentCountAndType;
         bool fragmentShaderGeneratedTBN;
-        TextureTransform baseColorTextureTransform = TextureTransform::None;
-        TextureTransform metallicRoughnessTextureTransform = TextureTransform::None;
-        TextureTransform normalTextureTransform = TextureTransform::None;
-        TextureTransform occlusionTextureTransform = TextureTransform::None;
-        TextureTransform emissiveTextureTransform = TextureTransform::None;
+        shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
+        shader_type::TextureTransform metallicRoughnessTextureTransform = shader_type::TextureTransform::None;
+        shader_type::TextureTransform normalTextureTransform = shader_type::TextureTransform::None;
+        shader_type::TextureTransform occlusionTextureTransform = shader_type::TextureTransform::None;
+        shader_type::TextureTransform emissiveTextureTransform = shader_type::TextureTransform::None;
         fastgltf::AlphaMode alphaMode;
 
         [[nodiscard]] bool operator==(const PrimitiveRendererSpecialization&) const noexcept = default;
@@ -238,23 +216,23 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         [[nodiscard]] FragmentShaderSpecializationData getFragmentShaderSpecializationData() const {
             FragmentShaderSpecializationData result{};
 
-            if (baseColorTextureTransform != TextureTransform::None) {
+            if (baseColorTextureTransform != shader_type::TextureTransform::None) {
                 result.packedTextureTransformTypes &= ~0xFU;
                 result.packedTextureTransformTypes |= static_cast<std::uint32_t>(baseColorTextureTransform);
             }
-            if (metallicRoughnessTextureTransform != TextureTransform::None) {
+            if (metallicRoughnessTextureTransform != shader_type::TextureTransform::None) {
                 result.packedTextureTransformTypes &= ~0xF0U;
                 result.packedTextureTransformTypes |= static_cast<std::uint32_t>(metallicRoughnessTextureTransform) << 4;
             }
-            if (normalTextureTransform != TextureTransform::None) {
+            if (normalTextureTransform != shader_type::TextureTransform::None) {
                 result.packedTextureTransformTypes &= ~0xF00U;
                 result.packedTextureTransformTypes |= static_cast<std::uint32_t>(normalTextureTransform) << 8;
             }
-            if (occlusionTextureTransform != TextureTransform::None) {
+            if (occlusionTextureTransform != shader_type::TextureTransform::None) {
                 result.packedTextureTransformTypes &= ~0xF000U;
                 result.packedTextureTransformTypes |= static_cast<std::uint32_t>(occlusionTextureTransform) << 12;
             }
-            if (emissiveTextureTransform != TextureTransform::None) {
+            if (emissiveTextureTransform != shader_type::TextureTransform::None) {
                 result.packedTextureTransformTypes &= ~0xF0000U;
                 result.packedTextureTransformTypes |= static_cast<std::uint32_t>(emissiveTextureTransform) << 16;
             }

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -34,25 +34,28 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             const rp::Scene &sceneRenderPass
         ) const {
             const auto vertexShaderSpecializationData = getVertexShaderSpecializationData();
+            const vk::SpecializationInfo vertexShaderSpecializationInfo {
+                SpecializationMap<VertexShaderSpecializationData>::value,
+                vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
+            };
+
             const auto fragmentShaderSpecializationData = getFragmentShaderSpecializationData();
+            const vk::SpecializationInfo fragmentShaderSpecializationInfo {
+                SpecializationMap<FragmentShaderSpecializationData>::value,
+                vk::ArrayProxyNoTemporaries<const FragmentShaderSpecializationData> { fragmentShaderSpecializationData },
+            };
 
             const vku::RefHolder pipelineStages = createPipelineStages(
                 device,
                 vku::Shader {
                     std::apply(LIFT(shader_selector::unlit_primitive_vert), getVertexShaderVariants()),
                     vk::ShaderStageFlagBits::eVertex,
-                    vku::unsafeAddress(vk::SpecializationInfo {
-                        SpecializationMap<VertexShaderSpecializationData>::value,
-                        vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
-                    }),
+                    &vertexShaderSpecializationInfo
                 },
                 vku::Shader {
                     std::apply(LIFT(shader_selector::unlit_primitive_frag), getFragmentShaderVariants()),
                     vk::ShaderStageFlagBits::eFragment,
-                    vku::unsafeAddress(vk::SpecializationInfo {
-                        SpecializationMap<FragmentShaderSpecializationData>::value,
-                        vk::ArrayProxyNoTemporaries<const FragmentShaderSpecializationData> { fragmentShaderSpecializationData },
-                    }),
+                    &fragmentShaderSpecializationInfo,
                 });
 
             switch (alphaMode) {

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -1,7 +1,6 @@
 module;
 
 #include <cassert>
-#include <cstddef>
 
 export module vk_gltf_viewer:vulkan.pipeline.UnlitPrimitiveRenderer;
 
@@ -13,156 +12,165 @@ import :shader_selector.unlit_primitive_frag;
 import :shader_selector.unlit_primitive_vert;
 export import :vulkan.pl.Primitive;
 export import :vulkan.rp.Scene;
+import :vulkan.specialization_constants.SpecializationMap;
+
+#define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+#define LIFT(...) [&](auto &&...xs) { return __VA_ARGS__(FWD(xs)...); }
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
-    [[nodiscard]] vk::raii::Pipeline createUnlitPrimitiveRenderer(
-        const vk::raii::Device &device,
-        const pl::Primitive &layout,
-        const rp::Scene &sceneRenderPass,
-        const std::optional<fastgltf::ComponentType> &baseColorTexcoordComponentType,
-        const std::optional<std::pair<std::uint8_t, fastgltf::ComponentType>> &colorComponentCountAndType,
-        fastgltf::AlphaMode alphaMode
-    ) {
+    export class UnlitPrimitiveRendererSpecialization {
+    public:
+        std::optional<fastgltf::ComponentType> baseColorTexcoordComponentType;
+        std::optional<std::pair<std::uint8_t, fastgltf::ComponentType>> colorComponentCountAndType;
+        fastgltf::AlphaMode alphaMode;
+
+        [[nodiscard]] bool operator==(const UnlitPrimitiveRendererSpecialization&) const noexcept = default;
+
+        [[nodiscard]] vk::raii::Pipeline createPipeline(
+            const vk::raii::Device &device,
+            const pl::Primitive &layout,
+            const rp::Scene &sceneRenderPass
+        ) const {
+            const auto vertexShaderSpecializationData = getVertexShaderSpecializationData();
+
+            const vku::RefHolder pipelineStages = createPipelineStages(
+                device,
+                vku::Shader {
+                    std::apply(LIFT(shader_selector::unlit_primitive_vert), getVertexShaderVariants()),
+                    vk::ShaderStageFlagBits::eVertex,
+                    vku::unsafeAddress(vk::SpecializationInfo {
+                        SpecializationMap<VertexShaderSpecializationData>::value,
+                        vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
+                    }),
+                },
+                vku::Shader {
+                    std::apply(LIFT(shader_selector::unlit_primitive_frag), getFragmentShaderVariants()),
+                    vk::ShaderStageFlagBits::eFragment,
+                });
+
+            switch (alphaMode) {
+                case fastgltf::AlphaMode::Opaque:
+                    return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
+                        pipelineStages.get(), *layout, 1, true, vk::SampleCountFlagBits::e4)
+                        .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                            {},
+                            true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                        }))
+                        .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                            {},
+                            vku::unsafeProxy({
+                                vk::DynamicState::eViewport,
+                                vk::DynamicState::eScissor,
+                                vk::DynamicState::eCullMode,
+                            }),
+                        }))
+                        .setRenderPass(*sceneRenderPass)
+                        .setSubpass(0)
+                    };
+                case fastgltf::AlphaMode::Mask:
+                    return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
+                        pipelineStages.get(), *layout, 1, true, vk::SampleCountFlagBits::e4)
+                        .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                            {},
+                            true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                        }))
+                        .setPMultisampleState(vku::unsafeAddress(vk::PipelineMultisampleStateCreateInfo {
+                            {},
+                            vk::SampleCountFlagBits::e4,
+                            {}, {}, {},
+                            true,
+                        }))
+                        .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                            {},
+                            vku::unsafeProxy({
+                                vk::DynamicState::eViewport,
+                                vk::DynamicState::eScissor,
+                                vk::DynamicState::eCullMode,
+                            }),
+                        }))
+                        .setRenderPass(*sceneRenderPass)
+                        .setSubpass(0)
+                    };
+                case fastgltf::AlphaMode::Blend:
+                    return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
+                        pipelineStages.get(), *layout, 1, true, vk::SampleCountFlagBits::e4)
+                        .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
+                            {},
+                            false, false,
+                            vk::PolygonMode::eFill,
+                            // Translucent objects' back faces shouldn't be culled.
+                            vk::CullModeFlagBits::eNone, {},
+                            false, {}, {}, {},
+                            1.f,
+                        }))
+                        .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                            {},
+                            // Translucent objects shouldn't interfere with the pre-rendered depth buffer. Use reverse Z.
+                            true, false, vk::CompareOp::eGreater,
+                        }))
+                        .setPColorBlendState(vku::unsafeAddress(vk::PipelineColorBlendStateCreateInfo {
+                            {},
+                            false, {},
+                            vku::unsafeProxy({
+                                vk::PipelineColorBlendAttachmentState {
+                                    true,
+                                    vk::BlendFactor::eOne, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
+                                    vk::BlendFactor::eOne, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
+                                    vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA,
+                                },
+                                vk::PipelineColorBlendAttachmentState {
+                                    true,
+                                    vk::BlendFactor::eZero, vk::BlendFactor::eOneMinusSrcColor, vk::BlendOp::eAdd,
+                                    vk::BlendFactor::eZero, vk::BlendFactor::eOneMinusSrcAlpha, vk::BlendOp::eAdd,
+                                    vk::ColorComponentFlagBits::eR,
+                                },
+                            }),
+                            { 1.f, 1.f, 1.f, 1.f },
+                        }))
+                        .setRenderPass(*sceneRenderPass)
+                        .setSubpass(1)
+                    };
+            }
+            std::unreachable();
+        }
+
+    private:
         struct VertexShaderSpecializationData {
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint8_t colorComponentCount = 0;
             std::uint32_t colorComponentType = 5126; // FLOAT
-        } vertexShaderSpecializationData{};
-
-        if (baseColorTexcoordComponentType) {
-            vertexShaderSpecializationData.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
-        }
-
-        if (colorComponentCountAndType) {
-            assert(ranges::one_of(colorComponentCountAndType->first, 3, 4));
-            assert(ranges::one_of(colorComponentCountAndType->second, fastgltf::ComponentType::UnsignedByte, fastgltf::ComponentType::UnsignedShort, fastgltf::ComponentType::Float));
-            vertexShaderSpecializationData.colorComponentCount = colorComponentCountAndType->first;
-            vertexShaderSpecializationData.colorComponentType = getGLComponentType(colorComponentCountAndType->second);
-        }
-
-        static constexpr std::array vertexShaderSpecializationMapEntries {
-            vk::SpecializationMapEntry {
-                0,
-                offsetof(VertexShaderSpecializationData, texcoordComponentType),
-                sizeof(VertexShaderSpecializationData::texcoordComponentType),
-             },
-            vk::SpecializationMapEntry {
-                1,
-                offsetof(VertexShaderSpecializationData, colorComponentCount),
-                sizeof(VertexShaderSpecializationData::colorComponentCount),
-            },
-            vk::SpecializationMapEntry {
-                2,
-                offsetof(VertexShaderSpecializationData, colorComponentType),
-                sizeof(VertexShaderSpecializationData::colorComponentType),
-            },
         };
 
-        const vk::SpecializationInfo vertexShaderSpecializationInfo {
-            vertexShaderSpecializationMapEntries,
-            vk::ArrayProxyNoTemporaries<const VertexShaderSpecializationData> { vertexShaderSpecializationData },
-        };
-
-        const vku::RefHolder pipelineStages = createPipelineStages(
-            device,
-            vku::Shader {
-                shader_selector::unlit_primitive_vert(
-                    baseColorTexcoordComponentType.has_value(),
-                    colorComponentCountAndType.has_value()),
-                vk::ShaderStageFlagBits::eVertex,
-                &vertexShaderSpecializationInfo,
-            },
-            vku::Shader {
-                shader_selector::unlit_primitive_frag(
-                    baseColorTexcoordComponentType.has_value(),
-                    colorComponentCountAndType.has_value(),
-                    alphaMode),
-                vk::ShaderStageFlagBits::eFragment,
-            });
-
-        switch (alphaMode) {
-            case fastgltf::AlphaMode::Opaque:
-                return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
-                    pipelineStages.get(), *layout, 1, true, vk::SampleCountFlagBits::e4)
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                    }))
-                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                        {},
-                        vku::unsafeProxy({
-                            vk::DynamicState::eViewport,
-                            vk::DynamicState::eScissor,
-                            vk::DynamicState::eCullMode,
-                        }),
-                    }))
-                    .setRenderPass(*sceneRenderPass)
-                    .setSubpass(0)
-                };
-            case fastgltf::AlphaMode::Mask:
-                return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
-                    pipelineStages.get(), *layout, 1, true, vk::SampleCountFlagBits::e4)
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                    }))
-                    .setPMultisampleState(vku::unsafeAddress(vk::PipelineMultisampleStateCreateInfo {
-                        {},
-                        vk::SampleCountFlagBits::e4,
-                        {}, {}, {},
-                        true,
-                    }))
-                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                        {},
-                        vku::unsafeProxy({
-                            vk::DynamicState::eViewport,
-                            vk::DynamicState::eScissor,
-                            vk::DynamicState::eCullMode,
-                        }),
-                    }))
-                    .setRenderPass(*sceneRenderPass)
-                    .setSubpass(0)
-                };
-            case fastgltf::AlphaMode::Blend:
-                return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
-                    pipelineStages.get(), *layout, 1, true, vk::SampleCountFlagBits::e4)
-                    .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
-                        {},
-                        false, false,
-                        vk::PolygonMode::eFill,
-                        // Translucent objects' back faces shouldn't be culled.
-                        vk::CullModeFlagBits::eNone, {},
-                        false, {}, {}, {},
-                        1.f,
-                    }))
-                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                        {},
-                        // Translucent objects shouldn't interfere with the pre-rendered depth buffer. Use reverse Z.
-                        true, false, vk::CompareOp::eGreater,
-                    }))
-                    .setPColorBlendState(vku::unsafeAddress(vk::PipelineColorBlendStateCreateInfo {
-                        {},
-                        false, {},
-                        vku::unsafeProxy({
-                            vk::PipelineColorBlendAttachmentState {
-                                true,
-                                vk::BlendFactor::eOne, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
-                                vk::BlendFactor::eOne, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
-                                vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA,
-                            },
-                            vk::PipelineColorBlendAttachmentState {
-                                true,
-                                vk::BlendFactor::eZero, vk::BlendFactor::eOneMinusSrcColor, vk::BlendOp::eAdd,
-                                vk::BlendFactor::eZero, vk::BlendFactor::eOneMinusSrcAlpha, vk::BlendOp::eAdd,
-                                vk::ColorComponentFlagBits::eR,
-                            },
-                        }),
-                        { 1.f, 1.f, 1.f, 1.f },
-                    }))
-                    .setRenderPass(*sceneRenderPass)
-                    .setSubpass(1)
-                };
+        [[nodiscard]] std::array<int, 2> getVertexShaderVariants() const noexcept {
+            return {
+                baseColorTexcoordComponentType.has_value(),
+                colorComponentCountAndType.has_value(),
+            };
         }
-        std::unreachable();
-    }
+
+        [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
+            VertexShaderSpecializationData result{};
+
+            if (baseColorTexcoordComponentType) {
+                result.texcoordComponentType = getGLComponentType(*baseColorTexcoordComponentType);
+            }
+
+            if (colorComponentCountAndType) {
+                assert(ranges::one_of(colorComponentCountAndType->first, 3, 4));
+                assert(ranges::one_of(colorComponentCountAndType->second, fastgltf::ComponentType::UnsignedByte, fastgltf::ComponentType::UnsignedShort, fastgltf::ComponentType::Float));
+                result.colorComponentCount = colorComponentCountAndType->first;
+                result.colorComponentType = getGLComponentType(colorComponentCountAndType->second);
+            }
+
+            return result;
+        }
+
+        [[nodiscard]] std::array<int, 3> getFragmentShaderVariants() const noexcept {
+            return {
+                baseColorTexcoordComponentType.has_value(),
+                colorComponentCountAndType.has_value(),
+                static_cast<int>(alphaMode),
+            };
+        }
+    };
 }

--- a/interface/vulkan/shader_type/TextureTransform.cppm
+++ b/interface/vulkan/shader_type/TextureTransform.cppm
@@ -1,0 +1,28 @@
+export module vk_gltf_viewer:vulkan.shader_type.TextureTransform;
+
+import std;
+
+namespace vk_gltf_viewer::vulkan::shader_type {
+    export enum class TextureTransform : std::uint8_t {
+        /**
+         * @brief No texture transform is performed.
+         *
+         * When the primitive's material textures don't have any KHR_texture_transform extensions, use this value to
+         * avoid the unnecessary matrix-vector multiplication in the fragment shader.
+         */
+        None = 0,
+        /**
+         * @brief Texture transform has scale and offset component.
+         *
+         * This is more efficient than <tt>All</tt> because this transform can be done by multiply-and-add (MAD) operation
+         * in fragment shader.
+         */
+        ScaleAndOffset = 1,
+        /**
+         * @brief Texture transform has rotation component.
+         *
+         * Avoid it if possible, because it takes more instructions than <tt>ScaleAndOffset</tt>.
+         */
+        All = 2,
+    };
+}

--- a/interface/vulkan/specialization_constants/SpecializationMap.cppm
+++ b/interface/vulkan/specialization_constants/SpecializationMap.cppm
@@ -1,0 +1,17 @@
+export module vk_gltf_viewer:vulkan.specialization_constants.SpecializationMap;
+
+import std;
+import reflect;
+export import vulkan_hpp;
+
+#define INDEX_SEQ(Is, N, ...) []<std::size_t... Is>(std::index_sequence<Is...>) __VA_ARGS__ (std::make_index_sequence<N>{})
+
+namespace vk_gltf_viewer::vulkan::inline specialization_constants {
+    export template <typename T> requires std::is_aggregate_v<T>
+    struct SpecializationMap {
+        static constexpr std::array<vk::SpecializationMapEntry, reflect::size<T>()> value
+            = INDEX_SEQ(Is, reflect::size<T>(), {
+                return std::array { vk::SpecializationMapEntry { Is, reflect::offset_of<Is, T>(), reflect::size_of<Is, T>() }... };
+            });
+    };
+}

--- a/shaders/mask_depth.frag
+++ b/shaders/mask_depth.frag
@@ -10,6 +10,8 @@
 
 #define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
 
+layout (constant_id = 0) const uint TEXTURE_TRANSFORM_TYPE = 0; // NONE
+
 layout (location = 0) flat in uint inNodeIndex;
 layout (location = 1) flat in uint inMaterialIndex;
 #if HAS_VARIADIC_IN
@@ -33,7 +35,14 @@ layout (set = 0, binding = 2) uniform sampler2D textures[];
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;
 #if HAS_BASE_COLOR_TEXTURE
-    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], variadic_in.baseColorTexcoord).a;
+    vec2 baseColorTexcoord = variadic_in.baseColorTexcoord;
+    if (TEXTURE_TRANSFORM_TYPE == 1) {
+        baseColorTexcoord = vec2(MATERIAL.baseColorTextureTransformUpperLeft2x2[0][0], MATERIAL.baseColorTextureTransformUpperLeft2x2[0][1]) * baseColorTexcoord + MATERIAL.baseColorTextureTransformOffset;
+    }
+    else if (TEXTURE_TRANSFORM_TYPE == 2) {
+        baseColorTexcoord = MATERIAL.baseColorTextureTransformUpperLeft2x2 * baseColorTexcoord + MATERIAL.baseColorTextureTransformOffset;
+    }
+    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], baseColorTexcoord).a;
 #endif
 #if HAS_COLOR_ALPHA_ATTRIBUTE
     baseColorAlpha *= variadic_in.colorAlpha;

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -10,6 +10,8 @@
 
 #define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
 
+layout (constant_id = 0) const uint TEXTURE_TRANSFORM_TYPE = 0; // NONE
+
 layout (location = 0) flat in uint inMaterialIndex;
 #if HAS_VARIADIC_IN
 layout (location = 1) in FRAG_VARIDIC_IN {
@@ -32,7 +34,14 @@ layout (set = 0, binding = 2) uniform sampler2D textures[];
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;
 #if HAS_BASE_COLOR_TEXTURE
-    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], variadic_in.baseColorTexcoord).a;
+    vec2 baseColorTexcoord = variadic_in.baseColorTexcoord;
+    if (TEXTURE_TRANSFORM_TYPE == 1) {
+        baseColorTexcoord = vec2(MATERIAL.baseColorTextureTransformUpperLeft2x2[0][0], MATERIAL.baseColorTextureTransformUpperLeft2x2[0][1]) * baseColorTexcoord + MATERIAL.baseColorTextureTransformOffset;
+    }
+    else if (TEXTURE_TRANSFORM_TYPE == 2) {
+        baseColorTexcoord = MATERIAL.baseColorTextureTransformUpperLeft2x2 * baseColorTexcoord + MATERIAL.baseColorTextureTransformOffset;
+    }
+    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex) + 1], baseColorTexcoord).a;
 #endif
 #if HAS_COLOR_ALPHA_ATTRIBUTE
     baseColorAlpha *= variadic_in.colorAlpha;

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -17,7 +17,18 @@ struct Material {
     float occlusionStrength;
     vec3 emissiveFactor;
     float alphaCutoff;
-};
+    mat2 baseColorTextureTransformUpperLeft2x2;
+    vec2 baseColorTextureTransformOffset;
+    mat2 metallicRoughnessTextureTransformUpperLeft2x2;
+    vec2 metallicRoughnessTextureTransformOffset;
+    mat2 normalTextureTransformUpperLeft2x2;
+    vec2 normalTextureTransformOffset;
+    mat2 occlusionTextureTransformUpperLeft2x2;
+    vec2 occlusionTextureTransformOffset;
+    mat2 emissiveTextureTransformUpperLeft2x2;
+    vec2 emissiveTextureTransformOffset;
+    vec2 padding1;
+}; // 192 bytes.
 
 // --------------------
 // Vertex shader only types

--- a/shaders/unlit_primitive.frag
+++ b/shaders/unlit_primitive.frag
@@ -10,6 +10,8 @@
 
 #define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ATTRIBUTE
 
+layout (constant_id = 0) const uint TEXTURE_TRANSFORM_TYPE = 0; // NONE
+
 layout (location = 0) flat in uint inMaterialIndex;
 #if HAS_VARIADIC_IN
 layout (location = 1) in FS_VARIADIC_IN {
@@ -67,7 +69,14 @@ void writeOutput(vec4 color) {
 void main(){
     vec4 baseColor = MATERIAL.baseColorFactor;
 #if HAS_BASE_COLOR_TEXTURE
-    baseColor *= texture(textures[int(MATERIAL.baseColorTextureIndex) + 1], variadic_in.baseColorTexcoord);
+    vec2 baseColorTexcoord = variadic_in.baseColorTexcoord;
+    if (TEXTURE_TRANSFORM_TYPE == 1) {
+        baseColorTexcoord = vec2(MATERIAL.baseColorTextureTransformUpperLeft2x2[0][0], MATERIAL.baseColorTextureTransformUpperLeft2x2[0][1]) * baseColorTexcoord + MATERIAL.baseColorTextureTransformOffset;
+    }
+    else if (TEXTURE_TRANSFORM_TYPE == 2) {
+        baseColorTexcoord = MATERIAL.baseColorTextureTransformUpperLeft2x2 * baseColorTexcoord + MATERIAL.baseColorTextureTransformOffset;
+    }
+    baseColor *= texture(textures[int(MATERIAL.baseColorTextureIndex) + 1], baseColorTexcoord);
 #endif
 #if HAS_COLOR_ATTRIBUTE
     baseColor *= variadic_in.color;


### PR DESCRIPTION
This PR implements the functionality of the `KHR_texture_transform extension`. It affects the following shaders: `primitive.frag`, `unlit_primitive.frag`, `mask_depth.frag` and `mask_jump_flood_seed.frag`. (The first shader accesses all textures, while the other three shaders access only the base color texture.)

Since the additional matrix-vector multiplication required for texture coordinate calculations introduces overhead, different computational methods are applied depending on whether the extension is used or the primitive can be optimized. These methods are determined at shader compilation time using specialization constants, ensuring no runtime overhead.

- If the primitive does not use this extension, no calculations are performed.
- If the texture transform does not include rotation components, the (1,1) and (2,2) components of the 3x3 transformation matrix are 0. Thus, the calculation for the new texture coordinates can be optimized to a MAD (multiply-and-add) operation as follows:
  ```
  (new texture coordinates) = scale * (previous texture coordinates) + offset
  ```
- If the transform includes rotation components, the calculation is performed as:
  ```
  (new texture coordinates) = T * (previous texture coordinates) + offset
  ```
  where T is a 2x2 transformation matrix containing both scale and rotation, and offset is the translation vector.

Additionally, a GUI has been implemented to indicate whether this extension is being used.