### PR TITLE
GUI fixes.

### DIFF
--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -828,7 +828,7 @@ void vk_gltf_viewer::MainApp::loadGltf(const std::filesystem::path &path) {
             to_optional(texture.samplerIndex)
                 .transform([this](std::size_t samplerIndex) { return *gltf->assetGpuTextures.samplers[samplerIndex]; })
                 .value_or(*gpuFallbackTexture.sampler),
-            *gltf->assetGpuTextures.imageViews.at(gltf::AssetGpuTextures::getPreferredImageIndex(texture)),
+            *gltf->assetGpuTextures.imageViews.at(getPreferredImageIndex(texture)),
             vk::ImageLayout::eShaderReadOnlyOptimal,
         };
     }));
@@ -849,7 +849,7 @@ void vk_gltf_viewer::MainApp::loadGltf(const std::filesystem::path &path) {
                     .value_or(*gpuFallbackTexture.sampler),
                 ranges::value_or(
                     gltf->assetGpuTextures.imageViews,
-                    gltf::AssetGpuTextures::getPreferredImageIndex(texture),
+                    getPreferredImageIndex(texture),
                     *gpuFallbackTexture.imageView),
                 VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
         })

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -157,13 +157,13 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::assetBuffers(std::span<fastglt
             ImGui::TextUnformatted(tempStringBuffer.write(ByteSize { buffer.byteLength }));
         }, ImGuiTableColumnFlags_WidthFixed },
         ImGui::ColumnInfo { "MIME", [](const fastgltf::Buffer &buffer) {
-            visit(fastgltf::visitor {
-                [](const auto &source) requires requires { source.mimeType -> fastgltf::MimeType; } {
+            visit([](const auto &source) {
+                if constexpr (requires { { source.mimeType } -> std::convertible_to<fastgltf::MimeType>; }) {
                     ImGui::TextUnformatted(to_string(source.mimeType));
-                },
-                [](const auto&) {
+                }
+                else {
                     ImGui::TextDisabled("-");
-                },
+                }
             }, buffer.data);
         }, ImGuiTableColumnFlags_WidthFixed },
         ImGui::ColumnInfo { "Location", [&](std::size_t row, const fastgltf::Buffer &buffer) {
@@ -241,13 +241,13 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::assetImages(std::span<fastgltf
             });
         }, ImGuiTableColumnFlags_WidthStretch },
         ImGui::ColumnInfo { "MIME", [](const fastgltf::Image &image) {
-            visit(fastgltf::visitor {
-                [](const auto &source) requires requires { source.mimeType -> fastgltf::MimeType; } {
+            visit([](const auto &source) {
+                if constexpr (requires { { source.mimeType } -> std::convertible_to<fastgltf::MimeType>; }) {
                     ImGui::TextUnformatted(to_string(source.mimeType));
-                },
-                [](const auto&) {
+                }
+                else {
                     ImGui::TextDisabled("-");
-                },
+                }
             }, image.data);
         }, ImGuiTableColumnFlags_WidthFixed },
         ImGui::ColumnInfo { "Location", [&](std::size_t i, const fastgltf::Image &image) {

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -516,9 +516,11 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
         if (ImGui::BeginCombo("Material", previewText)) {
             for (const auto &[i, material] : asset.materials | ranges::views::enumerate) {
                 const bool isSelected = i == selectedMaterialIndex;
-                if (ImGui::Selectable(nonempty_or(material.name, [&]() { return tempStringBuffer.write("<Unnamed material {}>", i).view(); }).c_str(), isSelected)) {
-                    selectedMaterialIndex.emplace(i);
-                }
+                ImGui::WithID(i, [&]() {
+                    if (ImGui::Selectable(nonempty_or(material.name, [&]() { return tempStringBuffer.write("<Unnamed material {}>", i).view(); }).c_str(), isSelected)) {
+                        selectedMaterialIndex.emplace(i);
+                    }
+                });
                 if (isSelected) {
                     ImGui::SetItemDefaultFocus();
                 }

--- a/interface/gltf/AssetGpuTextures.cppm
+++ b/interface/gltf/AssetGpuTextures.cppm
@@ -130,7 +130,7 @@ namespace vk_gltf_viewer::gltf {
         ) : asset { asset },
             gpu { gpu } {
             // Get images that are used by asset textures.
-            std::vector usedImageIndices { std::from_range, asset.textures | std::views::transform(getPreferredImageIndex) };
+            std::vector usedImageIndices { std::from_range, asset.textures | std::views::transform(fastgltf::getPreferredImageIndex) };
             std::ranges::sort(usedImageIndices);
             const auto [begin, end] = std::ranges::unique(usedImageIndices);
             usedImageIndices.erase(begin, end);
@@ -532,20 +532,6 @@ namespace vk_gltf_viewer::gltf {
             std::ignore = gpu.device.waitForFences(*graphicsFence, true, ~0ULL); // TODO: failure handling
 
             imageViews = createImageViews(gpu.device);
-        }
-
-        /**
-         * Get image index from \p texture with preference of GPU compressed texture.
-         *
-         * You should use this function to get the image index from a texture, rather than directly access such like
-         * <tt>texture.imageIndex</tt> or <tt>texture.basisuImageIndex</tt>.
-         *
-         * @param texture Texture to get the index.
-         * @return Image index.
-         */
-        [[nodiscard]] static auto getPreferredImageIndex(const fastgltf::Texture &texture) noexcept -> std::size_t {
-            return texture.basisuImageIndex // Prefer BasisU compressed image if exists.
-                .value_or(*texture.imageIndex); // Otherwise, use regular image.
         }
 
     private:

--- a/interface/helpers/fastgltf.cppm
+++ b/interface/helpers/fastgltf.cppm
@@ -270,6 +270,22 @@ namespace fastgltf {
         return textureInfo.texCoordIndex;
     }
 
+    /**
+     * Get image index from \p texture with preference of GPU compressed texture.
+     *
+     * You should use this function to get the image index from a texture, rather than directly access such like
+     * <tt>texture.imageIndex</tt> or <tt>texture.basisuImageIndex</tt>.
+     *
+     * @param texture Texture to get the index.
+     * @return Image index.
+     */
+    export
+    [[nodiscard]] std::size_t getPreferredImageIndex(const Texture &texture) {
+        return to_optional(texture.basisuImageIndex) // Prefer BasisU compressed image if exists.
+            .or_else([&]() { return to_optional(texture.imageIndex); }) // Otherwise, use regular image.
+            .value();
+    }
+
 namespace math {
     /**
      * @brief Convert matrix of type \tp U to matrix of type \tp T.

--- a/interface/helpers/imgui/table.cppm
+++ b/interface/helpers/imgui/table.cppm
@@ -61,7 +61,7 @@ namespace ImGui {
     void TableWithVirtualization(cpp_util::cstring_view str_id, ImGuiTableFlags flags, std::ranges::random_access_range auto &&items, const ColumnInfo<Fs> &...columnInfos) {
         // If item count is less than 32, use the normal Table function.
         if (items.size() < 32) {
-            Table(str_id, flags, FWD(items), columnInfos...);
+            Table<RowNumber>(str_id, flags, FWD(items), columnInfos...);
         }
         else if (BeginTable(str_id.c_str(), RowNumber + sizeof...(Fs), flags)) {
             TableSetupScrollFreeze(0, 1);


### PR DESCRIPTION
Fixed:

- resource MIME types were not being displayed correctly
- ImGui ID conflict

Internal bug fixed:

- `getPreferredImageIndex` function dereferences nullopt (might be problematic when using hardened STL)
- `ImGui::TableWithNoVirtualization<false>` with less than 32 entries fallback to `ImGui::Table<true>` (`ImGui::Table<false>` should to be used)