### PR TITLE
Implemented morph target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/buffer/IndirectDrawCommands.cppm
         interface/vulkan/buffer/InstancedNodeWorldTransforms.cppm
         interface/vulkan/buffer/Materials.cppm
+        interface/vulkan/buffer/MorphTargetWeights.cppm
         interface/vulkan/buffer/Nodes.cppm
         interface/vulkan/buffer/PrimitiveAttributes.cppm
         interface/vulkan/buffer/Primitives.cppm
@@ -188,6 +189,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/sampler/BrdfLutSampler.cppm
         interface/vulkan/sampler/CubemapSampler.cppm
         interface/vulkan/shader_type/Accessor.cppm
+        interface/vulkan/shader_type/Node.cppm
         interface/vulkan/shader_type/Primitive.cppm
         interface/vulkan/shader_type/TextureTransform.cppm
         interface/vulkan/SharedData.cppm

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -526,7 +526,11 @@ void vk_gltf_viewer::MainApp::run() {
                         gpu.queues.graphicsPresent.submit(vk::SubmitInfo { {}, {}, sharedDataUpdateCommandBuffer });
                         gpu.device.waitIdle();
                     }
-                }
+                },
+                [&](const control::task::ChangeMorphTargetWeight &task) {
+                    gpu.device.waitIdle();
+                    sharedData.gltfAsset.value().morphTargetWeightBuffer.updateWeight(task.nodeIndex, task.targetWeightIndex, task.newValue);
+                },
             }, task);
         }
 

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -986,6 +986,20 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::nodeInspector(
                 });
             }
 
+            std::span<float> morphTargetWeights = node.weights;
+            if (node.meshIndex && !asset.meshes[*node.meshIndex].weights.empty()) {
+                morphTargetWeights = asset.meshes[*node.meshIndex].weights;
+            }
+            if (!morphTargetWeights.empty()) {
+                ImGui::SeparatorText("Morph Target Weights");
+
+                for (auto &&[i, weight] : morphTargetWeights | ranges::views::enumerate) {
+                    if (ImGui::DragFloat(tempStringBuffer.write("Weight {}", i).view().c_str(), &weight, 0.01f)) {
+                        tasks.emplace_back(std::in_place_type<task::ChangeMorphTargetWeight>, selectedNodeIndex, i, weight);
+                    }
+                }
+            }
+
             if (ImGui::BeginTabBar("node-tab-bar")) {
                 if (node.meshIndex && ImGui::BeginTabItem("Mesh")) {
                     fastgltf::Mesh &mesh = asset.meshes[*node.meshIndex];

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -152,6 +152,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                     .colorComponentCountAndType = accessors.colorAccessor.transform([](const auto &info) {
                         return std::pair { info.componentCount, info.componentType };
                     }),
+                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
                     .baseColorTextureTransform = material.pbrData.baseColorTexture
                         .transform(fetchTextureTransform)
                         .value_or(shader_type::TextureTransform::None),
@@ -170,6 +171,9 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         return std::pair { info.componentCount, info.componentType };
                     }),
                     .fragmentShaderGeneratedTBN = !accessors.normalAccessor.has_value(),
+                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                    .hasNormalMorphTarget = !accessors.normalMorphTargetAccessors.empty(),
+                    .hasTangentMorphTarget = !accessors.tangentMorphTargetAccessors.empty(),
                     .baseColorTextureTransform = material.pbrData.baseColorTexture
                         .transform(fetchTextureTransform)
                         .value_or(shader_type::TextureTransform::None),
@@ -202,6 +206,9 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                     return std::pair { info.componentCount, info.componentType };
                 }),
                 .fragmentShaderGeneratedTBN = !accessors.normalAccessor.has_value(),
+                .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                .hasNormalMorphTarget = !accessors.normalMorphTargetAccessors.empty(),
+                .hasTangentMorphTarget = !accessors.tangentMorphTargetAccessors.empty(),
             });
         }
         return result;
@@ -227,15 +234,20 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         // Alpha value exists only if COLOR_0 is Vec4 type.
                         return value_if(info.componentCount == 4, info.componentType);
                     }),
+                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
                 });
             }
             else {
-                result.pipeline = sharedData.getDepthRenderer();
+                result.pipeline = sharedData.getDepthRenderer({
+                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                });
             }
             result.cullMode = material.doubleSided ? vk::CullModeFlagBits::eNone : vk::CullModeFlagBits::eBack;
         }
         else {
-            result.pipeline = sharedData.getDepthRenderer();
+            result.pipeline = sharedData.getDepthRenderer({
+                .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+            });
         }
         return result;
     };
@@ -260,15 +272,20 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         // Alpha value exists only if COLOR_0 is Vec4 type.
                         return value_if(info.componentCount == 4, info.componentType);
                     }),
+                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
                 });
             }
             else {
-                result.pipeline = sharedData.getJumpFloodSeedRenderer();
+                result.pipeline = sharedData.getJumpFloodSeedRenderer({
+                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                });
             }
             result.cullMode = material.doubleSided ? vk::CullModeFlagBits::eNone : vk::CullModeFlagBits::eBack;
         }
         else {
-            result.pipeline = sharedData.getJumpFloodSeedRenderer();
+            result.pipeline = sharedData.getJumpFloodSeedRenderer({
+                .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+            });
         }
         return result;
     };

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -152,7 +152,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                     .colorComponentCountAndType = accessors.colorAccessor.transform([](const auto &info) {
                         return std::pair { info.componentCount, info.componentType };
                     }),
-                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                     .baseColorTextureTransform = material.pbrData.baseColorTexture
                         .transform(fetchTextureTransform)
                         .value_or(shader_type::TextureTransform::None),
@@ -171,6 +171,11 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         return std::pair { info.componentCount, info.componentType };
                     }),
                     .fragmentShaderGeneratedTBN = !accessors.normalAccessor.has_value(),
+                    .morphTargetWeightCount = static_cast<std::uint32_t>(std::max({
+                        accessors.positionMorphTargetAccessors.size(),
+                        accessors.normalMorphTargetAccessors.size(),
+                        accessors.tangentMorphTargetAccessors.size(),
+                    })),
                     .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
                     .hasNormalMorphTarget = !accessors.normalMorphTargetAccessors.empty(),
                     .hasTangentMorphTarget = !accessors.tangentMorphTargetAccessors.empty(),
@@ -206,6 +211,11 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                     return std::pair { info.componentCount, info.componentType };
                 }),
                 .fragmentShaderGeneratedTBN = !accessors.normalAccessor.has_value(),
+                .morphTargetWeightCount = static_cast<std::uint32_t>(std::max({
+                    accessors.positionMorphTargetAccessors.size(),
+                    accessors.normalMorphTargetAccessors.size(),
+                    accessors.tangentMorphTargetAccessors.size(),
+                })),
                 .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
                 .hasNormalMorphTarget = !accessors.normalMorphTargetAccessors.empty(),
                 .hasTangentMorphTarget = !accessors.tangentMorphTargetAccessors.empty(),
@@ -234,19 +244,19 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         // Alpha value exists only if COLOR_0 is Vec4 type.
                         return value_if(info.componentCount == 4, info.componentType);
                     }),
-                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                 });
             }
             else {
                 result.pipeline = sharedData.getDepthRenderer({
-                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                 });
             }
             result.cullMode = material.doubleSided ? vk::CullModeFlagBits::eNone : vk::CullModeFlagBits::eBack;
         }
         else {
             result.pipeline = sharedData.getDepthRenderer({
-                .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
             });
         }
         return result;
@@ -272,19 +282,19 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         // Alpha value exists only if COLOR_0 is Vec4 type.
                         return value_if(info.componentCount == 4, info.componentType);
                     }),
