### PR TITLE
Platform-specific deployment setup.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install build dependencies (macOS)
         if: ${{ runner.os == 'macOS' }}
-        run: brew install llvm ninja autoconf automake libtool nasm shaderc
+        run: brew install llvm ninja autoconf automake libtool nasm shaderc molten-vk
 
       - name: Install build dependencies (Linux)
         if: ${{ runner.os == 'Linux' }}
@@ -82,6 +82,7 @@ jobs:
         with:
           name: ${{ runner.os }}_${{ runner.arch }}
           path: |
-            build/vk-gltf-viewer
             build/vk-gltf-viewer.exe
+            build/vk-gltf-viewer.app
+            build/vk-gltf-viewer
             build/*.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ target_sources(vk-gltf-viewer_asset PUBLIC
 )
 add_library(vk-gltf-viewer::asset ALIAS vk-gltf-viewer_asset)
 
-add_executable(vk-gltf-viewer
+add_executable(vk-gltf-viewer WIN32
     impl.cpp
     impl/control/AppWindow.cpp
     impl/control/ImGuiTaskCollector.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 ﻿cmake_minimum_required (VERSION 3.30)
 
-project(vk-gltf-viewer LANGUAGES CXX)
+project(vk-gltf-viewer
+    VERSION 0.1.0
+    DESCRIPTION "Vulkan glTF Viewer"
+    HOMEPAGE_URL "https://github.com/stripe2933/vk-gltf-viewer"
+    LANGUAGES CXX
+)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_MODULE_STD 1)
@@ -72,7 +77,7 @@ target_sources(vk-gltf-viewer_asset PUBLIC
 )
 add_library(vk-gltf-viewer::asset ALIAS vk-gltf-viewer_asset)
 
-add_executable(vk-gltf-viewer WIN32
+add_executable(vk-gltf-viewer WIN32 MACOSX_BUNDLE
     impl.cpp
     impl/control/AppWindow.cpp
     impl/control/ImGuiTaskCollector.cpp
@@ -229,6 +234,22 @@ if (UNIX AND NOT APPLE) # Linux?
     endif()
 endif()
 
+if (APPLE AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")
+    set_target_properties(vk-gltf-viewer PROPERTIES
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in
+        MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+        MACOSX_BUNDLE_INFO_STRING "${PROJECT_DESCRIPTION}"
+    )
+
+    find_package(Vulkan COMPONENTS MoltenVK REQUIRED)
+    set(APP_BUNDLE_CONTENTS_DIR "${CMAKE_CURRENT_BINARY_DIR}/vk-gltf-viewer.app/Contents")
+    add_custom_command(TARGET vk-gltf-viewer POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${APP_BUNDLE_CONTENTS_DIR}/lib" "${APP_BUNDLE_CONTENTS_DIR}/Resources"
+            && ${CMAKE_COMMAND} -E copy ${Vulkan_LIBRARY} ${Vulkan_MoltenVK_LIBRARY} "${APP_BUNDLE_CONTENTS_DIR}/lib" # Copy libvulkan.dylib, libMoltenVK.dylib
+            && ${CMAKE_COMMAND} -E rename "${APP_BUNDLE_CONTENTS_DIR}/lib/libvulkan.dylib" "${APP_BUNDLE_CONTENTS_DIR}/lib/libvulkan.1.dylib"
+            && ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/asset/resources" "${APP_BUNDLE_CONTENTS_DIR}/Resources"
+            && install_name_tool -add_rpath "@executable_path/../lib/" "${APP_BUNDLE_CONTENTS_DIR}/MacOS/vk-gltf-viewer")
+endif()
 
 # --------------------
 # Shader compilation.

--- a/asset/resources/vulkan/icd.d/MoltenVK_icd.json
+++ b/asset/resources/vulkan/icd.d/MoltenVK_icd.json
@@ -1,0 +1,8 @@
+{
+    "file_format_version": "1.0.0",
+    "ICD": {
+        "library_path": "../../../lib/libMoltenVK.dylib",
+        "api_version": "1.2.0",
+        "is_portability_driver": true
+    }
+}

--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2025 LEE KYOUNGHEON</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_VERSION}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_VERSION}</string>
+	<key>CFBundleName</key>
+	<string>Vulkan glTF Viewer</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.leekyoungheon.vk-gltf-viewer</string>
+	<key>CFBundleGetInfoString</key>
+	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
+</dict>
+</plist>

--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,11 @@
 import vk_gltf_viewer;
 import vulkan_hpp;
 
+#ifdef _WIN32
+int WinMain() {
+#else
 int main() {
+#endif
     glfwInit();
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
 


### PR DESCRIPTION
- For Windows, uses `WinMain` instead of `main` entrypoint to avoid showing the terminal.
- For macOS, packaging with `.app` extension and deploy MoltenVK.