### PR TITLE
Fix shader compilation scripts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,19 +280,19 @@ target_link_shaders(vk-gltf-viewer
 
 target_link_shader_variants(vk-gltf-viewer
     TARGET_ENV vulkan1.2
-    FILE shaders/prefilteredmap.comp
+    FILES
+        shaders/prefilteredmap.comp
+        shaders/subgroup_mipmap.comp
     MACRO_NAMES "AMD_SHADER_IMAGE_LOAD_STORE_LOD"
     MACRO_VALUES 0 1
 )
 target_link_shader_variants(vk-gltf-viewer
     TARGET_ENV vulkan1.2
-    FILE shaders/subgroup_mipmap.comp
-    MACRO_NAMES "AMD_SHADER_IMAGE_LOAD_STORE_LOD"
-    MACRO_VALUES 0 1
-)
-target_link_shader_variants(vk-gltf-viewer
-    TARGET_ENV vulkan1.2
-    FILE shaders/mask_depth.vert
+    FILES
+        shaders/mask_depth.vert
+        shaders/mask_depth.frag
+        shaders/mask_jump_flood_seed.vert
+        shaders/mask_jump_flood_seed.frag
     MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ALPHA_ATTRIBUTE"
     MACRO_VALUES
         "0 0" "0 1"
@@ -300,31 +300,7 @@ target_link_shader_variants(vk-gltf-viewer
 )
 target_link_shader_variants(vk-gltf-viewer
     TARGET_ENV vulkan1.2
-    FILE shaders/mask_depth.frag
-    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ALPHA_ATTRIBUTE"
-    MACRO_VALUES
-        "0 0" "0 1"
-        "1 0" "1 1"
-)
-target_link_shader_variants(vk-gltf-viewer
-    TARGET_ENV vulkan1.2
-    FILE shaders/mask_jump_flood_seed.vert
-    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ALPHA_ATTRIBUTE"
-    MACRO_VALUES
-        "0 0" "0 1"
-        "1 0" "1 1"
-)
-target_link_shader_variants(vk-gltf-viewer
-    TARGET_ENV vulkan1.2
-    FILE shaders/mask_jump_flood_seed.frag
-    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ALPHA_ATTRIBUTE"
-    MACRO_VALUES
-        "0 0" "0 1"
-        "1 0" "1 1"
-)
-target_link_shader_variants(vk-gltf-viewer
-    TARGET_ENV vulkan1.2
-    FILE shaders/primitive.vert
+    FILES shaders/primitive.vert
     MACRO_NAMES "TEXCOORD_COUNT" "HAS_COLOR_ATTRIBUTE" "FRAGMENT_SHADER_GENERATED_TBN"
     MACRO_VALUES
         "0 0 0" "0 0 1" "0 1 0" "0 1 1"
@@ -335,7 +311,7 @@ target_link_shader_variants(vk-gltf-viewer
 )
 target_link_shader_variants(vk-gltf-viewer
     TARGET_ENV vulkan1.2
-    FILE shaders/primitive.frag
+    FILES shaders/primitive.frag
     MACRO_NAMES "TEXCOORD_COUNT" "HAS_COLOR_ATTRIBUTE" "FRAGMENT_SHADER_GENERATED_TBN" "ALPHA_MODE"
     MACRO_VALUES
         "0 0 0 0" "0 0 0 1" "0 0 0 2" "0 0 1 0" "0 0 1 1" "0 0 1 2"
@@ -351,7 +327,7 @@ target_link_shader_variants(vk-gltf-viewer
 )
 target_link_shader_variants(vk-gltf-viewer
     TARGET_ENV vulkan1.2
-    FILE shaders/unlit_primitive.vert
+    FILES shaders/unlit_primitive.vert
     MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ATTRIBUTE"
     MACRO_VALUES
         "0 0" "0 1"
@@ -359,7 +335,7 @@ target_link_shader_variants(vk-gltf-viewer
 )
 target_link_shader_variants(vk-gltf-viewer
     TARGET_ENV vulkan1.2
-    FILE shaders/unlit_primitive.frag
+    FILES shaders/unlit_primitive.frag
     MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ATTRIBUTE" "ALPHA_MODE"
     MACRO_VALUES
         "0 0 0" "0 0 1" "0 0 2" "0 1 0" "0 1 1" "0 1 2"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,88 +258,110 @@ endif()
 include(cmake/CompileShader.cmake)
 
 target_link_shaders(vk-gltf-viewer
-    shaders/brdfmap.comp
-    shaders/cubemap_tone_mapping.frag
-    shaders/cubemap.comp
-    shaders/depth.frag
-    shaders/depth.vert
-    shaders/jump_flood_seed.frag
-    shaders/jump_flood_seed.vert
-    shaders/jump_flood.comp
-    shaders/multiply.comp
-    shaders/outline.frag
-    shaders/screen_quad.vert
-    shaders/skybox.frag
-    shaders/skybox.vert
-    shaders/spherical_harmonic_coefficients_sum.comp
-    shaders/spherical_harmonics.comp
-    shaders/weighted_blended_composition.frag
+    TARGET_ENV vulkan1.2
+    FILES
+        shaders/brdfmap.comp
+        shaders/cubemap_tone_mapping.frag
+        shaders/cubemap.comp
+        shaders/depth.frag
+        shaders/depth.vert
+        shaders/jump_flood_seed.frag
+        shaders/jump_flood_seed.vert
+        shaders/jump_flood.comp
+        shaders/multiply.comp
+        shaders/outline.frag
+        shaders/screen_quad.vert
+        shaders/skybox.frag
+        shaders/skybox.vert
+        shaders/spherical_harmonic_coefficients_sum.comp
+        shaders/spherical_harmonics.comp
+        shaders/weighted_blended_composition.frag
 )
 
 target_link_shader_variants(vk-gltf-viewer
-    shaders/prefilteredmap.comp
-    "AMD_SHADER_IMAGE_LOAD_STORE_LOD" 0 1
+    TARGET_ENV vulkan1.2
+    FILE shaders/prefilteredmap.comp
+    MACRO_NAMES "AMD_SHADER_IMAGE_LOAD_STORE_LOD"
+    MACRO_VALUES 0 1
 )
 target_link_shader_variants(vk-gltf-viewer
-    shaders/subgroup_mipmap.comp
-    "AMD_SHADER_IMAGE_LOAD_STORE_LOD" 0 1
+    TARGET_ENV vulkan1.2
+    FILE shaders/subgroup_mipmap.comp
+    MACRO_NAMES "AMD_SHADER_IMAGE_LOAD_STORE_LOD"
+    MACRO_VALUES 0 1
 )
 target_link_shader_variants(vk-gltf-viewer
-    shaders/mask_depth.vert
-    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ALPHA_ATTRIBUTE"
-    "0 0" "0 1"
-    "1 0" "1 1"
+    TARGET_ENV vulkan1.2
+    FILE shaders/mask_depth.vert
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ALPHA_ATTRIBUTE"
+    MACRO_VALUES
+        "0 0" "0 1"
+        "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
-    shaders/mask_depth.frag
-    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ALPHA_ATTRIBUTE"
-    "0 0" "0 1"
-    "1 0" "1 1"
+    TARGET_ENV vulkan1.2
+    FILE shaders/mask_depth.frag
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ALPHA_ATTRIBUTE"
+    MACRO_VALUES
+        "0 0" "0 1"
+        "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
-    shaders/mask_jump_flood_seed.vert
-    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ALPHA_ATTRIBUTE"
-    "0 0" "0 1"
-    "1 0" "1 1"
+    TARGET_ENV vulkan1.2
+    FILE shaders/mask_jump_flood_seed.vert
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ALPHA_ATTRIBUTE"
+    MACRO_VALUES
+        "0 0" "0 1"
+        "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
-    shaders/mask_jump_flood_seed.frag
-    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ALPHA_ATTRIBUTE"
-    "0 0" "0 1"
-    "1 0" "1 1"
+    TARGET_ENV vulkan1.2
+    FILE shaders/mask_jump_flood_seed.frag
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ALPHA_ATTRIBUTE"
+    MACRO_VALUES
+        "0 0" "0 1"
+        "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
-    shaders/primitive.vert
-    "TEXCOORD_COUNT;HAS_COLOR_ATTRIBUTE;FRAGMENT_SHADER_GENERATED_TBN"
-    "0 0 0" "0 0 1" "0 1 0" "0 1 1"
-    "1 0 0" "1 0 1" "1 1 0" "1 1 1"
-    "2 0 0" "2 0 1" "2 1 0" "2 1 1"
-    "3 0 0" "3 0 1" "3 1 0" "3 1 1"
-    "4 0 0" "4 0 1" "4 1 0" "4 1 1"
+    TARGET_ENV vulkan1.2
+    FILE shaders/primitive.vert
+    MACRO_NAMES "TEXCOORD_COUNT" "HAS_COLOR_ATTRIBUTE" "FRAGMENT_SHADER_GENERATED_TBN"
+    MACRO_VALUES
+        "0 0 0" "0 0 1" "0 1 0" "0 1 1"
+        "1 0 0" "1 0 1" "1 1 0" "1 1 1"
+        "2 0 0" "2 0 1" "2 1 0" "2 1 1"
+        "3 0 0" "3 0 1" "3 1 0" "3 1 1"
+        "4 0 0" "4 0 1" "4 1 0" "4 1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
-    shaders/primitive.frag
-    "TEXCOORD_COUNT;HAS_COLOR_ATTRIBUTE;FRAGMENT_SHADER_GENERATED_TBN;ALPHA_MODE"
-    "0 0 0 0" "0 0 0 1" "0 0 0 2" "0 0 1 0" "0 0 1 1" "0 0 1 2"
-    "0 1 0 0" "0 1 0 1" "0 1 0 2" "0 1 1 0" "0 1 1 1" "0 1 1 2"
-    "1 0 0 0" "1 0 0 1" "1 0 0 2" "1 0 1 0" "1 0 1 1" "1 0 1 2"
-    "1 1 0 0" "1 1 0 1" "1 1 0 2" "1 1 1 0" "1 1 1 1" "1 1 1 2"
-    "2 0 0 0" "2 0 0 1" "2 0 0 2" "2 0 1 0" "2 0 1 1" "2 0 1 2"
-    "2 1 0 0" "2 1 0 1" "2 1 0 2" "2 1 1 0" "2 1 1 1" "2 1 1 2"
-    "3 0 0 0" "3 0 0 1" "3 0 0 2" "3 0 1 0" "3 0 1 1" "3 0 1 2"
-    "3 1 0 0" "3 1 0 1" "3 1 0 2" "3 1 1 0" "3 1 1 1" "3 1 1 2"
-    "4 0 0 0" "4 0 0 1" "4 0 0 2" "4 0 1 0" "4 0 1 1" "4 0 1 2"
-    "4 1 0 0" "4 1 0 1" "4 1 0 2" "4 1 1 0" "4 1 1 1" "4 1 1 2"
+    TARGET_ENV vulkan1.2
+    FILE shaders/primitive.frag
+    MACRO_NAMES "TEXCOORD_COUNT" "HAS_COLOR_ATTRIBUTE" "FRAGMENT_SHADER_GENERATED_TBN" "ALPHA_MODE"
+    MACRO_VALUES
+        "0 0 0 0" "0 0 0 1" "0 0 0 2" "0 0 1 0" "0 0 1 1" "0 0 1 2"
+        "0 1 0 0" "0 1 0 1" "0 1 0 2" "0 1 1 0" "0 1 1 1" "0 1 1 2"
+        "1 0 0 0" "1 0 0 1" "1 0 0 2" "1 0 1 0" "1 0 1 1" "1 0 1 2"
+        "1 1 0 0" "1 1 0 1" "1 1 0 2" "1 1 1 0" "1 1 1 1" "1 1 1 2"
+        "2 0 0 0" "2 0 0 1" "2 0 0 2" "2 0 1 0" "2 0 1 1" "2 0 1 2"
+        "2 1 0 0" "2 1 0 1" "2 1 0 2" "2 1 1 0" "2 1 1 1" "2 1 1 2"
+        "3 0 0 0" "3 0 0 1" "3 0 0 2" "3 0 1 0" "3 0 1 1" "3 0 1 2"
+        "3 1 0 0" "3 1 0 1" "3 1 0 2" "3 1 1 0" "3 1 1 1" "3 1 1 2"
+        "4 0 0 0" "4 0 0 1" "4 0 0 2" "4 0 1 0" "4 0 1 1" "4 0 1 2"
+        "4 1 0 0" "4 1 0 1" "4 1 0 2" "4 1 1 0" "4 1 1 1" "4 1 1 2"
 )
 target_link_shader_variants(vk-gltf-viewer
-    shaders/unlit_primitive.vert
-    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ATTRIBUTE"
-    "0 0" "0 1"
-    "1 0" "1 1"
+    TARGET_ENV vulkan1.2
+    FILE shaders/unlit_primitive.vert
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ATTRIBUTE"
+    MACRO_VALUES
+        "0 0" "0 1"
+        "1 0" "1 1"
 )
 target_link_shader_variants(vk-gltf-viewer
-    shaders/unlit_primitive.frag
-    "HAS_BASE_COLOR_TEXTURE;HAS_COLOR_ATTRIBUTE;ALPHA_MODE"
-    "0 0 0" "0 0 1" "0 0 2" "0 1 0" "0 1 1" "0 1 2"
-    "1 0 0" "1 0 1" "1 0 2" "1 1 0" "1 1 1" "1 1 2"
+    TARGET_ENV vulkan1.2
+    FILE shaders/unlit_primitive.frag
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ATTRIBUTE" "ALPHA_MODE"
+    MACRO_VALUES
+        "0 0 0" "0 0 1" "0 0 2" "0 1 0" "0 1 1" "0 1 2"
+        "1 0 0" "1 0 1" "1 0 2" "1 1 0" "1 1 1" "1 1 2"
 )

--- a/cmake/CompileShader.cmake
+++ b/cmake/CompileShader.cmake
@@ -76,8 +76,8 @@ function(target_link_shaders TARGET)
 endfunction()
 
 function(target_link_shader_variants TARGET)
-    set(oneValueArgs TARGET_ENV FILE)
-    set(multiValueArgs MACRO_NAMES MACRO_VALUES)
+    set(oneValueArgs TARGET_ENV)
+    set(multiValueArgs FILES MACRO_NAMES MACRO_VALUES)
     cmake_parse_arguments(arg "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if (NOT arg_TARGET_ENV)
@@ -87,72 +87,6 @@ function(target_link_shader_variants TARGET)
     # Make target identifier.
     string(MAKE_C_IDENTIFIER ${TARGET} target_identifier)
 
-    # Get filename from source.
-    cmake_path(GET arg_FILE FILENAME filename)
-
-    # Make shader identifier.
-    string(MAKE_C_IDENTIFIER ${filename} shader_identifier)
-
-    # Make source path absolute.
-    cmake_path(ABSOLUTE_PATH arg_FILE)
-
-    set(spirv_num_filenames "")
-    set(template_specializations "")
-    set(extern_template_instantiations "")
-    foreach (macro_values IN LISTS arg_MACRO_VALUES)
-        # Split whitespace-delimited string to list.
-        separate_arguments(macro_values)
-
-        # Create CLI macro definitions by zipping the macro names and values.
-        # e.g. MACRO_NAMES=[MACRO1, MACRO2], macro_values=[0, 1] -> macro_cli_defs="-DMACRO1=0 -DMACRO2=1"
-        set(macro_cli_defs "")
-        foreach (macro_name macro_value IN ZIP_LISTS arg_MACRO_NAMES macro_values)
-            string(APPEND macro_cli_defs "-D${macro_name}=${macro_value} ")
-        endforeach ()
-
-        # Split whitespace-delimited string to list (to prevent macro_cli_defs are passed with double quotes).
-        separate_arguments(macro_cli_defs)
-
-        # Make filename-like parameter string.
-        # e.g., If macro_values=[0, 1], variant_filename="0_1".
-        list(JOIN macro_values "_" variant_filename)
-        set(spirv_num_filename "${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}_${variant_filename}.h")
-
-        if (${Vulkan_glslc_FOUND})
-            set(depfile "${CMAKE_CURRENT_BINARY_DIR}/shader_depfile/${filename}_${variant_filename}.d")
-            add_custom_command(
-                OUTPUT ${spirv_num_filename}
-                # Compile GLSL to SPIR-V.
-                COMMAND Vulkan::glslc -MD -MF ${depfile} $<$<CONFIG:Release>:-O> --target-env=${arg_TARGET_ENV} -mfmt=num ${macro_cli_defs} ${arg_FILE} -o ${spirv_num_filename}
-                DEPENDS ${arg_FILE}
-                BYPRODUCTS ${depfile}
-                DEPFILE ${depfile}
-                COMMAND_EXPAND_LISTS
-                VERBATIM
-            )
-        elseif (${Vulkan_glslangValidator_FOUND})
-            add_custom_command(
-                OUTPUT ${spirv_num_filename}
-                # Compile GLSL to SPIR-V.
-                COMMAND Vulkan::glslangValidator -V $<$<CONFIG:Release>:-Os> --target-env ${arg_TARGET_ENV} -x ${macro_cli_defs} ${arg_FILE} -o ${spirv_num_filename}
-                DEPENDS ${arg_FILE}
-                COMMAND_EXPAND_LISTS
-                VERBATIM
-            )
-        endif ()
-
-        # Make value parameter string.
-        # e.g., If macro_values=[0, 1], value_params="0, 1".
-        list(JOIN macro_values ", " value_params)
-
-        list(APPEND spirv_num_filenames ${spirv_num_filename})
-        list(APPEND template_specializations "SPECIALIZATION_BEGIN(${value_params})\n#include \"${spirv_num_filename}\"\nSPECIALIZATION_END()")
-        list(APPEND extern_template_instantiations "INSTANTIATION(${value_params})")
-    endforeach ()
-
-    # --------------------
-    # Make interface file.
-    # --------------------
 
     # "MACRO1;MACRO2;MACRO3" -> "int MACRO1, int MACRO2, int MACRO3"
     list(TRANSFORM arg_MACRO_NAMES PREPEND "int " OUTPUT_VARIABLE comma_separated_macro_params)
@@ -161,19 +95,91 @@ function(target_link_shader_variants TARGET)
     # "MACRO1;MACRO2;MACRO3" -> "MACRO1, MACRO2, MACRO3"
     list(JOIN arg_MACRO_NAMES ", " comma_separated_macro_names)
 
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/variant_shader_module_interface.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm @ONLY)
+    set(spirv_num_filenames "")
+    set(shader_module_interface_filenames "")
+    set(shader_module_impl_filenames "")
+    foreach (source IN LISTS arg_FILES)
+        # Get filename from source.
+        cmake_path(GET source FILENAME filename)
 
-    # --------------------
-    # Make implementation file.
-    # --------------------
+        # Make shader identifier.
+        string(MAKE_C_IDENTIFIER ${filename} shader_identifier)
 
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/variant_shader_module_impl.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cpp @ONLY)
+        # Make source path absolute.
+        cmake_path(ABSOLUTE_PATH source)
+
+        set(template_specializations "")
+        set(extern_template_instantiations "")
+        foreach (macro_values IN LISTS arg_MACRO_VALUES)
+            # Split whitespace-delimited string to list.
+            separate_arguments(macro_values)
+
+            # Create CLI macro definitions by zipping the macro names and values.
+            # e.g. MACRO_NAMES=[MACRO1, MACRO2], macro_values=[0, 1] -> macro_cli_defs="-DMACRO1=0 -DMACRO2=1"
+            set(macro_cli_defs "")
+            foreach (macro_name macro_value IN ZIP_LISTS arg_MACRO_NAMES macro_values)
+                list(APPEND macro_cli_defs "-D${macro_name}=${macro_value}")
+            endforeach ()
+
+            # Make filename-like parameter string.
+            # e.g., If macro_values=[0, 1], variant_filename="0_1".
+            list(JOIN macro_values "_" variant_filename)
+            set(spirv_num_filename "${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}_${variant_filename}.h")
+
+            if (${Vulkan_glslc_FOUND})
+                set(depfile "${CMAKE_CURRENT_BINARY_DIR}/shader_depfile/${filename}_${variant_filename}.d")
+                add_custom_command(
+                    OUTPUT ${spirv_num_filename}
+                    # Compile GLSL to SPIR-V.
+                    COMMAND Vulkan::glslc -MD -MF ${depfile} $<$<CONFIG:Release>:-O> --target-env=${arg_TARGET_ENV} -mfmt=num ${macro_cli_defs} ${source} -o ${spirv_num_filename}
+                    DEPENDS ${source}
+                    BYPRODUCTS ${depfile}
+                    DEPFILE ${depfile}
+                    COMMAND_EXPAND_LISTS
+                    VERBATIM
+                )
+            elseif (${Vulkan_glslangValidator_FOUND})
+                add_custom_command(
+                    OUTPUT ${spirv_num_filename}
+                    # Compile GLSL to SPIR-V.
+                    COMMAND Vulkan::glslangValidator -V $<$<CONFIG:Release>:-Os> --target-env ${arg_TARGET_ENV} -x ${macro_cli_defs} ${source} -o ${spirv_num_filename}
+                    DEPENDS ${source}
+                    COMMAND_EXPAND_LISTS
+                    VERBATIM
+                )
+            endif ()
+
+            # Make value parameter string.
+            # e.g., If macro_values=[0, 1], value_params="0, 1".
+            list(JOIN macro_values ", " value_params)
+
+            list(APPEND spirv_num_filenames ${spirv_num_filename})
+            list(APPEND template_specializations "SPECIALIZATION_BEGIN(${value_params})\n#include \"${spirv_num_filename}\"\nSPECIALIZATION_END()")
+            list(APPEND extern_template_instantiations "INSTANTIATION(${value_params})")
+        endforeach ()
+
+        # --------------------
+        # Make interface file.
+        # --------------------
+
+        set(shader_module_interface_filename "${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm")
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/variant_shader_module_interface.cmake.in ${shader_module_interface_filename} @ONLY)
+        list(APPEND shader_module_interface_filenames ${shader_module_interface_filename})
+
+        # --------------------
+        # Make implementation file.
+        # --------------------
+
+        set(shader_module_impl_filename "${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cpp")
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/variant_shader_module_impl.cmake.in ${shader_module_impl_filename} @ONLY)
+        list(APPEND shader_module_impl_filenames ${shader_module_impl_filename})
+    endforeach()
 
     # --------------------
     # Attach sources to the target.
     # --------------------
 
     target_sources(${TARGET} PRIVATE FILE_SET HEADERS FILES ${spirv_num_filenames})
-    target_sources(${TARGET} PRIVATE FILE_SET CXX_MODULES FILES ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cppm)
-    target_sources(${TARGET} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/shader/${filename}.cpp)
+    target_sources(${TARGET} PRIVATE FILE_SET CXX_MODULES FILES ${shader_module_interface_filenames})
+    target_sources(${TARGET} PRIVATE ${shader_module_impl_filenames})
 endfunction()

--- a/cmake/shader_module.cmake.in
+++ b/cmake/shader_module.cmake.in
@@ -1,0 +1,7 @@
+export module @target_identifier@:shader.@shader_identifier@;
+
+namespace @target_identifier@::shader {
+    export constexpr unsigned int @shader_identifier@[] = {
+#include "@spirv_num_filename@"
+    };
+}

--- a/cmake/variant_shader_module_impl.cmake.in
+++ b/cmake/variant_shader_module_impl.cmake.in
@@ -1,0 +1,7 @@
+module @target_identifier@;
+import :shader.@shader_identifier@;
+
+#define INSTANTIATION(...) \
+    extern template struct @target_identifier@::shader::@shader_identifier@_t<__VA_ARGS__>
+
+@extern_template_instantiations@;

--- a/cmake/variant_shader_module_interface.cmake.in
+++ b/cmake/variant_shader_module_interface.cmake.in
@@ -1,0 +1,18 @@
+export module @target_identifier@:shader.@shader_identifier@;
+
+#define SPECIALIZATION_BEGIN(...) \
+    template <> \
+    struct @shader_identifier@_t<__VA_ARGS__> { \
+        static constexpr unsigned int data[] = {
+#define SPECIALIZATION_END() \
+        }; \
+    }
+
+namespace @target_identifier@::shader {
+    template <int...> struct @shader_identifier@_t;
+
+    @template_specializations@;
+
+    export template <@comma_separated_macro_params@>
+    constexpr auto &@shader_identifier@ = @shader_identifier@_t<@comma_separated_macro_names@>::data;
+}


### PR DESCRIPTION
- Both `target_link_shaders` and `target_link_shader_variants` functions can now accept the target environment value, which is `vulkan1.0` by default.
- `target_link_shader_variants` function can now accept multiple files for sources.
- A bug that incorrect header inclusion dependency configuration when using `target_link_shader_variants` has been fixed.
  - This bug was from the wrong usage of `DEPFILE`, `BYPRODUCTS` with `APPEND` keyword.
  - It also get rids the bunch of the warnings during the configuration time.
- Use `configure_file` to simplify the code generation.