### PR TITLE
Disable Wayland feature.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,12 +228,6 @@ target_compile_definitions(vk-gltf-viewer PRIVATE
     GLFW_INCLUDE_NONE
 )
 
-if (UNIX AND NOT APPLE) # Linux?
-    if (DEFINED ENV{WAYLAND_DISPLAY})
-        target_compile_definitions(vk-gltf-viewer PRIVATE WAYLAND_DISPLAY)
-    endif()
-endif()
-
 if (APPLE AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")
     set_target_properties(vk-gltf-viewer PROPERTIES
         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -9,11 +9,7 @@ module;
 #elifdef __APPLE__
 #define GLFW_EXPOSE_NATIVE_COCOA
 #elifdef __linux__
-#ifdef WAYLAND_DISPLAY
-#define GLFW_EXPOSE_NATIVE_WAYLAND
-#else
 #define GLFW_EXPOSE_NATIVE_X11
-#endif
 #endif
 #include <nfd_glfw3.h>
 #include <nfd.hpp>


### PR DESCRIPTION
Currently GLFW doesn't support Wayland, therefore defining the related macros are redundant.