### PR TITLE
Pad texture index at host and use unsigned index type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/sampler/Cubemap.cppm
         interface/vulkan/sampler/Samplers.cppm
         interface/vulkan/shader_type/Accessor.cppm
+        interface/vulkan/shader_type/Material.cppm
         interface/vulkan/shader_type/Node.cppm
         interface/vulkan/shader_type/Primitive.cppm
         interface/vulkan/shader_type/TextureTransform.cppm

--- a/interface/vulkan/buffer/Materials.cppm
+++ b/interface/vulkan/buffer/Materials.cppm
@@ -34,11 +34,11 @@ namespace vk_gltf_viewer::vulkan::buffer {
             std::uint8_t occlusionTexcoordIndex;
             std::uint8_t emissiveTexcoordIndex;
             char padding0[1];
-            std::int16_t baseColorTextureIndex = -1;
-            std::int16_t metallicRoughnessTextureIndex = -1;
-            std::int16_t normalTextureIndex = -1;
-            std::int16_t occlusionTextureIndex = -1;
-            std::int16_t emissiveTextureIndex = -1;
+            std::uint16_t baseColorTextureIndex = 0;
+            std::uint16_t metallicRoughnessTextureIndex = 0;
+            std::uint16_t normalTextureIndex = 0;
+            std::uint16_t occlusionTextureIndex = 0;
+            std::uint16_t emissiveTextureIndex = 0;
             glm::vec4 baseColorFactor = { 1.f, 1.f, 1.f, 1.f };
             float metallicFactor = 1.f;
             float roughnessFactor = 1.f;
@@ -107,7 +107,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
 
                 if (const auto& baseColorTexture = material.pbrData.baseColorTexture) {
                     gpuMaterial.baseColorTexcoordIndex = baseColorTexture->texCoordIndex;
-                    gpuMaterial.baseColorTextureIndex = static_cast<std::int16_t>(baseColorTexture->textureIndex);
+                    gpuMaterial.baseColorTextureIndex = static_cast<std::uint16_t>(baseColorTexture->textureIndex) + 1;
 
                     if (const auto &transform = baseColorTexture->transform) {
                         gpuMaterial.baseColorTextureTransform = getTextureTransform(*transform);
@@ -118,7 +118,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
                 }
                 if (const auto& metallicRoughnessTexture = material.pbrData.metallicRoughnessTexture) {
                     gpuMaterial.metallicRoughnessTexcoordIndex = metallicRoughnessTexture->texCoordIndex;
-                    gpuMaterial.metallicRoughnessTextureIndex = static_cast<std::int16_t>(metallicRoughnessTexture->textureIndex);
+                    gpuMaterial.metallicRoughnessTextureIndex = static_cast<std::uint16_t>(metallicRoughnessTexture->textureIndex) + 1;
 
                     if (const auto &transform = metallicRoughnessTexture->transform) {
                         gpuMaterial.metallicRoughnessTextureTransform = getTextureTransform(*transform);
@@ -129,7 +129,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
                 }
                 if (const auto& normalTexture = material.normalTexture) {
                     gpuMaterial.normalTexcoordIndex = normalTexture->texCoordIndex;
-                    gpuMaterial.normalTextureIndex = static_cast<std::int16_t>(normalTexture->textureIndex);
+                    gpuMaterial.normalTextureIndex = static_cast<std::uint16_t>(normalTexture->textureIndex) + 1;
                     gpuMaterial.normalScale = normalTexture->scale;
 
                     if (const auto &transform = normalTexture->transform) {
@@ -141,7 +141,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
                 }
                 if (const auto& occlusionTexture = material.occlusionTexture) {
                     gpuMaterial.occlusionTexcoordIndex = occlusionTexture->texCoordIndex;
-                    gpuMaterial.occlusionTextureIndex = static_cast<std::int16_t>(occlusionTexture->textureIndex);
+                    gpuMaterial.occlusionTextureIndex = static_cast<std::uint16_t>(occlusionTexture->textureIndex) + 1;
                     gpuMaterial.occlusionStrength = occlusionTexture->strength;
 
                     if (const auto &transform = occlusionTexture->transform) {
@@ -153,7 +153,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
                 }
                 if (const auto& emissiveTexture = material.emissiveTexture) {
                     gpuMaterial.emissiveTexcoordIndex = emissiveTexture->texCoordIndex;
-                    gpuMaterial.emissiveTextureIndex = static_cast<std::int16_t>(emissiveTexture->textureIndex);
+                    gpuMaterial.emissiveTextureIndex = static_cast<std::uint16_t>(emissiveTexture->textureIndex) + 1;
 
                     if (const auto &transform = emissiveTexture->transform) {
                         gpuMaterial.emissiveTextureTransform = getTextureTransform(*transform);

--- a/interface/vulkan/buffer/Materials.cppm
+++ b/interface/vulkan/buffer/Materials.cppm
@@ -13,6 +13,7 @@ export import vulkan_hpp;
 import :helpers.optional;
 import :helpers.ranges;
 export import :vulkan.buffer.StagingBufferStorage;
+import :vulkan.shader_type.Material;
 import :vulkan.trait.PostTransferObject;
 
 [[nodiscard]] glm::mat3x2 getTextureTransform(const fastgltf::TextureTransform &transform) noexcept {
@@ -27,34 +28,6 @@ import :vulkan.trait.PostTransferObject;
 namespace vk_gltf_viewer::vulkan::buffer {
     export class Materials : trait::PostTransferObject {
     public:
-        struct GpuMaterial {
-            std::uint8_t baseColorTexcoordIndex;
-            std::uint8_t metallicRoughnessTexcoordIndex;
-            std::uint8_t normalTexcoordIndex;
-            std::uint8_t occlusionTexcoordIndex;
-            std::uint8_t emissiveTexcoordIndex;
-            char padding0[1];
-            std::uint16_t baseColorTextureIndex = 0;
-            std::uint16_t metallicRoughnessTextureIndex = 0;
-            std::uint16_t normalTextureIndex = 0;
-            std::uint16_t occlusionTextureIndex = 0;
-            std::uint16_t emissiveTextureIndex = 0;
-            glm::vec4 baseColorFactor = { 1.f, 1.f, 1.f, 1.f };
-            float metallicFactor = 1.f;
-            float roughnessFactor = 1.f;
-            float normalScale = 1.f;
-            float occlusionStrength = 1.f;
-            glm::vec3 emissiveFactor = { 0.f, 0.f, 0.f };
-            float alphaCutOff;
-            glm::mat3x2 baseColorTextureTransform;
-            glm::mat3x2 metallicRoughnessTextureTransform;
-            glm::mat3x2 normalTextureTransform;
-            glm::mat3x2 occlusionTextureTransform;
-            glm::mat3x2 emissiveTextureTransform;
-            char padding1[8];
-        };
-        static_assert(sizeof(GpuMaterial) == 192);
-
         Materials(
             const fastgltf::Asset &asset,
             vma::Allocator allocator,
@@ -89,15 +62,15 @@ namespace vk_gltf_viewer::vulkan::buffer {
         }
 
         [[nodiscard]] vku::AllocatedBuffer createBuffer(const fastgltf::Asset &asset, vma::Allocator allocator) const {
-            // This is workaround for Clang 18's bug that ranges::views::concat cannot be used with std::optional<GpuMaterial>.
+            // This is workaround for Clang 18's bug that ranges::views::concat cannot be used with std::optional<shader_type::Material>.
             // TODO: change it to use ranges::views::concat when available.
-            std::vector<GpuMaterial> bufferData;
+            std::vector<shader_type::Material> bufferData;
             bufferData.reserve(asset.materials.size() + useFallbackMaterialAtZero);
             if (useFallbackMaterialAtZero) {
                 bufferData.push_back({});
             }
             bufferData.append_range(asset.materials | std::views::transform([&](const fastgltf::Material& material) {
-                GpuMaterial gpuMaterial {
+                shader_type::Material result {
                     .baseColorFactor = glm::gtc::make_vec4(material.pbrData.baseColorFactor.data()),
                     .metallicFactor = material.pbrData.metallicFactor,
                     .roughnessFactor = material.pbrData.roughnessFactor,
@@ -106,64 +79,64 @@ namespace vk_gltf_viewer::vulkan::buffer {
                 };
 
                 if (const auto& baseColorTexture = material.pbrData.baseColorTexture) {
-                    gpuMaterial.baseColorTexcoordIndex = baseColorTexture->texCoordIndex;
-                    gpuMaterial.baseColorTextureIndex = static_cast<std::uint16_t>(baseColorTexture->textureIndex) + 1;
+                    result.baseColorTexcoordIndex = baseColorTexture->texCoordIndex;
+                    result.baseColorTextureIndex = static_cast<std::uint16_t>(baseColorTexture->textureIndex) + 1;
 
                     if (const auto &transform = baseColorTexture->transform) {
-                        gpuMaterial.baseColorTextureTransform = getTextureTransform(*transform);
+                        result.baseColorTextureTransform = getTextureTransform(*transform);
                         if (transform->texCoordIndex) {
-                            gpuMaterial.baseColorTexcoordIndex = *transform->texCoordIndex;
+                            result.baseColorTexcoordIndex = *transform->texCoordIndex;
                         }
                     }
                 }
                 if (const auto& metallicRoughnessTexture = material.pbrData.metallicRoughnessTexture) {
-                    gpuMaterial.metallicRoughnessTexcoordIndex = metallicRoughnessTexture->texCoordIndex;
-                    gpuMaterial.metallicRoughnessTextureIndex = static_cast<std::uint16_t>(metallicRoughnessTexture->textureIndex) + 1;
+                    result.metallicRoughnessTexcoordIndex = metallicRoughnessTexture->texCoordIndex;
+                    result.metallicRoughnessTextureIndex = static_cast<std::uint16_t>(metallicRoughnessTexture->textureIndex) + 1;
 
                     if (const auto &transform = metallicRoughnessTexture->transform) {
-                        gpuMaterial.metallicRoughnessTextureTransform = getTextureTransform(*transform);
+                        result.metallicRoughnessTextureTransform = getTextureTransform(*transform);
                         if (transform->texCoordIndex) {
-                            gpuMaterial.metallicRoughnessTexcoordIndex = *transform->texCoordIndex;
+                            result.metallicRoughnessTexcoordIndex = *transform->texCoordIndex;
                         }
                     }
                 }
                 if (const auto& normalTexture = material.normalTexture) {
-                    gpuMaterial.normalTexcoordIndex = normalTexture->texCoordIndex;
-                    gpuMaterial.normalTextureIndex = static_cast<std::uint16_t>(normalTexture->textureIndex) + 1;
-                    gpuMaterial.normalScale = normalTexture->scale;
+                    result.normalTexcoordIndex = normalTexture->texCoordIndex;
+                    result.normalTextureIndex = static_cast<std::uint16_t>(normalTexture->textureIndex) + 1;
+                    result.normalScale = normalTexture->scale;
 
                     if (const auto &transform = normalTexture->transform) {
-                        gpuMaterial.normalTextureTransform = getTextureTransform(*transform);
+                        result.normalTextureTransform = getTextureTransform(*transform);
                         if (transform->texCoordIndex) {
-                            gpuMaterial.normalTexcoordIndex = *transform->texCoordIndex;
+                            result.normalTexcoordIndex = *transform->texCoordIndex;
                         }
                     }
                 }
                 if (const auto& occlusionTexture = material.occlusionTexture) {
-                    gpuMaterial.occlusionTexcoordIndex = occlusionTexture->texCoordIndex;
-                    gpuMaterial.occlusionTextureIndex = static_cast<std::uint16_t>(occlusionTexture->textureIndex) + 1;
-                    gpuMaterial.occlusionStrength = occlusionTexture->strength;
+                    result.occlusionTexcoordIndex = occlusionTexture->texCoordIndex;
+                    result.occlusionTextureIndex = static_cast<std::uint16_t>(occlusionTexture->textureIndex) + 1;
+                    result.occlusionStrength = occlusionTexture->strength;
 
                     if (const auto &transform = occlusionTexture->transform) {
-                        gpuMaterial.occlusionTextureTransform = getTextureTransform(*transform);
+                        result.occlusionTextureTransform = getTextureTransform(*transform);
                         if (transform->texCoordIndex) {
-                            gpuMaterial.occlusionTexcoordIndex = *transform->texCoordIndex;
+                            result.occlusionTexcoordIndex = *transform->texCoordIndex;
                         }
                     }
                 }
                 if (const auto& emissiveTexture = material.emissiveTexture) {
-                    gpuMaterial.emissiveTexcoordIndex = emissiveTexture->texCoordIndex;
-                    gpuMaterial.emissiveTextureIndex = static_cast<std::uint16_t>(emissiveTexture->textureIndex) + 1;
+                    result.emissiveTexcoordIndex = emissiveTexture->texCoordIndex;
+                    result.emissiveTextureIndex = static_cast<std::uint16_t>(emissiveTexture->textureIndex) + 1;
 
                     if (const auto &transform = emissiveTexture->transform) {
-                        gpuMaterial.emissiveTextureTransform = getTextureTransform(*transform);
+                        result.emissiveTextureTransform = getTextureTransform(*transform);
                         if (transform->texCoordIndex) {
-                            gpuMaterial.emissiveTexcoordIndex = *transform->texCoordIndex;
+                            result.emissiveTexcoordIndex = *transform->texCoordIndex;
                         }
                     }
                 }
 
-                return gpuMaterial;
+                return result;
             }));
             
             vku::AllocatedBuffer buffer = vku::MappedBuffer {

--- a/interface/vulkan/shader_type/Material.cppm
+++ b/interface/vulkan/shader_type/Material.cppm
@@ -1,0 +1,43 @@
+module;
+
+#include <cstddef>
+
+export module vk_gltf_viewer:vulkan.shader_type.Material;
+
+import std;
+export import glm;
+
+namespace vk_gltf_viewer::vulkan::shader_type {
+    export struct Material {
+        std::uint8_t baseColorTexcoordIndex;
+        std::uint8_t metallicRoughnessTexcoordIndex;
+        std::uint8_t normalTexcoordIndex;
+        std::uint8_t occlusionTexcoordIndex;
+        std::uint8_t emissiveTexcoordIndex;
+        char padding0[1];
+        std::uint16_t baseColorTextureIndex = 0;
+        std::uint16_t metallicRoughnessTextureIndex = 0;
+        std::uint16_t normalTextureIndex = 0;
+        std::uint16_t occlusionTextureIndex = 0;
+        std::uint16_t emissiveTextureIndex = 0;
+        glm::vec4 baseColorFactor = { 1.f, 1.f, 1.f, 1.f };
+        float metallicFactor = 1.f;
+        float roughnessFactor = 1.f;
+        float normalScale = 1.f;
+        float occlusionStrength = 1.f;
+        glm::vec3 emissiveFactor = { 0.f, 0.f, 0.f };
+        float alphaCutOff;
+        glm::mat3x2 baseColorTextureTransform;
+        glm::mat3x2 metallicRoughnessTextureTransform;
+        glm::mat3x2 normalTextureTransform;
+        glm::mat3x2 occlusionTextureTransform;
+        glm::mat3x2 emissiveTextureTransform;
+        char padding1[8];
+    };
+
+    static_assert(sizeof(Material) == 192);
+    static_assert(offsetof(Material, baseColorTextureIndex) == 6);
+    static_assert(offsetof(Material, baseColorFactor) == 16);
+    static_assert(offsetof(Material, emissiveFactor) == 48);
+    static_assert(offsetof(Material, baseColorTextureTransform) == 64);
+}

--- a/shaders/mask_depth.frag
+++ b/shaders/mask_depth.frag
@@ -3,7 +3,6 @@
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
-#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
 #define FRAGMENT_SHADER
 #include "indexing.glsl"
@@ -43,7 +42,7 @@ void main(){
     else if (TEXTURE_TRANSFORM_TYPE == 2) {
         baseColorTexcoord = mat2(MATERIAL.baseColorTextureTransform) * baseColorTexcoord + MATERIAL.baseColorTextureTransform[2];
     }
-    baseColorAlpha *= texture(textures[MATERIAL.baseColorTextureIndex + 1S], baseColorTexcoord).a;
+    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord).a;
 #endif
 #if HAS_COLOR_ALPHA_ATTRIBUTE
     baseColorAlpha *= variadic_in.colorAlpha;

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -3,7 +3,6 @@
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
-#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
 #define FRAGMENT_SHADER
 #include "indexing.glsl"
@@ -42,7 +41,7 @@ void main(){
     else if (TEXTURE_TRANSFORM_TYPE == 2) {
         baseColorTexcoord = mat2(MATERIAL.baseColorTextureTransform) * baseColorTexcoord + MATERIAL.baseColorTextureTransform[2];
     }
-    baseColorAlpha *= texture(textures[MATERIAL.baseColorTextureIndex + 1S], baseColorTexcoord).a;
+    baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord).a;
 #endif
 #if HAS_COLOR_ALPHA_ATTRIBUTE
     baseColorAlpha *= variadic_in.colorAlpha;

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -111,7 +111,7 @@ void writeOutput(vec4 color) {
     outColor = vec4(color.rgb, 1.0);
 #elif ALPHA_MODE == 1
 #if TEXCOORD_COUNT >= 1
-    color.a *= 1.0 + geometricMean(textureQueryLod(textures[MATERIAL.baseColorTextureIndex + 1S], getTexcoord(MATERIAL.baseColorTexcoordIndex))) * 0.25;
+    color.a *= 1.0 + geometricMean(textureQueryLod(textures[uint(MATERIAL.baseColorTextureIndex)], getTexcoord(MATERIAL.baseColorTexcoordIndex))) * 0.25;
     // Apply sharpness to the alpha.
     // See: https://bgolus.medium.com/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f.
     color.a = (color.a - MATERIAL.alphaCutoff) / max(fwidth(color.a), 1e-4) + 0.5;
@@ -134,7 +134,7 @@ void main(){
 #if TEXCOORD_COUNT >= 1
     vec2 baseColorTexcoord = getTexcoord(MATERIAL.baseColorTexcoordIndex);
     baseColorTexcoord = transformTexcoord(baseColorTexcoord, MATERIAL.baseColorTextureTransform, PACKED_TEXTURE_TRANSFORM_TYPES);
-    baseColor *= texture(textures[MATERIAL.baseColorTextureIndex + 1S], baseColorTexcoord);
+    baseColor *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord);
 #endif
 #if HAS_COLOR_ATTRIBUTE
     baseColor *= variadic_in.color;
@@ -145,7 +145,7 @@ void main(){
 #if TEXCOORD_COUNT >= 1
     vec2 metallicRoughnessTexcoord = getTexcoord(MATERIAL.metallicRoughnessTexcoordIndex);
     metallicRoughnessTexcoord = transformTexcoord(metallicRoughnessTexcoord, MATERIAL.metallicRoughnessTextureTransform, PACKED_TEXTURE_TRANSFORM_TYPES >> 4U);
-    vec2 metallicRoughness = texture(textures[MATERIAL.metallicRoughnessTextureIndex + 1S], metallicRoughnessTexcoord).bg;
+    vec2 metallicRoughness = texture(textures[uint(MATERIAL.metallicRoughnessTextureIndex)], metallicRoughnessTexcoord).bg;
     metallic *= metallicRoughness.x;
     roughness *= metallicRoughness.y;
 #endif
@@ -157,19 +157,19 @@ void main(){
     N = normalize(cross(tangent, bitangent));
 
 #if TEXCOORD_COUNT >= 1
-    if (int(MATERIAL.normalTextureIndex) != -1){
+    if (MATERIAL.normalTextureIndex != 0US){
         vec2 normalTexcoord = getTexcoord(MATERIAL.normalTexcoordIndex);
         normalTexcoord = transformTexcoord(normalTexcoord, MATERIAL.normalTextureTransform, PACKED_TEXTURE_TRANSFORM_TYPES >> 8U);
-        vec3 tangentNormal = texture(textures[MATERIAL.normalTextureIndex + 1S], normalTexcoord).rgb;
+        vec3 tangentNormal = texture(textures[uint(MATERIAL.normalTextureIndex)], normalTexcoord).rgb;
         vec3 scaledNormal = (2.0 * tangentNormal - 1.0) * vec3(MATERIAL.normalScale, MATERIAL.normalScale, 1.0);
         N = normalize(mat3(tangent, bitangent, N) * scaledNormal);
     }
 #endif
 #elif TEXCOORD_COUNT >= 1
-    if (int(MATERIAL.normalTextureIndex) != -1){
+    if (MATERIAL.normalTextureIndex != 0US){
         vec2 normalTexcoord = getTexcoord(MATERIAL.normalTexcoordIndex);
         normalTexcoord = transformTexcoord(normalTexcoord, MATERIAL.normalTextureTransform, PACKED_TEXTURE_TRANSFORM_TYPES >> 8U);
-        vec3 tangentNormal = texture(textures[MATERIAL.normalTextureIndex + 1S], normalTexcoord).rgb;
+        vec3 tangentNormal = texture(textures[uint(MATERIAL.normalTextureIndex)], normalTexcoord).rgb;
         vec3 scaledNormal = (2.0 * tangentNormal - 1.0) * vec3(MATERIAL.normalScale, MATERIAL.normalScale, 1.0);
         N = normalize(variadic_in.tbn * scaledNormal);
     }
@@ -184,14 +184,14 @@ void main(){
 #if TEXCOORD_COUNT >= 1
     vec2 occlusionTexcoord = getTexcoord(MATERIAL.occlusionTexcoordIndex);
     occlusionTexcoord = transformTexcoord(occlusionTexcoord, MATERIAL.occlusionTextureTransform, PACKED_TEXTURE_TRANSFORM_TYPES >> 12U);
-    occlusion = 1.0 + MATERIAL.occlusionStrength * (texture(textures[MATERIAL.occlusionTextureIndex + 1S], occlusionTexcoord).r - 1.0);
+    occlusion = 1.0 + MATERIAL.occlusionStrength * (texture(textures[uint(MATERIAL.occlusionTextureIndex)], occlusionTexcoord).r - 1.0);
 #endif
 
     vec3 emissive = MATERIAL.emissiveFactor;
 #if TEXCOORD_COUNT >= 1
     vec2 emissiveTexcoord = getTexcoord(MATERIAL.emissiveTexcoordIndex);
     emissiveTexcoord = transformTexcoord(emissiveTexcoord, MATERIAL.emissiveTextureTransform, PACKED_TEXTURE_TRANSFORM_TYPES >> 16U);
-    emissive *= texture(textures[MATERIAL.emissiveTextureIndex + 1S], emissiveTexcoord).rgb;
+    emissive *= texture(textures[uint(MATERIAL.emissiveTextureIndex)], emissiveTexcoord).rgb;
 #endif
 
     vec3 V = normalize(pc.viewPosition - inPosition);

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -78,7 +78,7 @@ void main(){
     vec3 inNormal = getNormal((PACKED_ATTRIBUTE_COMPONENT_TYPES >> 4U) & 0xFU, (PACKED_MORPH_TARGET_AVAILABILITY & 0x2U) == 0x2U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
     variadic_out.tbn[2] = normalize(mat3(TRANSFORM) * inNormal); // N
 
-    if (int(MATERIAL.normalTextureIndex) != -1){
+    if (MATERIAL.normalTextureIndex != 0US){
         vec4 inTangent = getTangent((PACKED_ATTRIBUTE_COMPONENT_TYPES >> 8U) & 0xFU, (PACKED_MORPH_TARGET_AVAILABILITY & 0x4U) == 0x4U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
         variadic_out.tbn[0] = normalize(mat3(TRANSFORM) * inTangent.xyz); // T
         variadic_out.tbn[1] = cross(variadic_out.tbn[2], variadic_out.tbn[0]) * -inTangent.w; // B

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -8,11 +8,11 @@ struct Material {
     uint8_t occlusionTexcoordIndex;
     uint8_t emissiveTexcoordIndex;
     uint8_t padding0[1];
-    int16_t baseColorTextureIndex;
-    int16_t metallicRoughnessTextureIndex;
-    int16_t normalTextureIndex;
-    int16_t occlusionTextureIndex;
-    int16_t emissiveTextureIndex;
+    uint16_t baseColorTextureIndex;
+    uint16_t metallicRoughnessTextureIndex;
+    uint16_t normalTextureIndex;
+    uint16_t occlusionTextureIndex;
+    uint16_t emissiveTextureIndex;
     vec4 baseColorFactor;
     float metallicFactor;
     float roughnessFactor;

--- a/shaders/unlit_primitive.frag
+++ b/shaders/unlit_primitive.frag
@@ -3,7 +3,6 @@
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_EXT_shader_8bit_storage : require
-#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
 #define FRAGMENT_SHADER
 #include "indexing.glsl"
@@ -49,7 +48,7 @@ void writeOutput(vec4 color) {
     outColor = vec4(color.rgb, 1.0);
 #elif ALPHA_MODE == 1
 #if HAS_BASE_COLOR_TEXTURE
-    color.a *= 1.0 + geometricMean(textureQueryLod(textures[MATERIAL.baseColorTextureIndex + 1S], variadic_in.baseColorTexcoord)) * 0.25;
+    color.a *= 1.0 + geometricMean(textureQueryLod(textures[uint(MATERIAL.baseColorTextureIndex)], variadic_in.baseColorTexcoord)) * 0.25;
     // Apply sharpness to the alpha.
     // See: https://bgolus.medium.com/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f.
     color.a = (color.a - MATERIAL.alphaCutoff) / max(fwidth(color.a), 1e-4) + 0.5;
@@ -77,7 +76,7 @@ void main(){
     else if (TEXTURE_TRANSFORM_TYPE == 2) {
         baseColorTexcoord = mat2(MATERIAL.baseColorTextureTransform) * baseColorTexcoord + MATERIAL.baseColorTextureTransform[2];
     }
-    baseColor *= texture(textures[MATERIAL.baseColorTextureIndex + 1S], baseColorTexcoord);
+    baseColor *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord);
 #endif
 #if HAS_COLOR_ATTRIBUTE
     baseColor *= variadic_in.color;


### PR DESCRIPTION
Padding the texture index on the host can eliminate the need for an ALU instruction in the fragment shader and work around an AMD GPU driver bug. As a result, an unsigned index type can be used, since there is no need for negative indices.