### PR TITLE
Use compiler-specific [[lifetimebound]] attribute.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ add_executable(vk-gltf-viewer WIN32 MACOSX_BUNDLE
 target_include_directories(vk-gltf-viewer PRIVATE
     extlibs/include
     ${Stb_INCLUDE_DIR}
+    include
 )
 target_sources(vk-gltf-viewer PRIVATE
     FILE_SET CXX_MODULES

--- a/include/lifetimebound.hpp
+++ b/include/lifetimebound.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined(_MSC_VER)
+#define LIFETIMEBOUND [[msvc::lifetimebound]]
+#elif defined(__clang__)
+#define LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define LIFETIMEBOUND
+#endif

--- a/interface/control/AppWindow.cppm
+++ b/interface/control/AppWindow.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <GLFW/glfw3.h>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:control.AppWindow;
 
 import std;
@@ -15,7 +17,7 @@ namespace vk_gltf_viewer::control {
     public:
         AppState &appState;
 
-        AppWindow(const vk::raii::Instance &instance [[clang::lifetimebound]], AppState &appState);
+        AppWindow(const vk::raii::Instance &instance LIFETIMEBOUND, AppState &appState);
         ~AppWindow();
 
         [[nodiscard]] operator GLFWwindow*() const noexcept;

--- a/interface/gltf/MaterialVariantsMapping.cppm
+++ b/interface/gltf/MaterialVariantsMapping.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:gltf.MaterialVariantsMapping;
 
 import std;
@@ -17,7 +21,7 @@ namespace vk_gltf_viewer::gltf {
             std::uint32_t materialIndex;
         };
 
-        explicit MaterialVariantsMapping(fastgltf::Asset &asset [[clang::lifetimebound]]) noexcept {
+        explicit MaterialVariantsMapping(fastgltf::Asset &asset LIFETIMEBOUND) noexcept {
             for (fastgltf::Primitive &primitive : asset.meshes | std::views::transform(&fastgltf::Mesh::primitives) | std::views::join) {
                 for (const auto &[materialVariantIndex, mapping] : primitive.mappings | ranges::views::enumerate) {
                     if (mapping) {

--- a/interface/gltf/NodeWorldTransforms.cppm
+++ b/interface/gltf/NodeWorldTransforms.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:gltf.NodeWorldTransforms;
 
 import std;
@@ -10,7 +14,7 @@ namespace vk_gltf_viewer::gltf {
         std::reference_wrapper<const fastgltf::Asset> asset;
 
     public:
-        explicit NodeWorldTransforms(const fastgltf::Asset &asset [[clang::lifetimebound]])
+        explicit NodeWorldTransforms(const fastgltf::Asset &asset LIFETIMEBOUND)
             : vector { std::from_range, asset.nodes | std::views::transform([](const fastgltf::Node &node) {
                 return visit(fastgltf::visitor {
                     [](const fastgltf::TRS &trs) { return toMatrix(trs); },

--- a/interface/gltf/OrderedPrimitives.cppm
+++ b/interface/gltf/OrderedPrimitives.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:gltf.OrderedPrimitives;
 
 import std;
@@ -13,7 +17,7 @@ namespace vk_gltf_viewer::gltf {
      */
     export class OrderedPrimitives : public std::vector<const fastgltf::Primitive*> {
     public:
-        explicit OrderedPrimitives(const fastgltf::Asset &asset [[clang::lifetimebound]])
+        explicit OrderedPrimitives(const fastgltf::Asset &asset LIFETIMEBOUND)
             : vector {
                 std::from_range,
                 asset.meshes

--- a/interface/vulkan/Frame.cppm
+++ b/interface/vulkan/Frame.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.Frame;
 
 import std;
@@ -121,7 +123,7 @@ namespace vk_gltf_viewer::vulkan {
             std::optional<std::uint16_t> hoveringNodeIndex;
         };
 
-        explicit Frame(const SharedData &sharedData [[clang::lifetimebound]]);
+        explicit Frame(const SharedData &sharedData LIFETIMEBOUND);
 
         /**
          * @brief Wait for the previous frame execution to finish.
@@ -159,7 +161,7 @@ namespace vk_gltf_viewer::vulkan {
                 vk::raii::ImageView pingImageView;
                 vk::raii::ImageView pongImageView;
 
-                JumpFloodResources(const Gpu &gpu [[clang::lifetimebound]], const vk::Extent2D &extent);
+                JumpFloodResources(const Gpu &gpu LIFETIMEBOUND, const vk::Extent2D &extent);
             };
 
             vk::Extent2D extent;
@@ -172,7 +174,7 @@ namespace vk_gltf_viewer::vulkan {
             ag::JumpFloodSeed hoveringNodeJumpFloodSeedAttachmentGroup;
             ag::JumpFloodSeed selectedNodeJumpFloodSeedAttachmentGroup;
 
-            PassthruResources(const Gpu &gpu [[clang::lifetimebound]], const vk::Extent2D &extent, vk::CommandBuffer graphicsCommandBuffer);
+            PassthruResources(const Gpu &gpu LIFETIMEBOUND, const vk::Extent2D &extent, vk::CommandBuffer graphicsCommandBuffer);
 
         private:
             auto recordInitialImageLayoutTransitionCommands(vk::CommandBuffer graphicsCommandBuffer) const -> void;

--- a/interface/vulkan/Gpu.cppm
+++ b/interface/vulkan/Gpu.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.Gpu;
 
 import std;
@@ -73,7 +75,7 @@ namespace vk_gltf_viewer::vulkan {
         bool supportShaderImageLoadStoreLod;
         bool supportVariableDescriptorCount;
 
-        Gpu(const vk::raii::Instance &instance [[clang::lifetimebound]], vk::SurfaceKHR surface);
+        Gpu(const vk::raii::Instance &instance LIFETIMEBOUND, vk::SurfaceKHR surface);
         ~Gpu();
 
     private:

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -3,6 +3,8 @@ module;
 #include <boost/container/static_vector.hpp>
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.SharedData;
 
 import std;
@@ -140,7 +142,7 @@ namespace vk_gltf_viewer::vulkan {
         texture::Fallback fallbackTexture;
         std::optional<GltfAsset> gltfAsset;
 
-        SharedData(const Gpu &gpu [[clang::lifetimebound]], const vk::Extent2D &swapchainExtent, std::span<const vk::Image> swapchainImages)
+        SharedData(const Gpu &gpu LIFETIMEBOUND, const vk::Extent2D &swapchainExtent, std::span<const vk::Image> swapchainImages)
             : gpu { gpu }
             , swapchainExtent { swapchainExtent }
             , swapchainImages { swapchainImages }

--- a/interface/vulkan/attachment_group/DepthPrepass.cppm
+++ b/interface/vulkan/attachment_group/DepthPrepass.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.ag.DepthPrepass;
 
 export import vku;
@@ -6,7 +10,7 @@ export import :vulkan.Gpu;
 namespace vk_gltf_viewer::vulkan::ag {
     export struct DepthPrepass final : vku::AttachmentGroup {
         DepthPrepass(
-            const Gpu &gpu [[clang::lifetimebound]],
+            const Gpu &gpu LIFETIMEBOUND,
             const vk::Extent2D &extent
         ) : AttachmentGroup { extent } {
             addColorAttachment(

--- a/interface/vulkan/attachment_group/JumpFloodSeed.cppm
+++ b/interface/vulkan/attachment_group/JumpFloodSeed.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.ag.JumpFloodSeed;
 
 export import vku;
@@ -6,8 +10,8 @@ export import :vulkan.Gpu;
 namespace vk_gltf_viewer::vulkan::ag {
     export struct JumpFloodSeed final : vku::AttachmentGroup {
         JumpFloodSeed(
-            const Gpu &gpu [[clang::lifetimebound]],
-            const vku::Image &seedImage [[clang::lifetimebound]]
+            const Gpu &gpu LIFETIMEBOUND,
+            const vku::Image &seedImage LIFETIMEBOUND
         ) : AttachmentGroup { vku::toExtent2D(seedImage.extent) } {
             addColorAttachment(
                 gpu.device,

--- a/interface/vulkan/attachment_group/SceneOpaque.cppm
+++ b/interface/vulkan/attachment_group/SceneOpaque.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.ag.SceneOpaque;
 
 import std;
@@ -7,7 +11,7 @@ export import :vulkan.Gpu;
 namespace vk_gltf_viewer::vulkan::ag {
     export struct SceneOpaque final : vku::MultisampleAttachmentGroup {
         SceneOpaque(
-            const Gpu &gpu [[clang::lifetimebound]],
+            const Gpu &gpu LIFETIMEBOUND,
             const vk::Extent2D &extent,
             std::span<const vk::Image> swapchainImages
         ) : MultisampleAttachmentGroup { extent, vk::SampleCountFlagBits::e4 } {

--- a/interface/vulkan/attachment_group/SceneWeightedBlended.cppm
+++ b/interface/vulkan/attachment_group/SceneWeightedBlended.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.ag.SceneWeightedBlended;
 
 export import vku;
@@ -6,7 +10,7 @@ export import :vulkan.Gpu;
 namespace vk_gltf_viewer::vulkan::ag {
     export struct SceneWeightedBlended final : vku::MultisampleAttachmentGroup {
         SceneWeightedBlended(
-            const Gpu &gpu [[clang::lifetimebound]],
+            const Gpu &gpu LIFETIMEBOUND,
             const vk::Extent2D &extent,
             const vku::Image &depthImage
         ) : MultisampleAttachmentGroup { extent, vk::SampleCountFlagBits::e4 } {

--- a/interface/vulkan/attachment_group/Swapchain.cppm
+++ b/interface/vulkan/attachment_group/Swapchain.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <cassert>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.ag.Swapchain;
 
 import std;
@@ -11,7 +13,7 @@ export import :vulkan.Gpu;
 namespace vk_gltf_viewer::vulkan::ag {
     export struct Swapchain final : vku::AttachmentGroup {
         Swapchain(
-            const Gpu &gpu [[clang::lifetimebound]],
+            const Gpu &gpu LIFETIMEBOUND,
             const vk::Extent2D &extent,
             std::span<const vk::Image> swapchainImages,
             vk::Format format = vk::Format::eB8G8R8A8Srgb

--- a/interface/vulkan/buffer/CombinedIndices.cppm
+++ b/interface/vulkan/buffer/CombinedIndices.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.buffer.CombinedIndices;
 
 import std;
@@ -47,7 +49,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
         template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
         CombinedIndices(
             const fastgltf::Asset &asset,
-            const Gpu &gpu [[clang::lifetimebound]],
+            const Gpu &gpu LIFETIMEBOUND,
             StagingBufferStorage &stagingBufferStorage,
             const BufferDataAdapter &adapter = {}
         ) : PostTransferObject { stagingBufferStorage } {

--- a/interface/vulkan/buffer/InstancedNodeWorldTransforms.cppm
+++ b/interface/vulkan/buffer/InstancedNodeWorldTransforms.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.buffer.InstancedNodeWorldTransforms;
 
 import std;
@@ -43,7 +45,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
          */
         template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
         InstancedNodeWorldTransforms(
-            const fastgltf::Asset &asset [[clang::lifetimebound]],
+            const fastgltf::Asset &asset LIFETIMEBOUND,
             const gltf::NodeWorldTransforms &nodeWorldTransforms,
             vma::Allocator allocator,
             const BufferDataAdapter &adapter = {}

--- a/interface/vulkan/buffer/MorphTargetWeights.cppm
+++ b/interface/vulkan/buffer/MorphTargetWeights.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.buffer.MorphTargetWeights;
 
 import std;
@@ -8,7 +12,7 @@ export import :vulkan.Gpu;
 namespace vk_gltf_viewer::vulkan::buffer {
     export class MorphTargetWeights {
     public:
-        MorphTargetWeights(const fastgltf::Asset &asset, const Gpu &gpu [[clang::lifetimebound]])
+        MorphTargetWeights(const fastgltf::Asset &asset, const Gpu &gpu LIFETIMEBOUND)
             : buffer { createBuffer(asset, gpu.allocator) }
             , descriptorInfo { buffer, 0, vk::WholeSize } { }
 

--- a/interface/vulkan/descriptor_set_layout/Asset.cppm
+++ b/interface/vulkan/descriptor_set_layout/Asset.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.dsl.Asset;
 
 import std;
@@ -5,7 +9,7 @@ export import :vulkan.Gpu;
 
 namespace vk_gltf_viewer::vulkan::dsl {
     export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
-        explicit Asset(const Gpu &gpu [[clang::lifetimebound]])
+        explicit Asset(const Gpu &gpu LIFETIMEBOUND)
             : DescriptorSetLayout { gpu.device, vk::StructureChain {
                 vk::DescriptorSetLayoutCreateInfo {
                     vk::DescriptorSetLayoutCreateFlagBits::eUpdateAfterBindPool,
@@ -29,7 +33,7 @@ namespace vk_gltf_viewer::vulkan::dsl {
                 },
             }.get() } { }
 
-        Asset(const Gpu &gpu [[clang::lifetimebound]], std::uint32_t textureCount)
+        Asset(const Gpu &gpu LIFETIMEBOUND, std::uint32_t textureCount)
             : DescriptorSetLayout { gpu.device, vk::StructureChain {
                 vk::DescriptorSetLayoutCreateInfo {
                     vk::DescriptorSetLayoutCreateFlagBits::eUpdateAfterBindPool,

--- a/interface/vulkan/descriptor_set_layout/ImageBasedLighting.cppm
+++ b/interface/vulkan/descriptor_set_layout/ImageBasedLighting.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.dsl.ImageBasedLighting;
 
 import std;
@@ -8,9 +12,9 @@ export import :vulkan.sampler.Cubemap;
 namespace vk_gltf_viewer::vulkan::dsl {
     export struct ImageBasedLighting : vku::DescriptorSetLayout<vk::DescriptorType::eUniformBuffer, vk::DescriptorType::eCombinedImageSampler, vk::DescriptorType::eCombinedImageSampler> {
         ImageBasedLighting(
-            const vk::raii::Device &device [[clang::lifetimebound]],
-            const sampler::Cubemap &cubemapSampler [[clang::lifetimebound]],
-            const sampler::BrdfLut &brdfLutSampler [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND,
+            const sampler::Cubemap &cubemapSampler LIFETIMEBOUND,
+            const sampler::BrdfLut &brdfLutSampler LIFETIMEBOUND
         ) : DescriptorSetLayout { device, vk::DescriptorSetLayoutCreateInfo {
                 {},
                 vku::unsafeProxy(getBindings(

--- a/interface/vulkan/descriptor_set_layout/Skybox.cppm
+++ b/interface/vulkan/descriptor_set_layout/Skybox.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.dsl.Skybox;
 
 import std;
@@ -7,8 +11,8 @@ export import :vulkan.sampler.Cubemap;
 namespace vk_gltf_viewer::vulkan::dsl {
     export struct Skybox : vku::DescriptorSetLayout<vk::DescriptorType::eCombinedImageSampler> {
         Skybox(
-            const vk::raii::Device &device [[clang::lifetimebound]],
-            const sampler::Cubemap &cubemapSampler [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND,
+            const sampler::Cubemap &cubemapSampler LIFETIMEBOUND
         ) : DescriptorSetLayout { device, vk::DescriptorSetLayoutCreateInfo {
                 {},
                 vku::unsafeProxy(getBindings({ 1, vk::ShaderStageFlagBits::eFragment, &*cubemapSampler })),

--- a/interface/vulkan/generator/ImageBasedLightingResourceGenerator.cppm
+++ b/interface/vulkan/generator/ImageBasedLightingResourceGenerator.cppm
@@ -62,7 +62,7 @@ namespace vk_gltf_viewer::vulkan::inline generator {
 
         void recordCommands(
             vk::CommandBuffer computeCommandBuffer,
-            const Pipelines &pipelines [[clang::lifetimebound]],
+            const Pipelines &pipelines,
             const vku::Image &cubemapImage
         ) {
             constexpr auto getWorkgroupTotal = [](std::span<const std::uint32_t, 3> workgroupCount) {

--- a/interface/vulkan/generator/ImageBasedLightingResourceGenerator.cppm
+++ b/interface/vulkan/generator/ImageBasedLightingResourceGenerator.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.generator.ImageBasedLightingResourceGenerator;
 
 import std;
@@ -41,7 +43,7 @@ namespace vk_gltf_viewer::vulkan::inline generator {
         vku::MappedBuffer sphericalHarmonicsBuffer;
 
         ImageBasedLightingResourceGenerator(
-            const Gpu &gpu [[clang::lifetimebound]],
+            const Gpu &gpu LIFETIMEBOUND,
             const Config &config
         ) : gpu { gpu },
             prefilteredmapImage { gpu.allocator, vk::ImageCreateInfo {

--- a/interface/vulkan/generator/MipmappedCubemapGenerator.cppm
+++ b/interface/vulkan/generator/MipmappedCubemapGenerator.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.generator.MipmappedCubemapGenerator;
 
 import std;
@@ -32,7 +34,7 @@ namespace vk_gltf_viewer::vulkan::inline generator {
         vku::AllocatedImage cubemapImage;
 
         MipmappedCubemapGenerator(
-            const Gpu &gpu [[clang::lifetimebound]],
+            const Gpu &gpu LIFETIMEBOUND,
             const Config &config
         ) : gpu { gpu },
             cubemapImage { gpu.allocator, vk::ImageCreateInfo {

--- a/interface/vulkan/generator/MipmappedCubemapGenerator.cppm
+++ b/interface/vulkan/generator/MipmappedCubemapGenerator.cppm
@@ -48,7 +48,7 @@ namespace vk_gltf_viewer::vulkan::inline generator {
 
         void recordCommands(
             vk::CommandBuffer computeCommandBuffer,
-            const Pipelines &pipelines [[clang::lifetimebound]],
+            const Pipelines &pipelines,
             const vku::Image &eqmapImage
         ) {
             // --------------------

--- a/interface/vulkan/pipeline/BrdfmapComputer.cppm
+++ b/interface/vulkan/pipeline/BrdfmapComputer.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.BrdfmapComputer;
 
 import std;
@@ -11,7 +13,7 @@ import :shader.brdfmap_comp;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export struct BrdfmapComputer {
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eStorageImage> {
-            explicit DescriptorSetLayout(const vk::raii::Device &device [[clang::lifetimebound]])
+            explicit DescriptorSetLayout(const vk::raii::Device &device LIFETIMEBOUND)
                 : vku::DescriptorSetLayout<vk::DescriptorType::eStorageImage> {
                     device,
                     vk::DescriptorSetLayoutCreateInfo {
@@ -29,7 +31,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::PipelineLayout pipelineLayout;
         vk::raii::Pipeline pipeline;
 
-        explicit BrdfmapComputer(const vk::raii::Device &device [[clang::lifetimebound]], const SpecializationConstants &specializationConstants = { 1024 })
+        explicit BrdfmapComputer(const vk::raii::Device &device LIFETIMEBOUND, const SpecializationConstants &specializationConstants = { 1024 })
             : descriptorSetLayout { device }
             , pipelineLayout { device, vk::PipelineLayoutCreateInfo {
                     {},

--- a/interface/vulkan/pipeline/CubemapComputer.cppm
+++ b/interface/vulkan/pipeline/CubemapComputer.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.CubemapComputer;
 
 import std;
@@ -13,8 +15,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     export struct CubemapComputer {
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eCombinedImageSampler, vk::DescriptorType::eStorageImage> {
             DescriptorSetLayout(
-                const vk::raii::Device &device [[clang::lifetimebound]],
-                const vk::Sampler &sampler [[clang::lifetimebound]]
+                const vk::raii::Device &device LIFETIMEBOUND,
+                const vk::Sampler &sampler LIFETIMEBOUND
             ) : vku::DescriptorSetLayout<vk::DescriptorType::eCombinedImageSampler, vk::DescriptorType::eStorageImage> {
                     device,
                     vk::DescriptorSetLayoutCreateInfo {
@@ -32,7 +34,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         explicit CubemapComputer(
-            const vk::raii::Device &device [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND
         ) : eqmapSampler { device, vk::SamplerCreateInfo {
                 {},
                 vk::Filter::eLinear, vk::Filter::eLinear, vk::SamplerMipmapMode::eLinear,

--- a/interface/vulkan/pipeline/CubemapToneMappingRenderer.cppm
+++ b/interface/vulkan/pipeline/CubemapToneMappingRenderer.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.CubemapToneMappingRenderer;
 
 import std;
@@ -11,7 +15,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class CubemapToneMappingRenderer {
     public:
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eSampledImage> {
-            explicit DescriptorSetLayout(const vk::raii::Device &device [[clang::lifetimebound]])
+            explicit DescriptorSetLayout(const vk::raii::Device &device LIFETIMEBOUND)
                 : vku::DescriptorSetLayout<vk::DescriptorType::eSampledImage> { device, vk::DescriptorSetLayoutCreateInfo {
                     vk::DescriptorSetLayoutCreateFlagBits::ePushDescriptorKHR,
                     vku::unsafeProxy(getBindings({ 1, vk::ShaderStageFlagBits::eFragment })),
@@ -23,8 +27,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         CubemapToneMappingRenderer(
-            const vk::raii::Device &device [[clang::lifetimebound]],
-            const rp::CubemapToneMapping &renderPass [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND,
+            const rp::CubemapToneMapping &renderPass LIFETIMEBOUND
         ) : descriptorSetLayout { device },
             pipelineLayout { device, vk::PipelineLayoutCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/JumpFloodComputer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodComputer.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.JumpFloodComputer;
 
 import std;
@@ -7,14 +11,14 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class JumpFloodComputer {
     public:
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eStorageImage> {
-            explicit DescriptorSetLayout(const vk::raii::Device &device [[clang::lifetimebound]]);
+            explicit DescriptorSetLayout(const vk::raii::Device &device LIFETIMEBOUND);
         };
 
         DescriptorSetLayout descriptorSetLayout;
         vk::raii::PipelineLayout pipelineLayout;
         vk::raii::Pipeline pipeline;
 
-        explicit JumpFloodComputer(const vk::raii::Device &device [[clang::lifetimebound]]);
+        explicit JumpFloodComputer(const vk::raii::Device &device LIFETIMEBOUND);
 
         [[nodiscard]] auto compute(
             vk::CommandBuffer commandBuffer,

--- a/interface/vulkan/pipeline/MultiplyComputer.cppm
+++ b/interface/vulkan/pipeline/MultiplyComputer.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.MultiplyComputer;
 
 import std;
@@ -15,7 +17,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer> {
             explicit DescriptorSetLayout(
-                const vk::raii::Device &device [[clang::lifetimebound]]
+                const vk::raii::Device &device LIFETIMEBOUND
             ) : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer> {
                     device,
                     vk::DescriptorSetLayoutCreateInfo {
@@ -37,7 +39,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         explicit MultiplyComputer(
-            const vk::raii::Device &device [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND
         ) : descriptorSetLayout { device },
             pipelineLayout { device, vk::PipelineLayoutCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/OutlineRenderer.cppm
+++ b/interface/vulkan/pipeline/OutlineRenderer.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.OutlineRenderer;
 
 import std;
@@ -9,7 +13,7 @@ import :shader.outline_frag;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export struct OutlineRenderer {
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eSampledImage>{
-            explicit DescriptorSetLayout(const vk::raii::Device &device [[clang::lifetimebound]])
+            explicit DescriptorSetLayout(const vk::raii::Device &device LIFETIMEBOUND)
                 : vku::DescriptorSetLayout<vk::DescriptorType::eSampledImage> {
                     device,
                     vk::DescriptorSetLayoutCreateInfo {
@@ -30,7 +34,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         OutlineRenderer(
-            const vk::raii::Device &device [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND
         ) : descriptorSetLayout { device },
             pipelineLayout { device, vk::PipelineLayoutCreateInfo{
                 {},

--- a/interface/vulkan/pipeline/PrefilteredmapComputer.cppm
+++ b/interface/vulkan/pipeline/PrefilteredmapComputer.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.PrefilteredmapComputer;
 
 import std;
@@ -24,8 +26,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eCombinedImageSampler, vk::DescriptorType::eStorageImage> {
             DescriptorSetLayout(
-                const Gpu &gpu [[clang::lifetimebound]],
-                const vk::Sampler &sampler [[clang::lifetimebound]],
+                const Gpu &gpu LIFETIMEBOUND,
+                const vk::Sampler &sampler LIFETIMEBOUND,
                 std::uint32_t roughnessLevels
             ) : vku::DescriptorSetLayout<vk::DescriptorType::eCombinedImageSampler, vk::DescriptorType::eStorageImage> {
                 gpu.device,
@@ -45,7 +47,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         PrefilteredmapComputer(
-            const Gpu &gpu [[clang::lifetimebound]],
+            const Gpu &gpu LIFETIMEBOUND,
             const SpecializationConstants &specializationConstants
         ) : cubemapSampler { gpu.device, vk::SamplerCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/SkyboxRenderer.cppm
+++ b/interface/vulkan/pipeline/SkyboxRenderer.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.SkyboxRenderer;
 
 import std;
@@ -23,11 +25,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         SkyboxRenderer(
-            const vk::raii::Device &device [[clang::lifetimebound]],
-            const dsl::Skybox &descriptorSetLayout [[clang::lifetimebound]],
+            const vk::raii::Device &device LIFETIMEBOUND,
+            const dsl::Skybox &descriptorSetLayout LIFETIMEBOUND,
             bool isCubemapImageToneMapped,
-            const rp::Scene &sceneRenderPass [[clang::lifetimebound]],
-            const buffer::CubeIndices &cubeIndices [[clang::lifetimebound]]
+            const rp::Scene &sceneRenderPass LIFETIMEBOUND,
+            const buffer::CubeIndices &cubeIndices LIFETIMEBOUND
         ) : pipelineLayout { device, vk::PipelineLayoutCreateInfo {
                 {},
                 *descriptorSetLayout,

--- a/interface/vulkan/pipeline/SphericalHarmonicCoefficientsSumComputer.cppm
+++ b/interface/vulkan/pipeline/SphericalHarmonicCoefficientsSumComputer.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.SphericalHarmonicCoefficientsSumComputer;
 
 import std;
@@ -15,7 +17,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer> {
             explicit DescriptorSetLayout(
-                const vk::raii::Device &device [[clang::lifetimebound]]
+                const vk::raii::Device &device LIFETIMEBOUND
             ) : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer> {
                     device,
                     vk::DescriptorSetLayoutCreateInfo {
@@ -36,7 +38,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         explicit SphericalHarmonicCoefficientsSumComputer(
-            const vk::raii::Device &device [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND
         ) : descriptorSetLayout { device },
             pipelineLayout { device, vk::PipelineLayoutCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/SphericalHarmonicsComputer.cppm
+++ b/interface/vulkan/pipeline/SphericalHarmonicsComputer.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.SphericalHarmonicsComputer;
 
 import std;
@@ -14,7 +16,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eSampledImage, vk::DescriptorType::eStorageBuffer> {
             explicit DescriptorSetLayout(
-                const vk::raii::Device &device [[clang::lifetimebound]]
+                const vk::raii::Device &device LIFETIMEBOUND
             ) : vku::DescriptorSetLayout<vk::DescriptorType::eSampledImage, vk::DescriptorType::eStorageBuffer> {
                 device,
                     vk::DescriptorSetLayoutCreateInfo {
@@ -31,7 +33,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         explicit SphericalHarmonicsComputer(
-            const vk::raii::Device &device [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND
         ) : descriptorSetLayout { device },
             pipelineLayout { device, vk::PipelineLayoutCreateInfo {
                 {},

--- a/interface/vulkan/pipeline/SubgroupMipmapComputer.cppm
+++ b/interface/vulkan/pipeline/SubgroupMipmapComputer.cppm
@@ -4,6 +4,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.SubgroupMipmapComputer;
 
 import std;
@@ -21,7 +23,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eStorageImage> {
             DescriptorSetLayout(
-                const Gpu &gpu [[clang::lifetimebound]],
+                const Gpu &gpu LIFETIMEBOUND,
                 std::uint32_t mipImageCount
             ) : vku::DescriptorSetLayout<vk::DescriptorType::eStorageImage> {
                 gpu.device,
@@ -37,7 +39,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         SubgroupMipmapComputer(
-            const Gpu &gpu [[clang::lifetimebound]],
+            const Gpu &gpu LIFETIMEBOUND,
             std::uint32_t mipImageCount
         ) : descriptorSetLayout { gpu, mipImageCount },
             pipelineLayout { gpu.device, vk::PipelineLayoutCreateInfo {

--- a/interface/vulkan/pipeline/WeightedBlendedCompositionRenderer.cppm
+++ b/interface/vulkan/pipeline/WeightedBlendedCompositionRenderer.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pipeline.WeightedBlendedCompositionRenderer;
 
 import vku;
@@ -9,7 +13,7 @@ export import :vulkan.rp.Scene;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export struct WeightedBlendedCompositionRenderer {
         struct DescriptorSetLayout : vku::DescriptorSetLayout<vk::DescriptorType::eInputAttachment, vk::DescriptorType::eInputAttachment> {
-            explicit DescriptorSetLayout(const vk::raii::Device &device [[clang::lifetimebound]])
+            explicit DescriptorSetLayout(const vk::raii::Device &device LIFETIMEBOUND)
                 : vku::DescriptorSetLayout<vk::DescriptorType::eInputAttachment, vk::DescriptorType::eInputAttachment> {
                     device,
                     vk::DescriptorSetLayoutCreateInfo {
@@ -26,8 +30,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         vk::raii::Pipeline pipeline;
 
         WeightedBlendedCompositionRenderer(
-            const vk::raii::Device &device [[clang::lifetimebound]],
-            const rp::Scene &sceneRenderPass [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND,
+            const rp::Scene &sceneRenderPass LIFETIMEBOUND
         ) : descriptorSetLayout { device },
             pipelineLayout { device, vk::PipelineLayoutCreateInfo {
                 {},

--- a/interface/vulkan/pipeline_layout/Primitive.cppm
+++ b/interface/vulkan/pipeline_layout/Primitive.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pl.Primitive;
 
 import std;
@@ -19,8 +21,8 @@ namespace vk_gltf_viewer::vulkan::pl {
         };
 
         Primitive(
-            const vk::raii::Device &device [[clang::lifetimebound]],
-            std::pair<const dsl::ImageBasedLighting&, const dsl::Asset&> descriptorSetLayouts [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND,
+            std::pair<const dsl::ImageBasedLighting&, const dsl::Asset&> descriptorSetLayouts LIFETIMEBOUND
         ) : PipelineLayout { device, vk::PipelineLayoutCreateInfo {
                 {},
                 vku::unsafeProxy({ *descriptorSetLayouts.first, *descriptorSetLayouts.second }),

--- a/interface/vulkan/pipeline_layout/PrimitiveNoShading.cppm
+++ b/interface/vulkan/pipeline_layout/PrimitiveNoShading.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.pl.PrimitiveNoShading;
 
 import std;
@@ -17,7 +19,7 @@ namespace vk_gltf_viewer::vulkan::pl {
         };
 
         PrimitiveNoShading(
-            const vk::raii::Device &device [[clang::lifetimebound]],
+            const vk::raii::Device &device LIFETIMEBOUND,
             const dsl::Asset& descriptorSetLayout
         ) : PipelineLayout { device, vk::PipelineLayoutCreateInfo {
                 {},

--- a/interface/vulkan/render_pass/CubemapToneMapping.cppm
+++ b/interface/vulkan/render_pass/CubemapToneMapping.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.rp.CubemapToneMapping;
 
 #ifdef _MSC_VER
@@ -8,7 +12,7 @@ export import vulkan_hpp;
 
 namespace vk_gltf_viewer::vulkan::rp {
     export struct CubemapToneMapping final : vk::raii::RenderPass {
-        explicit CubemapToneMapping(const vk::raii::Device &device [[clang::lifetimebound]])
+        explicit CubemapToneMapping(const vk::raii::Device &device LIFETIMEBOUND)
             : RenderPass { device, vk::StructureChain {
                 vk::RenderPassCreateInfo {
                     {},

--- a/interface/vulkan/render_pass/Scene.cppm
+++ b/interface/vulkan/render_pass/Scene.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.rp.Scene;
 
 #ifdef _MSC_VER
@@ -8,7 +12,7 @@ export import vulkan_hpp;
 
 namespace vk_gltf_viewer::vulkan::rp {
     export struct Scene final : vk::raii::RenderPass {
-        explicit Scene(const vk::raii::Device &device [[clang::lifetimebound]])
+        explicit Scene(const vk::raii::Device &device LIFETIMEBOUND)
             : RenderPass { device, vk::RenderPassCreateInfo {
                 {},
                 vku::unsafeProxy({

--- a/interface/vulkan/sampler/BrdfLut.cppm
+++ b/interface/vulkan/sampler/BrdfLut.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.sampler.BrdfLut;
 
 #ifdef _MSC_VER
@@ -8,7 +12,7 @@ export import vulkan_hpp;
 namespace vk_gltf_viewer::vulkan::sampler {
     export struct BrdfLut : vk::raii::Sampler {
         explicit BrdfLut(
-            const vk::raii::Device &device [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND
         ) : Sampler { device, vk::SamplerCreateInfo {
                 {},
                 vk::Filter::eLinear, vk::Filter::eLinear, {},

--- a/interface/vulkan/sampler/Cubemap.cppm
+++ b/interface/vulkan/sampler/Cubemap.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.sampler.Cubemap;
 
 #ifdef _MSC_VER
@@ -8,7 +12,7 @@ export import vulkan_hpp;
 namespace vk_gltf_viewer::vulkan::sampler {
     export struct Cubemap : vk::raii::Sampler {
         explicit Cubemap(
-            const vk::raii::Device &device [[clang::lifetimebound]]
+            const vk::raii::Device &device LIFETIMEBOUND
         ) : Sampler { device, vk::SamplerCreateInfo {
                 {},
                 vk::Filter::eLinear, vk::Filter::eLinear, vk::SamplerMipmapMode::eLinear,

--- a/interface/vulkan/sampler/Samplers.cppm
+++ b/interface/vulkan/sampler/Samplers.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.sampler.Samplers;
 
 import std;
@@ -23,7 +25,7 @@ export import vulkan_hpp;
 
 namespace vk_gltf_viewer::vulkan::sampler {
     export struct Samplers : std::vector<vk::raii::Sampler> {
-        Samplers(const fastgltf::Asset &asset, const vk::raii::Device &device [[clang::lifetimebound]]) {
+        Samplers(const fastgltf::Asset &asset, const vk::raii::Device &device LIFETIMEBOUND) {
             reserve(asset.samplers.size());
             for (const fastgltf::Sampler &sampler : asset.samplers) {
                 vk::SamplerCreateInfo createInfo {

--- a/interface/vulkan/texture/Fallback.cppm
+++ b/interface/vulkan/texture/Fallback.cppm
@@ -2,6 +2,8 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer:vulkan.texture.Fallback;
 
 import std;
@@ -31,7 +33,7 @@ namespace vk_gltf_viewer::vulkan::texture {
          */
         vk::raii::Sampler sampler;
 
-        explicit Fallback(const vulkan::Gpu &gpu [[clang::lifetimebound]])
+        explicit Fallback(const vulkan::Gpu &gpu LIFETIMEBOUND)
             : image { gpu.allocator, vk::ImageCreateInfo {
                 {},
                 vk::ImageType::e2D,


### PR DESCRIPTION
`[[msvc::lifetimebound]]` and `[[clang::lifetimebound]]` are used for MSVC and Clang, respectively.
Additionally, the incorrect attribute usage has been fixed (parameters of functions returning `void` cannot be attributed).