### PR TITLE
Implemented KHR_mesh_quantization extension support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Blazingly fast[^1] Vulkan glTF viewer.
 - Support glTF 2.0 extensions:
   - [`KHR_materials_unlit`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_unlit) for lighting independent material shading
   - [`KHR_materials_variants`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_variants)
+  - [`KHR_mesh_quantization`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_mesh_quantization)
   - [`KHR_texture_basisu`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_basisu) for BC7 GPU compression texture decoding
   - [`KHR_texture_transform`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform)
   - [`EXT_mesh_gpu_instancing`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing) for instancing multiple meshes with the same geometry

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -16,6 +16,7 @@ import :helpers.optional;
 import :helpers.ranges;
 import :vulkan.ag.DepthPrepass;
 import :vulkan.buffer.IndirectDrawCommands;
+import :vulkan.shader_type.Accessor;
 
 constexpr auto NO_INDEX = std::numeric_limits<std::uint16_t>::max();
 
@@ -147,6 +148,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
 
             if (material.unlit) {
                 result.pipeline = sharedData.getUnlitPrimitiveRenderer({
+                    .positionComponentType = accessors.positionAccessor.componentType,
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return accessors.texcoordAccessors.at(textureInfo.texCoordIndex).componentType;
                     }),
@@ -162,6 +164,13 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
             }
             else {
                 result.pipeline = sharedData.getPrimitiveRenderer({
+                    .positionComponentType = accessors.positionAccessor.componentType,
+                    .normalComponentType = accessors.normalAccessor.transform([](const shader_type::Accessor &accessor) {
+                        return accessor.componentType;
+                     }),
+                    .tangentComponentType = accessors.tangentAccessor.transform([](const shader_type::Accessor &accessor) {
+                        return accessor.componentType;
+                     }),
                     .texcoordComponentTypes = accessors.texcoordAccessors
                         | std::views::transform([](const auto &info) {
                             return info.componentType;
@@ -202,6 +211,13 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
         }
         else {
             result.pipeline = sharedData.getPrimitiveRenderer({
+                .positionComponentType = accessors.positionAccessor.componentType,
+                .normalComponentType = accessors.normalAccessor.transform([](const shader_type::Accessor &accessor) {
+                    return accessor.componentType;
+                }),
+                .tangentComponentType = accessors.tangentAccessor.transform([](const shader_type::Accessor &accessor) {
+                    return accessor.componentType;
+                }),
                 .texcoordComponentTypes = accessors.texcoordAccessors
                     | std::views::transform([](const auto &info) {
                         return info.componentType;
@@ -238,6 +254,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
             const fastgltf::Material& material = task.gltf->asset.materials[*primitive.materialIndex];
             if (material.alphaMode == fastgltf::AlphaMode::Mask) {
                 result.pipeline = sharedData.getMaskDepthRenderer({
+                    .positionComponentType = accessors.positionAccessor.componentType,
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return accessors.texcoordAccessors.at(textureInfo.texCoordIndex).componentType;
                     }),
@@ -253,6 +270,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
             }
             else {
                 result.pipeline = sharedData.getDepthRenderer({
+                    .positionComponentType = accessors.positionAccessor.componentType,
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                 });
             }
@@ -260,6 +278,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
         }
         else {
             result.pipeline = sharedData.getDepthRenderer({
+                .positionComponentType = accessors.positionAccessor.componentType,
                 .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
             });
         }
@@ -279,6 +298,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
             const fastgltf::Material &material = task.gltf->asset.materials[*primitive.materialIndex];
             if (material.alphaMode == fastgltf::AlphaMode::Mask) {
                 result.pipeline = sharedData.getMaskJumpFloodSeedRenderer({
+                    .positionComponentType = accessors.positionAccessor.componentType,
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return accessors.texcoordAccessors.at(textureInfo.texCoordIndex).componentType;
                     }),
@@ -294,6 +314,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
             }
             else {
                 result.pipeline = sharedData.getJumpFloodSeedRenderer({
+                    .positionComponentType = accessors.positionAccessor.componentType,
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                 });
             }
@@ -301,6 +322,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
         }
         else {
             result.pipeline = sharedData.getJumpFloodSeedRenderer({
+                .positionComponentType = accessors.positionAccessor.componentType,
                 .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
             });
         }

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -26,6 +26,7 @@ namespace vk_gltf_viewer {
         static constexpr fastgltf::Extensions SUPPORTED_EXTENSIONS
             = fastgltf::Extensions::KHR_materials_unlit
             | fastgltf::Extensions::KHR_materials_variants
+            | fastgltf::Extensions::KHR_mesh_quantization
             | fastgltf::Extensions::KHR_texture_basisu
             | fastgltf::Extensions::KHR_texture_transform
             | fastgltf::Extensions::EXT_mesh_gpu_instancing;

--- a/interface/vulkan/buffer/PrimitiveAttributes.cppm
+++ b/interface/vulkan/buffer/PrimitiveAttributes.cppm
@@ -239,7 +239,8 @@ namespace vk_gltf_viewer::vulkan::buffer {
                     const auto getGpuAccessor = [&](std::size_t accessorIndex) {
                         const fastgltf::Accessor &accessor = asset.accessors[accessorIndex];
                         shader_type::Accessor result {
-                            .componentType = static_cast<std::uint8_t>(getGLComponentType(accessor.componentType) - getGLComponentType(fastgltf::ComponentType::Byte)),
+                            .componentType = static_cast<std::uint8_t>((accessor.normalized ? 8U : 0U)
+                                | (getGLComponentType(accessor.componentType) - getGLComponentType(fastgltf::ComponentType::Byte))),
                             .componentCount = static_cast<std::uint8_t>(getNumComponents(accessor.type)),
                         };
 

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -16,6 +16,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class DepthRendererSpecialization {
     public:
+        std::uint8_t positionComponentType = 0;
         std::uint32_t positionMorphTargetWeightCount = 0;
 
         [[nodiscard]] bool operator==(const DepthRendererSpecialization&) const = default;
@@ -60,16 +61,18 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     private:
         struct VertexShaderSpecializationData {
+            std::uint32_t positionComponentType;
             std::uint32_t positionMorphTargetWeightCount;
         };
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            return { positionMorphTargetWeightCount };
+            return { positionComponentType, positionMorphTargetWeightCount };
         }
     };
 
     class MaskDepthRendererSpecialization {
     public:
+        std::uint8_t positionComponentType;
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
         std::uint32_t positionMorphTargetWeightCount = 0;
@@ -124,6 +127,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     private:
         struct VertexShaderSpecializationData {
+            std::uint32_t positionComponentType;
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentType = 5126; // FLOAT
             std::uint32_t positionMorphTargetWeightCount;
@@ -142,6 +146,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
+                .positionComponentType = positionComponentType,
                 .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
             };
 

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -16,6 +16,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class JumpFloodSeedRendererSpecialization {
     public:
+        std::uint8_t positionComponentType = 0;
         std::uint32_t positionMorphTargetWeightCount = 0;
 
         [[nodiscard]] bool operator==(const JumpFloodSeedRendererSpecialization&) const = default;
@@ -60,16 +61,18 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     private:
         struct VertexShaderSpecializationData {
+            std::uint32_t positionComponentType;
             std::uint32_t positionMorphTargetWeightCount;
         };
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            return { positionMorphTargetWeightCount };
+            return { positionComponentType, positionMorphTargetWeightCount };
         }
     };
 
     class MaskJumpFloodSeedRendererSpecialization {
     public:
+        std::uint8_t positionComponentType;
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
         std::uint32_t positionMorphTargetWeightCount = 0;
@@ -124,6 +127,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     private:
         struct VertexShaderSpecializationData {
+            std::uint32_t positionComponentType;
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentType = 5126; // FLOAT
             std::uint32_t positionMorphTargetWeightCount;
@@ -142,6 +146,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
+                .positionComponentType = positionComponentType,
                 .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
             };
 

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -21,6 +21,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class UnlitPrimitiveRendererSpecialization {
     public:
+        std::uint8_t positionComponentType;
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::pair<std::uint8_t, std::uint8_t>> colorComponentCountAndType;
         std::uint32_t positionMorphTargetWeightCount = 0;
@@ -147,6 +148,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     private:
         struct VertexShaderSpecializationData {
+            std::uint32_t positionComponentType;
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentCount = 0;
             std::uint32_t colorComponentType = 5126; // FLOAT
@@ -166,6 +168,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
+                .positionComponentType = positionComponentType,
                 .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
             };
 

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -12,7 +12,8 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (constant_id = 0) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
+layout (constant_id = 1) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (location = 0) flat out uint outNodeIndex;
 
@@ -38,6 +39,6 @@ layout (push_constant) uniform PushConstant {
 void main(){
     outNodeIndex = NODE_INDEX;
 
-    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/dequantize.glsl
+++ b/shaders/dequantize.glsl
@@ -1,32 +1,64 @@
 #ifndef DEQUANTIZE_GLSL
 #define DEQUANTIZE_GLSL
 
+float dequantize(int8_t data) {
+    return max(float(data) / 127.0, -1.0);
+}
+
 float dequantize(uint8_t data) {
     return float(data) / 255.0;
+}
+
+float dequantize(int16_t data) {
+    return max(float(data) / 32767.0, -1.0);
 }
 
 float dequantize(uint16_t data) {
     return float(data) / 65536.0;
 }
 
+vec2 dequantize(i8vec2 data) {
+    return max(vec2(data) / 127.0, -1.0);
+}
+
 vec2 dequantize(u8vec2 data) {
     return vec2(data) / 255.0;
+}
+
+vec2 dequantize(i16vec2 data) {
+    return max(vec2(data) / 32767.0, -1.0);
 }
 
 vec2 dequantize(u16vec2 data) {
     return vec2(data) / 65536.0;
 }
 
+vec3 dequantize(i8vec3 data) {
+    return max(vec3(data) / 127.0, -1.0);
+}
+
 vec3 dequantize(u8vec3 data) {
     return vec3(data) / 255.0;
+}
+
+vec3 dequantize(i16vec3 data) {
+    return max(vec3(data) / 32767.0, -1.0);
 }
 
 vec3 dequantize(u16vec3 data) {
     return vec3(data) / 65536.0;
 }
 
+vec4 dequantize(i8vec4 data) {
+    return max(vec4(data) / 127.0, -1.0);
+}
+
 vec4 dequantize(u8vec4 data) {
     return vec4(data) / 255.0;
+}
+
+vec4 dequantize(i16vec4 data) {
+    return max(vec4(data) / 32767.0, -1.0);
 }
 
 vec4 dequantize(u16vec4 data) {

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -12,7 +12,8 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-layout (constant_id = 0) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
+layout (constant_id = 1) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
@@ -34,6 +35,6 @@ layout (push_constant) uniform PushConstant {
 #include "vertex_pulling.glsl"
 
 void main(){
-    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -57,10 +57,10 @@ void main(){
     outNodeIndex = NODE_INDEX;
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE
-    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
+    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex), TEXCOORD_COMPONENT_TYPE);
 #endif
 #if HAS_COLOR_ALPHA_ATTRIBUTE
-    variadic_out.colorAlpha = getColorAlpha();
+    variadic_out.colorAlpha = getColorAlpha(COLOR_COMPONENT_TYPE);
 #endif
 
     vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -14,9 +14,10 @@
 
 #define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
 
-layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 1) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 2) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
+layout (constant_id = 1) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 3) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (location = 0) flat out uint outNodeIndex;
 layout (location = 1) flat out uint outMaterialIndex;
@@ -63,6 +64,6 @@ void main(){
     variadic_out.colorAlpha = getColorAlpha(COLOR_COMPONENT_TYPE);
 #endif
 
-    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -55,10 +55,10 @@ layout (push_constant, std430) uniform PushConstant {
 void main(){
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE
-    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
+    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex), TEXCOORD_COMPONENT_TYPE);
 #endif
 #if HAS_COLOR_ALPHA_ATTRIBUTE
-    variadic_out.colorAlpha = getColorAlpha();
+    variadic_out.colorAlpha = getColorAlpha(COLOR_COMPONENT_TYPE);
 #endif
 
     vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -14,9 +14,10 @@
 
 #define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
 
-layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 1) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 2) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
+layout (constant_id = 1) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 3) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -61,6 +62,6 @@ void main(){
     variadic_out.colorAlpha = getColorAlpha(COLOR_COMPONENT_TYPE);
 #endif
 
-    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
 }

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -87,15 +87,15 @@ void main(){
 #endif
 
 #if TEXCOORD_COUNT == 1
-    variadic_out.texcoord = getTexcoord(0);
+    variadic_out.texcoord = getTexcoord(0, PACKED_TEXCOORD_COMPONENT_TYPES & 0xFFU);
 #elif TEXCOORD_COUNT >= 2
     for (uint i = 0; i < TEXCOORD_COUNT; i++){
-        variadic_out.texcoords[i] = getTexcoord(i);
+        variadic_out.texcoords[i] = getTexcoord(i, (PACKED_TEXCOORD_COMPONENT_TYPES >> (8U * i)) & 0xFFU);
     }
 #endif
 
 #if HAS_COLOR_ATTRIBUTE
-    variadic_out.color = getColor();
+    variadic_out.color = getColor(COLOR_COMPONENT_TYPE);
 #endif
 
     gl_Position = pc.projectionView * vec4(outPosition, 1.0);

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -60,11 +60,11 @@ void main(){
 
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE
-    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex));
+    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex), TEXCOORD_COMPONENT_TYPE);
 #endif
 
 #if HAS_COLOR_ATTRIBUTE
-    variadic_out.color = getColor();
+    variadic_out.color = getColor(COLOR_COMPONENT_TYPE);
 #endif
 
     gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -14,10 +14,11 @@
 
 #define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ATTRIBUTE
 
-layout (constant_id = 0) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 1) const uint COLOR_COMPONENT_COUNT = 0;
-layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 3) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
+layout (constant_id = 1) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 2) const uint COLOR_COMPONENT_COUNT = 0;
+layout (constant_id = 3) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
+layout (constant_id = 4) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -56,7 +57,7 @@ layout (push_constant, std430) uniform PushConstant {
 #include "vertex_pulling.glsl"
 
 void main(){
-    vec3 inPosition = getPosition(POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
 
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE

--- a/shaders/vertex_pulling.glsl
+++ b/shaders/vertex_pulling.glsl
@@ -5,55 +5,155 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer Int8Ref { int8_t data; };
 layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer Uint8Ref { uint8_t data; };
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer I8Vec2Ref { i8vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec2Ref { u8vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer I8Vec3Ref { i8vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec3Ref { u8vec3 data; };
+layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer I8Vec4Ref { i8vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 1) readonly buffer U8Vec4Ref { u8vec4 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer Int16Ref { int16_t data; };
 layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer Uint16Ref { uint16_t data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer I16Vec2Ref { i16vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec2Ref { u16vec2 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer I16Vec3Ref { i16vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec3Ref { u16vec3 data; };
+layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer I16Vec4Ref { i16vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 2) readonly buffer U16Vec4Ref { u16vec4 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer FloatRef { float data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec2Ref { vec2 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec3Ref { vec3 data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
 
-vec3 getPosition(uint morphTargetWeightCount) {
+vec3 getPosition(uint componentType, uint morphTargetWeightCount) {
     uint64_t fetchAddress = PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * uint(gl_VertexIndex);
-    vec3 position = Vec3Ref(fetchAddress).data;
+    vec3 position;
+    switch (componentType) {
+    case 0U: // BYTE
+        position = vec3(I8Vec3Ref(fetchAddress).data);
+        break;
+    case 1U: // UNSIGNED BYTE
+        position = vec3(U8Vec3Ref(fetchAddress).data);
+        break;
+    case 2U: // SHORT
+        position = vec3(I16Vec3Ref(fetchAddress).data);
+        break;
+    case 3U: // UNSIGNED SHORT
+        position = vec3(U16Vec3Ref(fetchAddress).data);
+        break;
+    case 6U: // FLOAT
+        position = Vec3Ref(fetchAddress).data;
+        break;
+    case 8U: // BYTE normalized
+        position = dequantize(I8Vec3Ref(fetchAddress).data);
+        break;
+    case 9U: // UNSIGNED BYTE normalized
+        position = dequantize(U8Vec3Ref(fetchAddress).data);
+        break;
+    case 10U: // SHORT normalized
+        position = dequantize(I16Vec3Ref(fetchAddress).data);
+        break;
+    case 11U: // UNSIGNED SHORT normalized
+        position = dequantize(U16Vec3Ref(fetchAddress).data);
+        break;
+    }
 
     for (uint i = 0; i < morphTargetWeightCount; i++) {
         Accessor accessor = PRIMITIVE.positionMorphTargetAccessors.data[i];
         fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
-        position += Vec3Ref(fetchAddress).data * morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
+
+        float weight = morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
+        switch (uint(accessor.componentType)) {
+        case 0U: // BYTE
+            position += weight * vec3(I8Vec3Ref(fetchAddress).data);
+            break;
+        case 2U: // SHORT
+            position += weight * vec3(I16Vec3Ref(fetchAddress).data);
+            break;
+        case 6U:
+            position += weight * Vec3Ref(fetchAddress).data;
+            break;
+        case 8U: // BYTE normalized
+            position += weight * dequantize(I8Vec3Ref(fetchAddress).data);
+            break;
+        case 10U: // SHORT normalized
+            position += weight * dequantize(I16Vec3Ref(fetchAddress).data);
+            break;
+        }
     }
 
     return position;
 }
 
-vec3 getNormal(uint morphTargetWeightCount) {
+vec3 getNormal(uint componentType, uint morphTargetWeightCount) {
     uint64_t fetchAddress = PRIMITIVE.pNormalBuffer + uint(PRIMITIVE.normalByteStride) * uint(gl_VertexIndex);
-    vec3 normal = Vec3Ref(fetchAddress).data;
+    vec3 normal;
+    switch (componentType) {
+    case 6U: // FLOAT
+        normal = Vec3Ref(fetchAddress).data;
+        break;
+    case 8U: // BYTE normalized
+        normal = dequantize(I8Vec3Ref(fetchAddress).data);
+        break;
+    case 10U: // SHORT normalized
+        normal = dequantize(I16Vec3Ref(fetchAddress).data);
+        break;
+    }
 
     for (uint i = 0; i < morphTargetWeightCount; i++) {
         Accessor accessor = PRIMITIVE.normalMorphTargetAccessors.data[i];
         fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
-        normal += Vec3Ref(fetchAddress).data * morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
+
+        float weight = morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
+        switch (uint(accessor.componentType)) {
+        case 6U: // FLOAT
+            normal += weight * Vec3Ref(fetchAddress).data;
+            break;
+        case 8U: // BYTE normalized
+            normal += weight * dequantize(I8Vec3Ref(fetchAddress).data);
+            break;
+        case 10U: // SHORT normalized
+            normal += weight * dequantize(I16Vec3Ref(fetchAddress).data);
+            break;
+        }
     }
 
     return normal;
 }
 
-vec4 getTangent(uint morphTargetWeightCount) {
+vec4 getTangent(uint componentType, uint morphTargetWeightCount) {
     uint64_t fetchAddress = PRIMITIVE.pTangentBuffer + uint(PRIMITIVE.tangentByteStride) * uint(gl_VertexIndex);
-    vec4 tangent = Vec4Ref(fetchAddress).data;
+    vec4 tangent;
+    switch (componentType) {
+    case 6U: // FLOAT
+        tangent = Vec4Ref(fetchAddress).data;
+        break;
+    case 8U: // BYTE normalized
+        tangent = dequantize(I8Vec4Ref(fetchAddress).data);
+        break;
+    case 10U: // SHORT normalized
+        tangent = dequantize(I16Vec4Ref(fetchAddress).data);
+        break;
+    }
 
     for (uint i = 0; i < morphTargetWeightCount; i++) {
         Accessor accessor = PRIMITIVE.tangentMorphTargetAccessors.data[i];
         fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
 
         // Tangent morph target only adds XYZ vertex tangent displacements.
-        tangent.xyz += Vec3Ref(fetchAddress).data * morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
+        float weight = morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
+        switch (uint(accessor.componentType)) {
+        case 6U: // FLOAT
+            tangent.xyz += weight * Vec3Ref(fetchAddress).data;
+            break;
+        case 8U: // BYTE normalized
+            tangent.xyz += weight * dequantize(I8Vec3Ref(fetchAddress).data);
+            break;
+        case 10U: // SHORT normalized
+            tangent.xyz += weight * dequantize(I16Vec3Ref(fetchAddress).data);
+            break;
+        }
     }
 
     return tangent;
@@ -65,12 +165,24 @@ vec2 getTexcoord(uint texcoordIndex, uint componentType){
     uint64_t fetchAddress = getFetchAddress(texcoordAccessor, gl_VertexIndex);
 
     switch (componentType) {
+    case 0U: // BYTE
+        return vec2(I8Vec2Ref(fetchAddress).data);
     case 1U: // UNSIGNED BYTE
-        return dequantize(U8Vec2Ref(fetchAddress).data);
+        return vec2(U8Vec2Ref(fetchAddress).data);
+    case 2U: // SHORT
+        return vec2(I16Vec2Ref(fetchAddress).data);
     case 3U: // UNSIGNED SHORT
-        return dequantize(U16Vec2Ref(fetchAddress).data);
+        return vec2(U16Vec2Ref(fetchAddress).data);
     case 6U: // FLOAT
         return Vec2Ref(fetchAddress).data;
+    case 8U: // BYTE normalized
+        return dequantize(I8Vec2Ref(fetchAddress).data);
+    case 9U: // UNSIGNED BYTE normalized
+        return dequantize(U8Vec2Ref(fetchAddress).data);
+    case 10U: // SHORT normalized
+        return dequantize(I16Vec2Ref(fetchAddress).data);
+    case 11U: // UNSIGNED SHORT normalized
+        return dequantize(U16Vec2Ref(fetchAddress).data);
     }
     return vec2(0.0); // unreachable.
 }
@@ -81,22 +193,22 @@ vec4 getColor(uint componentType) {
     uint64_t fetchAddress = PRIMITIVE.pColorBuffer + uint(PRIMITIVE.colorByteStride) * uint(gl_VertexIndex);
     if (COLOR_COMPONENT_COUNT == 3U) {
         switch (componentType) {
-        case 1U: // UNSIGNED BYTE
-            return vec4(dequantize(U8Vec3Ref(fetchAddress).data), 1.0);
-        case 3U: // UNSIGNED SHORT
-            return vec4(dequantize(U16Vec3Ref(fetchAddress).data), 1.0);
         case 6U: // FLOAT
             return vec4(Vec3Ref(fetchAddress).data, 1.0);
+        case 9U: // UNSIGNED BYTE normalized
+            return vec4(dequantize(U8Vec3Ref(fetchAddress).data), 1.0);
+        case 11U: // UNSIGNED SHORT normalized
+            return vec4(dequantize(U16Vec3Ref(fetchAddress).data), 1.0);
         }
     }
     else if (COLOR_COMPONENT_COUNT == 4U) {
         switch (componentType) {
-        case 1U: // UNSIGNED BYTE
-            return dequantize(U8Vec4Ref(fetchAddress).data);
-        case 3U: // UNSIGNED SHORT
-            return dequantize(U16Vec4Ref(fetchAddress).data);
         case 6U: // FLOAT
             return Vec4Ref(fetchAddress).data;
+        case 9U: // UNSIGNED BYTE normalized
+            return dequantize(U8Vec4Ref(fetchAddress).data);
+        case 11U: // UNSIGNED SHORT normalized
+            return dequantize(U16Vec4Ref(fetchAddress).data);
         }
     }
     return vec4(1.0); // unreachable.
@@ -109,15 +221,15 @@ float getColorAlpha(uint componentType) {
     // integer arithmetic instruction.
     uint fetchIndex = uint(PRIMITIVE.colorByteStride) * uint(gl_VertexIndex);
     switch (componentType) {
-    case 1U: // UNSIGNED BYTE
-        fetchIndex += 3U; // sizeof(u8vec3)
-        return dequantize(Uint8Ref(PRIMITIVE.pColorBuffer + fetchIndex).data);
-    case 3U: // UNSIGNED SHORT
-        fetchIndex += 6U; // sizeof(u16vec3)
-        return dequantize(Uint16Ref(PRIMITIVE.pColorBuffer + fetchIndex).data);
     case 6U: // FLOAT
         fetchIndex += 12; // sizeof(vec3)
         return FloatRef(PRIMITIVE.pColorBuffer + fetchIndex).data;
+    case 9U: // UNSIGNED BYTE normalized
+        fetchIndex += 3U; // sizeof(u8vec3)
+        return dequantize(Uint8Ref(PRIMITIVE.pColorBuffer + fetchIndex).data);
+    case 11U: // UNSIGNED SHORT normalized
+        fetchIndex += 6U; // sizeof(u16vec3)
+        return dequantize(Uint16Ref(PRIMITIVE.pColorBuffer + fetchIndex).data);
     }
     return 1.0; // unreachable.
 }


### PR DESCRIPTION
- Now Accessor::componentType is embedding the flag whether the accessor is normalized or not, using 4-th LSB.

|`Accessor::componentType`|type|
|---|---|
|0|BYTE|
|1|UNSIGNED BYTE|
|2|SHORT|
|3|UNSIGNED SHORT|
|6|FLOAT|
|8|BYTE normalized|
|9|UNSIGNED BYTE normalized|
|10|SHORT normalized|
|11|UNSIGNED SHORT normalized|

- Morph target attribute's component type is determined by reading it dynamically, not by specialization constant. Future PR may add the corresponding specialization constant for indicating the attribute uses the same component type of its base attribute's.