-                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                 });
             }
             else {
                 result.pipeline = sharedData.getJumpFloodSeedRenderer({
-                    .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                 });
             }
             result.cullMode = material.doubleSided ? vk::CullModeFlagBits::eNone : vk::CullModeFlagBits::eBack;
         }
         else {
             result.pipeline = sharedData.getJumpFloodSeedRenderer({
-                .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
+                .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
             });
         }
         return result;

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -22,6 +22,7 @@ namespace vk_gltf_viewer::control {
         struct ChangeCameraView { };
         struct InvalidateDrawCommandSeparation { };
         struct SelectMaterialVariants { std::size_t variantIndex; };
+        struct ChangeMorphTargetWeight { std::size_t nodeIndex; std::size_t targetWeightIndex; float newValue; };
     }
 
     export using Task = std::variant<
@@ -41,5 +42,6 @@ namespace vk_gltf_viewer::control {
         task::TightenNearFarPlane,
         task::ChangeCameraView,
         task::InvalidateDrawCommandSeparation,
-        task::SelectMaterialVariants>;
+        task::SelectMaterialVariants,
+        task::ChangeMorphTargetWeight>;
 }

--- a/interface/gltf/algorithm/bounding_box.cppm
+++ b/interface/gltf/algorithm/bounding_box.cppm
@@ -5,6 +5,66 @@ export import fastgltf;
 
 namespace vk_gltf_viewer::gltf::algorithm {
     /**
+     * @brief Get min/max points of \p primitive's bounding box.
+     *
+     * @tparam T Floating point type for calculate position, default: <tt>double</tt>.
+     * @param primtiive primitive to get the bounding box corner points.
+     * @param node Node that owns \p primitive.
+     * @param asset Asset that owns \p node.
+     * @return Array of (min, max) of the bounding box.
+     */
+    export template <std::floating_point T = double>
+    [[nodiscard]] std::array<fastgltf::math::vec<T, 3>, 2> getBoundingBoxMinMax(
+        const fastgltf::Primitive &primitive,
+        const fastgltf::Node &node,
+        const fastgltf::Asset &asset
+    ) {
+        constexpr auto getAccessorMinMax = [](const fastgltf::Accessor &accessor) {
+            if (accessor.normalized) {
+                // Unless KHR_mesh_quantization extension is enabled, POSITION accessor must be VEC3/FLOAT type.
+                // Normalized accessor means that extension is used.
+                throw std::runtime_error { "Sorry, unimplemented." };
+            }
+
+            const auto pMin = std::get_if<std::pmr::vector<double>>(&accessor.min)->data();
+            const auto pMax = std::get_if<std::pmr::vector<double>>(&accessor.max)->data();
+            return std::array {
+                fastgltf::math::vec<T, 3> { static_cast<T>(pMin[0]), static_cast<T>(pMin[1]), static_cast<T>(pMin[2]) },
+                fastgltf::math::vec<T, 3> { static_cast<T>(pMax[0]), static_cast<T>(pMax[1]), static_cast<T>(pMax[2]) },
+            };
+        };
+
+        const fastgltf::Accessor &accessor = asset.accessors[primitive.findAttribute("POSITION")->accessorIndex];
+        std::array bound = getAccessorMinMax(accessor);
+
+        std::span<const float> morphTargetWeights = node.weights;
+        if (node.meshIndex && !asset.meshes[*node.meshIndex].weights.empty()) {
+            morphTargetWeights = asset.meshes[*node.meshIndex].weights;
+        }
+
+        for (const auto &[weight, attributes] : std::views::zip(morphTargetWeights, primitive.targets)) {
+            for (const auto &[attributeName, accessorIndex] : attributes) {
+                using namespace std::string_view_literals;
+                if (attributeName == "POSITION"sv) {
+                    const fastgltf::Accessor &accessor = asset.accessors[accessorIndex];
+                    std::array offset = getAccessorMinMax(accessor);
+
+                    // TODO: is this code valid? Need investigation.
+                    if (weight < 0) {
+                        std::swap(get<0>(offset), get<1>(offset));
+                    }
+                    get<0>(bound) += get<0>(offset) * weight;
+                    get<1>(bound) += get<1>(offset) * weight;
+
+                    break;
+                }
+            }
+        }
+
+        return bound;
+    }
+
+    /**
      * @brief Get 8 corner points of \p primitive's bounding box, which are ordered by:
      * - (minX, minY, minZ)
      * - (minX, minY, maxZ)
@@ -15,29 +75,27 @@ namespace vk_gltf_viewer::gltf::algorithm {
      * - (maxX, maxY, minZ)
      * - (maxX, maxY, maxZ)
      *
-     * @param asset fastgltf asset.
-     * @param primtiive fastgltf primitive. This must be originated from \p asset.
+     * @param primtiive primitive to get the bounding box corner points.
+     * @param node Node that owns \p primitive.
+     * @param asset Asset that owns \p node.
      * @return Array of 8 corner points of the bounding box.
      */
     export
-    [[nodiscard]] std::array<fastgltf::math::dvec3, 8> getBoundingBoxCornerPoints(const fastgltf::Asset &asset, const fastgltf::Primitive &primitive) {
-        const fastgltf::Accessor &accessor = asset.accessors[primitive.findAttribute("POSITION")->accessorIndex];
-
-        // TODO: current glTF specification guarantees that there are min/max attributes for POSITION with
-        //  dvec3 type, but KHR_mesh_quantization extension offers non-double precision POSITION attributes,
-        //  which would be problematic in future. Need caution.
-        const double *const pMin = std::get_if<std::pmr::vector<double>>(&accessor.min)->data();
-        const double *const pMax = std::get_if<std::pmr::vector<double>>(&accessor.max)->data();
-
+    [[nodiscard]] std::array<fastgltf::math::dvec3, 8> getBoundingBoxCornerPoints(
+        const fastgltf::Primitive &primitive,
+        const fastgltf::Node &node,
+        const fastgltf::Asset &asset
+    ) {
+        const auto [min, max] = getBoundingBoxMinMax(primitive, node, asset);
         return {
-            fastgltf::math::dvec3 { pMin[0], pMin[1], pMin[2] },
-            fastgltf::math::dvec3 { pMin[0], pMin[1], pMax[2] },
-            fastgltf::math::dvec3 { pMin[0], pMax[1], pMin[2] },
-            fastgltf::math::dvec3 { pMin[0], pMax[1], pMax[2] },
-            fastgltf::math::dvec3 { pMax[0], pMin[1], pMin[2] },
-            fastgltf::math::dvec3 { pMax[0], pMin[1], pMax[2] },
-            fastgltf::math::dvec3 { pMax[0], pMax[1], pMin[2] },
-            fastgltf::math::dvec3 { pMax[0], pMax[1], pMax[2] },
+            min,
+            fastgltf::math::dvec3 { min[0], min[1], max[2] },
+            fastgltf::math::dvec3 { min[0], max[1], min[2] },
+            fastgltf::math::dvec3 { min[0], max[1], max[2] },
+            fastgltf::math::dvec3 { max[0], min[1], min[2] },
+            fastgltf::math::dvec3 { max[0], min[1], max[2] },
+            fastgltf::math::dvec3 { max[0], max[1], min[2] },
+            max,
         };
     }
 }

--- a/interface/gltf/algorithm/miniball.cppm
+++ b/interface/gltf/algorithm/miniball.cppm
@@ -44,7 +44,7 @@ namespace vk_gltf_viewer::gltf::algorithm {
             const fastgltf::Mesh &mesh = asset.meshes[*node.meshIndex];
             const auto collectTransformedBoundingBoxPoints = [&](const fastgltf::math::dmat4x4 &worldTransform) {
                 for (const fastgltf::Primitive &primitive : mesh.primitives) {
-                    for (const fastgltf::math::dvec3 &point : getBoundingBoxCornerPoints(asset, primitive)) {
+                    for (const fastgltf::math::dvec3 &point : getBoundingBoxCornerPoints(primitive, node, asset)) {
                         const fastgltf::math::dvec3 transformedPoint { worldTransform * fastgltf::math::dvec4 { point.x(), point.y(), point.z(), 1.0 } };
                         meshBoundingBoxPoints.emplace_back(transformedPoint.x(), transformedPoint.y(), transformedPoint.z());
                     }

--- a/interface/helpers/fastgltf.cppm
+++ b/interface/helpers/fastgltf.cppm
@@ -385,6 +385,29 @@ namespace fastgltf {
         return data;
     }
 
+    /**
+     * @brief Get target weight count of \p node, with respecting its mesh target weights existency.
+     *
+     * glTF spec:
+     *   A mesh with morph targets MAY also define an optional mesh.weights property that stores the default targets'
+     *   weights. These weights MUST be used when node.weights is undefined. When mesh.weights is undefined, the default
+     *   targets' weights are zeros.
+     *
+     * Therefore, when calculating the count of a node's target weights, its mesh target weights MUST be also considered.
+     *
+     * @param node Node to get the target weight count.
+     * @param asset Asset that is owning \p node.
+     * @return Target weight count.
+     */
+    export
+    [[nodiscard]] std::size_t getTargetWeightCount(const Node &node, const Asset &asset) noexcept {
+        return to_optional(node.meshIndex)
+            .and_then([&](std::size_t meshIndex) {
+                return value_if(!asset.meshes[meshIndex].weights.empty(), asset.meshes[meshIndex].weights.size());
+            })
+            .value_or(node.weights.size());
+    }
+
 namespace math {
     /**
      * @brief Convert matrix of type \tp U to matrix of type \tp T.

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -247,7 +247,7 @@ namespace vk_gltf_viewer::vulkan {
             }
 
             const GltfAsset &inner = gltfAsset.emplace(asset, directory, nodeWorldTransforms, orderedPrimitives, gpu, adapter);
-            if (assetDescriptorSetLayout.descriptorCounts[4] != textureCount) {
+            if (assetDescriptorSetLayout.descriptorCounts[5] != textureCount) {
                 // If texture count is different, descriptor set layouts, pipeline layouts and pipelines have to be recreated.
                 depthPipelines.clear();
                 maskDepthPipelines.clear();
@@ -280,8 +280,9 @@ namespace vk_gltf_viewer::vulkan {
                 assetDescriptorSet.getWrite<0>(inner.primitiveBuffer.getDescriptorInfo()),
                 assetDescriptorSet.getWrite<1>(inner.nodeBuffer.getDescriptorInfo()),
                 assetDescriptorSet.getWrite<2>(inner.instancedNodeWorldTransformBuffer.getDescriptorInfo()),
-                assetDescriptorSet.getWrite<3>(inner.materialBuffer.getDescriptorInfo()),
-                assetDescriptorSet.getWrite<4>(imageInfos),
+                assetDescriptorSet.getWrite<3>(inner.morphTargetWeightBuffer.getDescriptorInfo()),
+                assetDescriptorSet.getWrite<4>(inner.materialBuffer.getDescriptorInfo()),
+                assetDescriptorSet.getWrite<5>(imageInfos),
             }, {});
         }
 

--- a/interface/vulkan/buffer/MorphTargetWeights.cppm
+++ b/interface/vulkan/buffer/MorphTargetWeights.cppm
@@ -1,0 +1,43 @@
+export module vk_gltf_viewer:vulkan.buffer.MorphTargetWeights;
+
+import std;
+export import fastgltf;
+import :vulkan.buffer;
+export import :vulkan.Gpu;
+
+namespace vk_gltf_viewer::vulkan::buffer {
+    export class MorphTargetWeights {
+    public:
+        MorphTargetWeights(const fastgltf::Asset &asset, const Gpu &gpu [[clang::lifetimebound]])
+            : buffer { createBuffer(asset, gpu) } { }
+
+        [[nodiscard]] vk::DeviceAddress getStartAddress(std::size_t nodeIndex) const noexcept {
+            return startAddresses[nodeIndex];
+        }
+
+    private:
+        std::vector<vk::DeviceAddress> startAddresses;
+        vku::MappedBuffer buffer;
+
+        [[nodiscard]] vku::MappedBuffer createBuffer(const fastgltf::Asset &asset, const Gpu &gpu) {
+            auto [buffer, copyOffsets] = createCombinedBuffer(
+                gpu.allocator,
+                asset.nodes | std::views::transform([&](const fastgltf::Node &node) {
+                    std::span<const float> weights = node.weights;
+                    if (node.meshIndex) {
+                        const fastgltf::Mesh &mesh = asset.meshes[*node.meshIndex];
+                        weights = mesh.weights;
+                    }
+                    return weights;
+                }),
+                vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress);
+
+            const vk::DeviceAddress bufferAddress = gpu.device.getBufferAddress({ buffer });
+            startAddresses = { std::from_range, copyOffsets | std::views::transform([&](vk::DeviceSize copyOffset) {
+                return bufferAddress + copyOffset;
+            }) };
+
+            return std::move(buffer);
+        }
+    };
+}

--- a/interface/vulkan/buffer/Nodes.cppm
+++ b/interface/vulkan/buffer/Nodes.cppm
@@ -6,9 +6,12 @@ export module vk_gltf_viewer:vulkan.buffer.Nodes;
 
 import std;
 export import fastgltf;
+import :helpers.fastgltf;
 import :helpers.ranges;
 export import :vulkan.buffer.InstancedNodeWorldTransforms;
+export import :vulkan.buffer.MorphTargetWeights;
 export import :vulkan.buffer.StagingBufferStorage;
+import :vulkan.shader_type.Node;
 import :vulkan.trait.PostTransferObject;
 
 namespace vk_gltf_viewer::vulkan::buffer {
@@ -17,10 +20,11 @@ namespace vk_gltf_viewer::vulkan::buffer {
         Nodes(
             const fastgltf::Asset &asset,
             const InstancedNodeWorldTransforms &instancedNodeWorldTransformBuffer,
+            const MorphTargetWeights &morphTargetWeights,
             vma::Allocator allocator,
             StagingBufferStorage &stagingBufferStorage
         ) : PostTransferObject { stagingBufferStorage },
-            buffer { createBuffer(asset, instancedNodeWorldTransformBuffer, allocator) },
+            buffer { createBuffer(asset, instancedNodeWorldTransformBuffer, morphTargetWeights, allocator) },
             descriptorInfo { buffer, 0, vk::WholeSize } { }
 
         [[nodiscard]] const vk::DescriptorBufferInfo &getDescriptorInfo() const noexcept {
@@ -37,12 +41,17 @@ namespace vk_gltf_viewer::vulkan::buffer {
         [[nodiscard]] vku::AllocatedBuffer createBuffer(
             const fastgltf::Asset &asset,
             const InstancedNodeWorldTransforms &instancedNodeWorldTransformBuffer,
+            const MorphTargetWeights &morphTargetWeights,
             vma::Allocator allocator
         ) const {
             vku::AllocatedBuffer buffer = vku::MappedBuffer {
                 allocator,
                 std::from_range, ranges::views::upto(asset.nodes.size()) | std::views::transform([&](std::size_t nodeIndex) {
-                    return instancedNodeWorldTransformBuffer.getStartIndex(nodeIndex);
+                    return shader_type::Node {
+                        .morphTargetWeightsStartAddress = morphTargetWeights.getStartAddress(nodeIndex),
+                        .morphTargetWeightsCount = static_cast<std::uint32_t>(getTargetWeightCount(asset.nodes[nodeIndex], asset)),
+                        .instancedTransformStartIndex = instancedNodeWorldTransformBuffer.getStartIndex(nodeIndex),
+                    };
                 }),
                 vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc,
             }.unmap();

--- a/interface/vulkan/buffer/Nodes.cppm
+++ b/interface/vulkan/buffer/Nodes.cppm
@@ -48,9 +48,8 @@ namespace vk_gltf_viewer::vulkan::buffer {
                 allocator,
                 std::from_range, ranges::views::upto(asset.nodes.size()) | std::views::transform([&](std::size_t nodeIndex) {
                     return shader_type::Node {
-                        .morphTargetWeightsStartAddress = morphTargetWeights.getStartAddress(nodeIndex),
-                        .morphTargetWeightsCount = static_cast<std::uint32_t>(getTargetWeightCount(asset.nodes[nodeIndex], asset)),
                         .instancedTransformStartIndex = instancedNodeWorldTransformBuffer.getStartIndex(nodeIndex),
+                        .morphTargetWeightStartIndex = morphTargetWeights.getStartIndex(nodeIndex),
                     };
                 }),
                 vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc,

--- a/interface/vulkan/buffer/Primitives.cppm
+++ b/interface/vulkan/buffer/Primitives.cppm
@@ -87,13 +87,24 @@ namespace vk_gltf_viewer::vulkan::buffer {
                         .positionByteStride = accessors.positionAccessor.byteStride,
                         .materialIndex = to_optional(pPrimitive->materialIndex).transform(LIFT(materialBuffer.get().padMaterialIndex)).value_or(0U),
                     };
+                    if (!accessors.positionMorphTargetAccessors.empty()) {
+                        result.pPositionMorphTargetAccessorBuffer = accessors.positionMorphTargetAccessorBufferAddress;
+                    }
                     if (accessors.normalAccessor) {
                         result.pNormalBuffer = accessors.normalAccessor->bufferAddress;
                         result.normalByteStride = accessors.normalAccessor->byteStride;
+
+                        if (!accessors.normalMorphTargetAccessors.empty()) {
+                            result.pNormalMorphTargetAccessorBuffer = accessors.normalMorphTargetAccessorBufferAddress;
+                        }
                     }
                     if (accessors.tangentAccessor) {
                         result.pTangentBuffer = accessors.tangentAccessor->bufferAddress;
                         result.tangentByteStride = accessors.tangentAccessor->byteStride;
+
+                        if (!accessors.tangentMorphTargetAccessors.empty()) {
+                            result.pTangentMorphTargetAccessorBuffer = accessors.tangentMorphTargetAccessorBufferAddress;
+                        }
                     }
                     if (accessors.colorAccessor) {
                         result.pColorBuffer = accessors.colorAccessor->bufferAddress;

--- a/interface/vulkan/descriptor_set_layout/Asset.cppm
+++ b/interface/vulkan/descriptor_set_layout/Asset.cppm
@@ -4,7 +4,7 @@ import std;
 export import :vulkan.Gpu;
 
 namespace vk_gltf_viewer::vulkan::dsl {
-    export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
+    export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
         Asset(const Gpu &gpu [[clang::lifetimebound]], std::uint32_t textureCount)
             : DescriptorSetLayout { gpu.device, vk::StructureChain {
                 vk::DescriptorSetLayoutCreateInfo {
@@ -13,11 +13,13 @@ namespace vk_gltf_viewer::vulkan::dsl {
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
+                        { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment },
                         { textureCount, vk::ShaderStageFlagBits::eFragment })),
                 },
                 vk::DescriptorSetLayoutBindingFlagsCreateInfo {
                     vku::unsafeProxy<vk::DescriptorBindingFlags>({
+                        {},
                         {},
                         {},
                         {},

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -16,7 +16,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class DepthRendererSpecialization {
     public:
-        bool hasPositionMorphTarget = false;
+        std::uint32_t positionMorphTargetWeightCount = 0;
 
         [[nodiscard]] bool operator==(const DepthRendererSpecialization&) const = default;
 
@@ -60,11 +60,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     private:
         struct VertexShaderSpecializationData {
-            vk::Bool32 hasPositionMorphTarget;
+            std::uint32_t positionMorphTargetWeightCount;
         };
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            return { hasPositionMorphTarget };
+            return { positionMorphTargetWeightCount };
         }
     };
 
@@ -72,7 +72,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
-        bool hasPositionMorphTarget = false;
+        std::uint32_t positionMorphTargetWeightCount = 0;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
 
         [[nodiscard]] bool operator==(const MaskDepthRendererSpecialization&) const = default;
@@ -126,7 +126,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         struct VertexShaderSpecializationData {
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentType = 5126; // FLOAT
-            vk::Bool32 hasPositionMorphTarget;
+            std::uint32_t positionMorphTargetWeightCount;
         };
 
         struct FragmentShaderSpecializationData {
@@ -142,7 +142,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
-                .hasPositionMorphTarget = hasPositionMorphTarget,
+                .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
             };
 
             if (baseColorTexcoordComponentType) {

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -14,10 +14,65 @@ import :vulkan.specialization_constants.SpecializationMap;
 #define LIFT(...) [&](auto &&...xs) { return __VA_ARGS__(FWD(xs)...); }
 
 namespace vk_gltf_viewer::vulkan::inline pipeline {
+    export class JumpFloodSeedRendererSpecialization {
+    public:
+        bool hasPositionMorphTarget = false;
+
+        [[nodiscard]] bool operator==(const JumpFloodSeedRendererSpecialization&) const = default;
+
+        [[nodiscard]] vk::raii::Pipeline createPipeline(
+            const vk::raii::Device &device,
+            const pl::PrimitiveNoShading &pipelineLayout
+        ) const {
+            return { device, nullptr, vk::StructureChain {
+                vku::getDefaultGraphicsPipelineCreateInfo(
+                    createPipelineStages(
+                        device,
+                        vku::Shader {
+                            shader::jump_flood_seed_vert,
+                            vk::ShaderStageFlagBits::eVertex,
+                            vku::unsafeAddress(vk::SpecializationInfo {
+                                SpecializationMap<VertexShaderSpecializationData>::value,
+                                vku::unsafeProxy(getVertexShaderSpecializationData()),
+                            }),
+                        },
+                        vku::Shader { shader::jump_flood_seed_frag, vk::ShaderStageFlagBits::eFragment }).get(),
+                    *pipelineLayout, 1, true)
+                    .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                        {},
+                        true, true, vk::CompareOp::eGreater, // Use reverse Z.
+                    }))
+                    .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                        {},
+                        vku::unsafeProxy({
+                            vk::DynamicState::eViewport,
+                            vk::DynamicState::eScissor,
+                            vk::DynamicState::eCullMode,
+                        }),
+                    })),
+                vk::PipelineRenderingCreateInfo {
+                    {},
+                    vku::unsafeProxy(vk::Format::eR16G16Uint),
+                    vk::Format::eD32Sfloat,
+                }
+            }.get() };
+        }
+
+    private:
+        struct VertexShaderSpecializationData {
+            vk::Bool32 hasPositionMorphTarget;
+        };
+
+        [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
+            return { hasPositionMorphTarget };
+        }
+    };
+
     class MaskJumpFloodSeedRendererSpecialization {
     public:
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
+        bool hasPositionMorphTarget = false;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
 
         [[nodiscard]] bool operator==(const MaskJumpFloodSeedRendererSpecialization&) const = default;
@@ -71,6 +126,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         struct VertexShaderSpecializationData {
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentType = 5126; // FLOAT
+            vk::Bool32 hasPositionMorphTarget;
         };
 
         struct FragmentShaderSpecializationData {
@@ -85,7 +141,9 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         }
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            VertexShaderSpecializationData result{};
+            VertexShaderSpecializationData result {
+                .hasPositionMorphTarget = hasPositionMorphTarget,
+            };
 
             if (baseColorTexcoordComponentType) {
                 result.texcoordComponentType = *baseColorTexcoordComponentType;
@@ -112,35 +170,4 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             return result;
         }
     };
-    
-    [[nodiscard]] vk::raii::Pipeline createJumpFloodSeedRenderer(
-        const vk::raii::Device &device,
-        const pl::PrimitiveNoShading &pipelineLayout
-    ) {
-        return { device, nullptr, vk::StructureChain {
-            vku::getDefaultGraphicsPipelineCreateInfo(
-                createPipelineStages(
-                    device,
-                    vku::Shader { shader::jump_flood_seed_vert, vk::ShaderStageFlagBits::eVertex },
-                    vku::Shader { shader::jump_flood_seed_frag, vk::ShaderStageFlagBits::eFragment }).get(),
-                *pipelineLayout, 1, true)
-                .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
-                    {},
-                    true, true, vk::CompareOp::eGreater, // Use reverse Z.
-                }))
-                .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
-                    {},
-                    vku::unsafeProxy({
-                        vk::DynamicState::eViewport,
-                        vk::DynamicState::eScissor,
-                        vk::DynamicState::eCullMode,
-                    }),
-                })),
-            vk::PipelineRenderingCreateInfo {
-                {},
-                vku::unsafeProxy(vk::Format::eR16G16Uint),
-                vk::Format::eD32Sfloat,
-            }
-        }.get() };
-    }
 }

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -16,7 +16,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class JumpFloodSeedRendererSpecialization {
     public:
-        bool hasPositionMorphTarget = false;
+        std::uint32_t positionMorphTargetWeightCount = 0;
 
         [[nodiscard]] bool operator==(const JumpFloodSeedRendererSpecialization&) const = default;
 
@@ -60,11 +60,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     private:
         struct VertexShaderSpecializationData {
-            vk::Bool32 hasPositionMorphTarget;
+            std::uint32_t positionMorphTargetWeightCount;
         };
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            return { hasPositionMorphTarget };
+            return { positionMorphTargetWeightCount };
         }
     };
 
@@ -72,7 +72,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
-        bool hasPositionMorphTarget = false;
+        std::uint32_t positionMorphTargetWeightCount = 0;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
 
         [[nodiscard]] bool operator==(const MaskJumpFloodSeedRendererSpecialization&) const = default;
@@ -126,7 +126,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         struct VertexShaderSpecializationData {
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentType = 5126; // FLOAT
-            vk::Bool32 hasPositionMorphTarget;
+            std::uint32_t positionMorphTargetWeightCount;
         };
 
         struct FragmentShaderSpecializationData {
@@ -142,7 +142,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
-                .hasPositionMorphTarget = hasPositionMorphTarget,
+                .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
             };
 
             if (baseColorTexcoordComponentType) {

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -27,6 +27,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         boost::container::static_vector<std::uint8_t, 4> texcoordComponentTypes;
         std::optional<std::pair<std::uint8_t, std::uint8_t>> colorComponentCountAndType;
         bool fragmentShaderGeneratedTBN;
+        std::uint32_t morphTargetWeightCount = 0;
         bool hasPositionMorphTarget = false;
         bool hasNormalMorphTarget = false;
         bool hasTangentMorphTarget = false;
@@ -160,6 +161,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             std::uint32_t packedTexcoordComponentTypes = 0x06060606; // [FLOAT, FLOAT, FLOAT, FLOAT]
             std::uint32_t colorComponentCount = 0;
             std::uint32_t colorComponentType = 5126; // FLOAT
+            std::uint32_t morphTargetWeightCount = 0;
             std::uint32_t packedMorphTargetAvailability = 0x00000000;
         };
 
@@ -177,6 +179,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
+                .morphTargetWeightCount = morphTargetWeightCount,
                 .packedMorphTargetAvailability = (hasPositionMorphTarget ? 1U : 0U)
                                                | (hasNormalMorphTarget ? 2U : 0U)
                                                | (hasTangentMorphTarget ? 4U : 0U),

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -27,6 +27,9 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         boost::container::static_vector<std::uint8_t, 4> texcoordComponentTypes;
         std::optional<std::pair<std::uint8_t, std::uint8_t>> colorComponentCountAndType;
         bool fragmentShaderGeneratedTBN;
+        bool hasPositionMorphTarget = false;
+        bool hasNormalMorphTarget = false;
+        bool hasTangentMorphTarget = false;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
         shader_type::TextureTransform metallicRoughnessTextureTransform = shader_type::TextureTransform::None;
         shader_type::TextureTransform normalTextureTransform = shader_type::TextureTransform::None;
@@ -157,6 +160,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             std::uint32_t packedTexcoordComponentTypes = 0x06060606; // [FLOAT, FLOAT, FLOAT, FLOAT]
             std::uint32_t colorComponentCount = 0;
             std::uint32_t colorComponentType = 5126; // FLOAT
+            std::uint32_t packedMorphTargetAvailability = 0x00000000;
         };
 
         struct FragmentShaderSpecializationData {
@@ -172,7 +176,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         }
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            VertexShaderSpecializationData result{};
+            VertexShaderSpecializationData result {
+                .packedMorphTargetAvailability = (hasPositionMorphTarget ? 1U : 0U)
+                                               | (hasNormalMorphTarget ? 2U : 0U)
+                                               | (hasTangentMorphTarget ? 4U : 0U),
+            };
 
             for (auto [i, componentType] : texcoordComponentTypes | ranges::views::enumerate) {
                 assert(ranges::one_of(componentType, 1 /* UNSIGNED_BYTE */, 3 /* UNSIGNED_SHORT */, 6 /* FLOAT */));

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -23,6 +23,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::pair<std::uint8_t, std::uint8_t>> colorComponentCountAndType;
+        bool hasPositionMorphTarget = false;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
         fastgltf::AlphaMode alphaMode;
 
@@ -149,6 +150,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentCount = 0;
             std::uint32_t colorComponentType = 5126; // FLOAT
+            vk::Bool32 hasPositionMorphTarget;
         };
 
         struct FragmentShaderSpecializationData {
@@ -163,7 +165,9 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         }
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            VertexShaderSpecializationData result{};
+            VertexShaderSpecializationData result {
+                .hasPositionMorphTarget = hasPositionMorphTarget,
+            };
 
             if (baseColorTexcoordComponentType) {
                 result.texcoordComponentType = *baseColorTexcoordComponentType;

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -23,7 +23,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::pair<std::uint8_t, std::uint8_t>> colorComponentCountAndType;
-        bool hasPositionMorphTarget = false;
+        std::uint32_t positionMorphTargetWeightCount = 0;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
         fastgltf::AlphaMode alphaMode;
 
@@ -150,7 +150,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentCount = 0;
             std::uint32_t colorComponentType = 5126; // FLOAT
-            vk::Bool32 hasPositionMorphTarget;
+            std::uint32_t positionMorphTargetWeightCount;
         };
 
         struct FragmentShaderSpecializationData {
@@ -166,7 +166,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
-                .hasPositionMorphTarget = hasPositionMorphTarget,
+                .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
             };
 
             if (baseColorTexcoordComponentType) {

--- a/interface/vulkan/shader_type/Node.cppm
+++ b/interface/vulkan/shader_type/Node.cppm
@@ -5,17 +5,14 @@ module;
 export module vk_gltf_viewer:vulkan.shader_type.Node;
 
 import std;
-export import vulkan_hpp;
 
 namespace vk_gltf_viewer::vulkan::shader_type {
     export struct Node {
-        vk::DeviceAddress morphTargetWeightsStartAddress;
-        std::uint32_t morphTargetWeightsCount;
         std::uint32_t instancedTransformStartIndex;
+        std::uint32_t morphTargetWeightStartIndex;
     };
 
-    static_assert(sizeof(Node) == 16);
-    static_assert(offsetof(Node, morphTargetWeightsStartAddress) == 0);
-    static_assert(offsetof(Node, morphTargetWeightsCount) == 8);
-    static_assert(offsetof(Node, instancedTransformStartIndex) == 12);
+    static_assert(sizeof(Node) == 8);
+    static_assert(offsetof(Node, instancedTransformStartIndex) == 0);
+    static_assert(offsetof(Node, morphTargetWeightStartIndex) == 4);
 }

--- a/interface/vulkan/shader_type/Node.cppm
+++ b/interface/vulkan/shader_type/Node.cppm
@@ -1,0 +1,21 @@
+module;
+
+#include <cstddef>
+
+export module vk_gltf_viewer:vulkan.shader_type.Node;
+
+import std;
+export import vulkan_hpp;
+
+namespace vk_gltf_viewer::vulkan::shader_type {
+    export struct Node {
+        vk::DeviceAddress morphTargetWeightsStartAddress;
+        std::uint32_t morphTargetWeightsCount;
+        std::uint32_t instancedTransformStartIndex;
+    };
+
+    static_assert(sizeof(Node) == 16);
+    static_assert(offsetof(Node, morphTargetWeightsStartAddress) == 0);
+    static_assert(offsetof(Node, morphTargetWeightsCount) == 8);
+    static_assert(offsetof(Node, instancedTransformStartIndex) == 12);
+}

--- a/interface/vulkan/shader_type/Primitive.cppm
+++ b/interface/vulkan/shader_type/Primitive.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <cstddef>
+
 export module vk_gltf_viewer:vulkan.shader_type.Primitive;
 
 import std;
@@ -6,8 +10,11 @@ export import vulkan_hpp;
 namespace vk_gltf_viewer::vulkan::shader_type {
     export struct Primitive {
         vk::DeviceAddress pPositionBuffer;
+        vk::DeviceAddress pPositionMorphTargetAccessorBuffer;
         vk::DeviceAddress pNormalBuffer;
+        vk::DeviceAddress pNormalMorphTargetAccessorBuffer;
         vk::DeviceAddress pTangentBuffer;
+        vk::DeviceAddress pTangentMorphTargetAccessorBuffer;
         vk::DeviceAddress pTexcoordAttributeMappingInfoBuffer;
         vk::DeviceAddress pColorBuffer;
         std::uint8_t positionByteStride;
@@ -15,5 +22,10 @@ namespace vk_gltf_viewer::vulkan::shader_type {
         std::uint8_t tangentByteStride;
         std::uint8_t colorByteStride;
         std::uint32_t materialIndex;
+        std::uint8_t _padding0_[8];
     };
+
+    static_assert(sizeof(Primitive) == 80);
+    static_assert(offsetof(Primitive, positionByteStride) == 64);
+    static_assert(offsetof(Primitive, materialIndex) == 68);
 }

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -25,6 +25,9 @@ layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
 layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
 };
+layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
+    float morphTargetWeights[];
+};
 
 layout (push_constant) uniform PushConstant {
     mat4 projectionView;

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -12,13 +12,15 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
+layout (constant_id = 0) const bool HAS_POSITION_MORPH_TARGET = false;
+
 layout (location = 0) flat out uint outNodeIndex;
 
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
-    uint instancedTransformStartIndices[];
+    Node nodes[];
 };
 layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
@@ -33,6 +35,6 @@ layout (push_constant) uniform PushConstant {
 void main(){
     outNodeIndex = NODE_INDEX;
 
-    vec3 inPosition = getPosition();
+    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -12,7 +12,7 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (constant_id = 0) const bool HAS_POSITION_MORPH_TARGET = false;
+layout (constant_id = 0) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (location = 0) flat out uint outNodeIndex;
 
@@ -35,6 +35,6 @@ layout (push_constant) uniform PushConstant {
 void main(){
     outNodeIndex = NODE_INDEX;
 
-    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
+    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/indexing.glsl
+++ b/shaders/indexing.glsl
@@ -7,8 +7,9 @@
 #define PRIMITIVE_INDEX gl_BaseInstance & 0xFFFFU
 #define PRIMITIVE primitives[PRIMITIVE_INDEX]
 #define NODE_INDEX gl_BaseInstance >> 16U
+#define NODE nodes[NODE_INDEX]
 #define INSTANCE_INDEX gl_InstanceIndex - gl_BaseInstance
-#define TRANSFORM instancedTransforms[instancedTransformStartIndices[NODE_INDEX] + INSTANCE_INDEX]
+#define TRANSFORM instancedTransforms[NODE.instancedTransformStartIndex + INSTANCE_INDEX]
 #define MATERIAL_INDEX PRIMITIVE.materialIndex
 #define MATERIAL materials[MATERIAL_INDEX]
 

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -12,11 +12,13 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
+layout (constant_id = 0) const bool HAS_POSITION_MORPH_TARGET = false;
+
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
-    uint instancedTransformStartIndices[];
+    Node nodes[];
 };
 layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
@@ -29,6 +31,6 @@ layout (push_constant) uniform PushConstant {
 #include "vertex_pulling.glsl"
 
 void main(){
-    vec3 inPosition = getPosition();
+    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -12,7 +12,7 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (constant_id = 0) const bool HAS_POSITION_MORPH_TARGET = false;
+layout (constant_id = 0) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
@@ -31,6 +31,6 @@ layout (push_constant) uniform PushConstant {
 #include "vertex_pulling.glsl"
 
 void main(){
-    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
+    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -23,6 +23,9 @@ layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
 layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
 };
+layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
+    float morphTargetWeights[];
+};
 
 layout (push_constant) uniform PushConstant {
     mat4 projectionView;

--- a/shaders/mask_depth.frag
+++ b/shaders/mask_depth.frag
@@ -27,10 +27,10 @@ layout (location = 2) in FRAG_VARIADIC_IN {
 
 layout (location = 0) out uint outNodeIndex;
 
-layout (set = 0, binding = 3, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 4, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 0, binding = 4) uniform sampler2D textures[];
+layout (set = 0, binding = 5) uniform sampler2D textures[];
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -16,7 +16,7 @@
 
 layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 1) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 2) const bool HAS_POSITION_MORPH_TARGET = false;
+layout (constant_id = 2) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (location = 0) flat out uint outNodeIndex;
 layout (location = 1) flat out uint outMaterialIndex;
@@ -60,6 +60,6 @@ void main(){
     variadic_out.colorAlpha = getColorAlpha();
 #endif
 
-    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
+    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -40,7 +40,10 @@ layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
 layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
 };
-layout (set = 0, binding = 3, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
+    float morphTargetWeights[];
+};
+layout (set = 0, binding = 4, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -16,6 +16,7 @@
 
 layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 1) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 2) const bool HAS_POSITION_MORPH_TARGET = false;
 
 layout (location = 0) flat out uint outNodeIndex;
 layout (location = 1) flat out uint outMaterialIndex;
@@ -34,7 +35,7 @@ layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
-    uint instancedTransformStartIndices[];
+    Node nodes[];
 };
 layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
@@ -59,6 +60,6 @@ void main(){
     variadic_out.colorAlpha = getColorAlpha();
 #endif
 
-    vec3 inPosition = getPosition();
+    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -26,10 +26,10 @@ layout (location = 1) in FRAG_VARIDIC_IN {
 
 layout (location = 0) out uvec2 outCoordinate;
 
-layout (set = 0, binding = 3, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 4, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 0, binding = 4) uniform sampler2D textures[];
+layout (set = 0, binding = 5) uniform sampler2D textures[];
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -16,6 +16,7 @@
 
 layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 1) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 2) const bool HAS_POSITION_MORPH_TARGET = false;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -33,7 +34,7 @@ layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
-    uint instancedTransformStartIndices[];
+    Node nodes[];
 };
 layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
@@ -57,6 +58,6 @@ void main(){
     variadic_out.colorAlpha = getColorAlpha();
 #endif
 
-    vec3 inPosition = getPosition();
+    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -39,7 +39,10 @@ layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
 layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
 };
-layout (set = 0, binding = 3, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
+    float morphTargetWeights[];
+};
+layout (set = 0, binding = 4, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -16,7 +16,7 @@
 
 layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 1) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 2) const bool HAS_POSITION_MORPH_TARGET = false;
+layout (constant_id = 2) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -58,6 +58,6 @@ void main(){
     variadic_out.colorAlpha = getColorAlpha();
 #endif
 
-    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
+    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -54,10 +54,10 @@ layout (set = 0, binding = 0, scalar) uniform SphericalHarmonicsBuffer {
 layout (set = 0, binding = 1) uniform samplerCube prefilteredmap;
 layout (set = 0, binding = 2) uniform sampler2D brdfmap;
 
-layout (set = 1, binding = 3, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 4, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 1, binding = 4) uniform sampler2D textures[];
+layout (set = 1, binding = 5) uniform sampler2D textures[];
 
 layout (push_constant, std430) uniform PushConstant {
     mat4 projectionView;

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -55,7 +55,10 @@ layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {
 layout (set = 1, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
 };
-layout (set = 1, binding = 3, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 3) readonly buffer MorphTargetWeightBuffer {
+    float morphTargetWeights[];
+};
+layout (set = 1, binding = 4, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -17,7 +17,8 @@
 layout (constant_id = 0) const uint PACKED_TEXCOORD_COMPONENT_TYPES = 0x06060606; // [FLOAT, FLOAT, FLOAT, FLOAT]
 layout (constant_id = 1) const uint COLOR_COMPONENT_COUNT = 0;
 layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 3) const uint PACKED_MORPH_TARGET_AVAILABILITY = 0;
+layout (constant_id = 3) const uint MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 4) const uint PACKED_MORPH_TARGET_AVAILABILITY = 0;
 
 layout (location = 0) out vec3 outPosition;
 layout (location = 1) flat out uint outMaterialIndex;
@@ -66,17 +67,17 @@ layout (push_constant, std430) uniform PushConstant {
 #include "vertex_pulling.glsl"
 
 void main(){
-    vec3 inPosition = getPosition((PACKED_MORPH_TARGET_AVAILABILITY & 0x1U) == 0x1U);
+    vec3 inPosition = getPosition((PACKED_MORPH_TARGET_AVAILABILITY & 0x1U) == 0x1U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
     outPosition = (TRANSFORM * vec4(inPosition, 1.0)).xyz;
 
     outMaterialIndex = MATERIAL_INDEX;
 
 #if !FRAGMENT_SHADER_GENERATED_TBN
-    vec3 inNormal = getNormal((PACKED_MORPH_TARGET_AVAILABILITY & 0x2U) == 0x2U);
+    vec3 inNormal = getNormal((PACKED_MORPH_TARGET_AVAILABILITY & 0x2U) == 0x2U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
     variadic_out.tbn[2] = normalize(mat3(TRANSFORM) * inNormal); // N
 
     if (int(MATERIAL.normalTextureIndex) != -1){
-        vec4 inTangent = getTangent((PACKED_MORPH_TARGET_AVAILABILITY & 0x4U) == 0x4U);
+        vec4 inTangent = getTangent((PACKED_MORPH_TARGET_AVAILABILITY & 0x4U) == 0x4U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
         variadic_out.tbn[0] = normalize(mat3(TRANSFORM) * inTangent.xyz); // T
         variadic_out.tbn[1] = cross(variadic_out.tbn[2], variadic_out.tbn[0]) * -inTangent.w; // B
     }

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -17,6 +17,7 @@
 layout (constant_id = 0) const uint PACKED_TEXCOORD_COMPONENT_TYPES = 0x06060606; // [FLOAT, FLOAT, FLOAT, FLOAT]
 layout (constant_id = 1) const uint COLOR_COMPONENT_COUNT = 0;
 layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 3) const uint PACKED_MORPH_TARGET_AVAILABILITY = 0;
 
 layout (location = 0) out vec3 outPosition;
 layout (location = 1) flat out uint outMaterialIndex;
@@ -48,7 +49,7 @@ layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {
-    uint instancedTransformStartIndices[];
+    Node nodes[];
 };
 layout (set = 1, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
@@ -65,17 +66,17 @@ layout (push_constant, std430) uniform PushConstant {
 #include "vertex_pulling.glsl"
 
 void main(){
-    vec3 inPosition = getPosition();
+    vec3 inPosition = getPosition((PACKED_MORPH_TARGET_AVAILABILITY & 0x1U) == 0x1U);
     outPosition = (TRANSFORM * vec4(inPosition, 1.0)).xyz;
 
     outMaterialIndex = MATERIAL_INDEX;
 
 #if !FRAGMENT_SHADER_GENERATED_TBN
-    vec3 inNormal = getNormal();
+    vec3 inNormal = getNormal((PACKED_MORPH_TARGET_AVAILABILITY & 0x2U) == 0x2U);
     variadic_out.tbn[2] = normalize(mat3(TRANSFORM) * inNormal); // N
 
     if (int(MATERIAL.normalTextureIndex) != -1){
-        vec4 inTangent = getTangent();
+        vec4 inTangent = getTangent((PACKED_MORPH_TARGET_AVAILABILITY & 0x4U) == 0x4U);
         variadic_out.tbn[0] = normalize(mat3(TRANSFORM) * inTangent.xyz); // T
         variadic_out.tbn[1] = cross(variadic_out.tbn[2], variadic_out.tbn[0]) * -inTangent.w; // B
     }

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -34,12 +34,9 @@ struct Material {
 
 #ifdef VERTEX_SHADER
 
-layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer FloatArray { float data[]; };
-
 struct Node {
-    FloatArray morphTargetWeights;
-    uint morphTargetWeightCount;
     uint instancedTransformStartIndex;
+    uint morphTargetWeightStartIndex;
 };
 
 struct Accessor {

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -34,6 +34,14 @@ struct Material {
 
 #ifdef VERTEX_SHADER
 
+layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer FloatArray { float data[]; };
+
+struct Node {
+    FloatArray morphTargetWeights;
+    uint morphTargetWeightCount;
+    uint instancedTransformStartIndex;
+};
+
 struct Accessor {
     uint64_t bufferAddress;
     uint8_t componentType;
@@ -42,12 +50,19 @@ struct Accessor {
     uint8_t _padding_[5];
 };
 
+uint64_t getFetchAddress(Accessor accessor, uint index) {
+    return accessor.bufferAddress + uint(accessor.stride) * index;
+}
+
 layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Accessors { Accessor data[]; };
 
 struct Primitive {
     uint64_t pPositionBuffer;
+    Accessors positionMorphTargetAccessors;
     uint64_t pNormalBuffer;
+    Accessors normalMorphTargetAccessors;
     uint64_t pTangentBuffer;
+    Accessors tangentMorphTargetAccessors;
     Accessors texcoordAccessors;
     uint64_t pColorBuffer;
     uint8_t positionByteStride;
@@ -55,6 +70,7 @@ struct Primitive {
     uint8_t tangentByteStride;
     uint8_t colorByteStride;
     uint materialIndex;
+    vec2 _padding0_;
 };
 
 #endif

--- a/shaders/unlit_primitive.frag
+++ b/shaders/unlit_primitive.frag
@@ -30,10 +30,10 @@ layout (location = 0) out vec4 outColor;
 layout (location = 1) out float outRevealage;
 #endif
 
-layout (set = 1, binding = 3, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 4, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 1, binding = 4) uniform sampler2D textures[];
+layout (set = 1, binding = 5) uniform sampler2D textures[];
 
 #if ALPHA_MODE == 0 || ALPHA_MODE == 2
 layout (early_fragment_tests) in;

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -17,6 +17,7 @@
 layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 1) const uint COLOR_COMPONENT_COUNT = 0;
 layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 3) const bool HAS_POSITION_MORPH_TARGET = false;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -35,7 +36,7 @@ layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {
-    uint instancedTransformStartIndices[];
+    Node nodes[];
 };
 layout (set = 1, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
@@ -52,7 +53,7 @@ layout (push_constant, std430) uniform PushConstant {
 #include "vertex_pulling.glsl"
 
 void main(){
-    vec3 inPosition = getPosition();
+    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
 
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -17,7 +17,7 @@
 layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 1) const uint COLOR_COMPONENT_COUNT = 0;
 layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 3) const bool HAS_POSITION_MORPH_TARGET = false;
+layout (constant_id = 3) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -53,7 +53,7 @@ layout (push_constant, std430) uniform PushConstant {
 #include "vertex_pulling.glsl"
 
 void main(){
-    vec3 inPosition = getPosition(HAS_POSITION_MORPH_TARGET);
+    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
 
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -41,7 +41,10 @@ layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {
 layout (set = 1, binding = 2) readonly buffer InstancedTransformBuffer {
     mat4 instancedTransforms[];
 };
-layout (set = 1, binding = 3, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 3) readonly buffer MorphTargetWeightBuffer {
+    float morphTargetWeights[];
+};
+layout (set = 1, binding = 4, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/vertex_pulling.glsl
+++ b/shaders/vertex_pulling.glsl
@@ -18,48 +18,42 @@ layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Ve
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
 
-vec3 getPosition(bool hasMorphTarget) {
+vec3 getPosition(uint morphTargetWeightCount) {
     uint64_t fetchAddress = PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * uint(gl_VertexIndex);
     vec3 position = Vec3Ref(fetchAddress).data;
 
-    if (hasMorphTarget) {
-        for (uint i = 0; i < NODE.morphTargetWeightCount; i++) {
-            Accessor accessor = PRIMITIVE.positionMorphTargetAccessors.data[i];
-            fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
-            position += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
-        }
+    for (uint i = 0; i < morphTargetWeightCount; i++) {
+        Accessor accessor = PRIMITIVE.positionMorphTargetAccessors.data[i];
+        fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
+        position += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
     }
 
     return position;
 }
 
-vec3 getNormal(bool hasMorphTarget) {
+vec3 getNormal(uint morphTargetWeightCount) {
     uint64_t fetchAddress = PRIMITIVE.pNormalBuffer + uint(PRIMITIVE.normalByteStride) * uint(gl_VertexIndex);
     vec3 normal = Vec3Ref(fetchAddress).data;
 
-    if (hasMorphTarget) {
-        for (uint i = 0; i < NODE.morphTargetWeightCount; i++) {
-            Accessor accessor = PRIMITIVE.normalMorphTargetAccessors.data[i];
-            fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
-            normal += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
-        }
+    for (uint i = 0; i < morphTargetWeightCount; i++) {
+        Accessor accessor = PRIMITIVE.normalMorphTargetAccessors.data[i];
+        fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
+        normal += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
     }
 
     return normal;
 }
 
-vec4 getTangent(bool hasMorphTarget) {
+vec4 getTangent(uint morphTargetWeightCount) {
     uint64_t fetchAddress = PRIMITIVE.pTangentBuffer + uint(PRIMITIVE.tangentByteStride) * uint(gl_VertexIndex);
     vec4 tangent = Vec4Ref(fetchAddress).data;
 
-    if (hasMorphTarget) {
-        for (uint i = 0; i < NODE.morphTargetWeightCount; i++) {
-            Accessor accessor = PRIMITIVE.tangentMorphTargetAccessors.data[i];
-            fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
+    for (uint i = 0; i < morphTargetWeightCount; i++) {
+        Accessor accessor = PRIMITIVE.tangentMorphTargetAccessors.data[i];
+        fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
 
-            // Tangent morph target only adds XYZ vertex tangent displacements.
-            tangent.xyz += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
-        }
+        // Tangent morph target only adds XYZ vertex tangent displacements.
+        tangent.xyz += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
     }
 
     return tangent;

--- a/shaders/vertex_pulling.glsl
+++ b/shaders/vertex_pulling.glsl
@@ -25,7 +25,7 @@ vec3 getPosition(uint morphTargetWeightCount) {
     for (uint i = 0; i < morphTargetWeightCount; i++) {
         Accessor accessor = PRIMITIVE.positionMorphTargetAccessors.data[i];
         fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
-        position += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
+        position += Vec3Ref(fetchAddress).data * morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
     }
 
     return position;
@@ -38,7 +38,7 @@ vec3 getNormal(uint morphTargetWeightCount) {
     for (uint i = 0; i < morphTargetWeightCount; i++) {
         Accessor accessor = PRIMITIVE.normalMorphTargetAccessors.data[i];
         fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
-        normal += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
+        normal += Vec3Ref(fetchAddress).data * morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
     }
 
     return normal;
@@ -53,7 +53,7 @@ vec4 getTangent(uint morphTargetWeightCount) {
         fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
 
         // Tangent morph target only adds XYZ vertex tangent displacements.
-        tangent.xyz += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
+        tangent.xyz += Vec3Ref(fetchAddress).data * morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
     }
 
     return tangent;

--- a/shaders/vertex_pulling.glsl
+++ b/shaders/vertex_pulling.glsl
@@ -18,25 +18,57 @@ layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Ve
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
 
-vec3 getPosition() {
+vec3 getPosition(bool hasMorphTarget) {
     uint64_t fetchAddress = PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * uint(gl_VertexIndex);
-    return Vec3Ref(fetchAddress).data;
+    vec3 position = Vec3Ref(fetchAddress).data;
+
+    if (hasMorphTarget) {
+        for (uint i = 0; i < NODE.morphTargetWeightCount; i++) {
+            Accessor accessor = PRIMITIVE.positionMorphTargetAccessors.data[i];
+            fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
+            position += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
+        }
+    }
+
+    return position;
 }
 
-vec3 getNormal() {
+vec3 getNormal(bool hasMorphTarget) {
     uint64_t fetchAddress = PRIMITIVE.pNormalBuffer + uint(PRIMITIVE.normalByteStride) * uint(gl_VertexIndex);
-    return Vec3Ref(fetchAddress).data;
+    vec3 normal = Vec3Ref(fetchAddress).data;
+
+    if (hasMorphTarget) {
+        for (uint i = 0; i < NODE.morphTargetWeightCount; i++) {
+            Accessor accessor = PRIMITIVE.normalMorphTargetAccessors.data[i];
+            fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
+            normal += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
+        }
+    }
+
+    return normal;
 }
 
-vec4 getTangent() {
+vec4 getTangent(bool hasMorphTarget) {
     uint64_t fetchAddress = PRIMITIVE.pTangentBuffer + uint(PRIMITIVE.tangentByteStride) * uint(gl_VertexIndex);
-    return Vec4Ref(fetchAddress).data;
+    vec4 tangent = Vec4Ref(fetchAddress).data;
+
+    if (hasMorphTarget) {
+        for (uint i = 0; i < NODE.morphTargetWeightCount; i++) {
+            Accessor accessor = PRIMITIVE.tangentMorphTargetAccessors.data[i];
+            fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
+
+            // Tangent morph target only adds XYZ vertex tangent displacements.
+            tangent.xyz += Vec3Ref(fetchAddress).data * NODE.morphTargetWeights.data[i];
+        }
+    }
+
+    return tangent;
 }
 
 #if TEXCOORD_COUNT >= 1
 vec2 getTexcoord(uint texcoordIndex){
     Accessor texcoordAccessor = PRIMITIVE.texcoordAccessors.data[texcoordIndex];
-    uint64_t fetchAddress = texcoordAccessor.bufferAddress + uint(texcoordAccessor.stride) * uint(gl_VertexIndex);
+    uint64_t fetchAddress = getFetchAddress(texcoordAccessor, gl_VertexIndex);
 
     switch ((PACKED_TEXCOORD_COMPONENT_TYPES >> (8U * texcoordIndex)) & 0xFFU) {
     case 1U: // UNSIGNED BYTE
@@ -53,7 +85,7 @@ vec2 getTexcoord(uint texcoordIndex){
 #if HAS_BASE_COLOR_TEXTURE
 vec2 getTexcoord(uint texcoordIndex){
     Accessor texcoordAccessor = PRIMITIVE.texcoordAccessors.data[texcoordIndex];
-    uint64_t fetchAddress = texcoordAccessor.bufferAddress + uint(texcoordAccessor.stride) * uint(gl_VertexIndex);
+    uint64_t fetchAddress = getFetchAddress(texcoordAccessor, gl_VertexIndex);
 
     switch (TEXCOORD_COMPONENT_TYPE) {
     case 1U: // UNSIGNED BYTE


### PR DESCRIPTION
This PR implemented the concept of [glTF's morph target](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#morph-targets), for `POSITION`, `NORMAL` and `TANGENT` attributes. Morphing offset calculation is done in the vertex shader only if the regarding specialization constants set to true, unlimited target weights count and per-accessor stride (i.e. different byte stride of the accessors in the same morph target attributes) are supported.

Interactive GUI is provided for adjusting target weights.