### PR TITLE
Use macOS 15 runner.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest, ubuntu-24.04-arm]
+        os: [windows-latest, macos-15, ubuntu-latest, ubuntu-24.04-arm]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/scripts/CMakeUserPresets.json
+++ b/.github/workflows/scripts/CMakeUserPresets.json
@@ -10,13 +10,11 @@
       }
     },
     {
-      "name": "macos-latest",
+      "name": "macos-15",
       "inherits": "default",
       "cacheVariables": {
         "CMAKE_C_COMPILER": "/opt/homebrew/opt/llvm/bin/clang",
         "CMAKE_CXX_COMPILER": "/opt/homebrew/opt/llvm/bin/clang++",
-        "CMAKE_CXX_FLAGS": "-nostdinc++ -nostdlib++ -isystem /opt/homebrew/opt/llvm/include/c++/v1",
-        "CMAKE_EXE_LINKER_FLAGS": "-L /opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++ -lc++",
         "VCPKG_TARGET_TRIPLET": "arm64-macos-clang-release"
       }
     },

--- a/README.md
+++ b/README.md
@@ -268,8 +268,6 @@ Add the following CMake user preset file in your project directory. I'll assume 
       "cacheVariables": {
         "CMAKE_C_COMPILER": "/opt/homebrew/opt/llvm/bin/clang",
         "CMAKE_CXX_COMPILER": "/opt/homebrew/opt/llvm/bin/clang++",
-        "CMAKE_CXX_FLAGS": "-nostdinc++ -nostdlib++ -isystem /opt/homebrew/opt/llvm/include/c++/v1",
-        "CMAKE_EXE_LINKER_FLAGS": "-L /opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++ -lc++",
         "VCPKG_TARGET_TRIPLET": "arm64-macos-clang"
       }
     }


### PR DESCRIPTION
It uses the system-default libc++, instead of homebrew provided, which should remove the needs for end user to install LLVM manually.