### PR TITLE
Use latest Vulkan SDK (1.4.309) and vku.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Vulkan SDK (without GLSL -> SPIR-V compiler)
         if: ${{ runner.os != 'Windows' }}
-        uses: utzcoz/setup-vulkan-sdk@improve-cache-for-architectures
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.296.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Vulkan SDK (with GLSL -> SPIR-V compiler)
         if: ${{ runner.os == 'Windows' }}
-        uses: utzcoz/setup-vulkan-sdk@improve-cache-for-architectures
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.296.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang, SPIRV-Tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
-          vulkan-query-version: 1.3.296.0
+          vulkan-query-version: latest
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
 
@@ -35,7 +35,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
-          vulkan-query-version: 1.3.296.0
+          vulkan-query-version: latest
           vulkan-components: Vulkan-Headers, Vulkan-Loader, Glslang, SPIRV-Tools
           vulkan-use-cache: true
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,6 @@ I initially developed this application for leveraging Vulkan's performance and u
 
 ## Usage
 
-> [!WARNING]
-> The latest Vulkan SDK (1.4.304) is not compatible to the application's core library ([vku](https://github.com/stripe2933/vku)), due to [the upstream issue](https://github.com/KhronosGroup/Vulkan-Hpp/issues/2045). You need to use the previous version (1.3.296) for now.
-
 ### Vulkan Requirements
 
 The extensions and feature used in this application are quite common in the modern desktop GPU drivers, so I hope you don't have any problem with this.

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -120,10 +120,9 @@ vk_gltf_viewer::MainApp::MainApp() {
                     });
 
                 // Compute BRDF.
-                vku::DescriptorSet<vulkan::BrdfmapComputer::DescriptorSetLayout> brdfmapSet;
                 brdfmapComputer.compute(
                     cb,
-                    brdfmapSet.getWriteOne<0>({ {}, *brdfmapImageView, vk::ImageLayout::eGeneral }),
+                    vulkan::BrdfmapComputer::DescriptorSetLayout::getWriteOne<0>({ {}, *brdfmapImageView, vk::ImageLayout::eGeneral }),
                     vku::toExtent2D(brdfmapImage.extent));
 
                 // brdfmapImage will be used as sampled image.
@@ -1217,11 +1216,10 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
                 }, vk::SubpassContents::eInline);
 
                 cb.bindPipeline(vk::PipelineBindPoint::eGraphics, *cubemapToneMappingRenderer.pipeline);
-                vku::DescriptorSet<vulkan::CubemapToneMappingRenderer::DescriptorSetLayout> cubemapToneMappingDescriptorSet;
                 cb.pushDescriptorSetKHR(
                     vk::PipelineBindPoint::eGraphics,
                     *cubemapToneMappingRenderer.pipelineLayout,
-                    0, cubemapToneMappingDescriptorSet.getWriteOne<0>({ {}, *cubemapImageArrayView, vk::ImageLayout::eShaderReadOnlyOptimal }));
+                    0, vulkan::CubemapToneMappingRenderer::DescriptorSetLayout::getWriteOne<0>({ {}, *cubemapImageArrayView, vk::ImageLayout::eShaderReadOnlyOptimal }));
                 cb.setViewport(0, vku::unsafeProxy(vku::toViewport(vku::toExtent2D(toneMappedCubemapImage.extent))));
                 cb.setScissor(0, vku::unsafeProxy(vk::Rect2D { { 0, 0 }, vku::toExtent2D(toneMappedCubemapImage.extent) }));
                 cb.draw(3, 1, 0, 0);

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -44,7 +44,7 @@ vk_gltf_viewer::vulkan::Frame::Frame(const SharedData &sharedData)
 
     // Allocate descriptor sets.
     std::tie(hoveringNodeJumpFloodSet, selectedNodeJumpFloodSet, hoveringNodeOutlineSet, selectedNodeOutlineSet, weightedBlendedCompositionSet)
-        = allocateDescriptorSets(*sharedData.gpu.device, *descriptorPool, std::tie(
+        = allocateDescriptorSets(*descriptorPool, std::tie(
             sharedData.jumpFloodComputer.descriptorSetLayout,
             sharedData.jumpFloodComputer.descriptorSetLayout,
             sharedData.outlineRenderer.descriptorSetLayout,

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -178,10 +178,8 @@ namespace vk_gltf_viewer::vulkan {
                 }
             }().get() }
             , fallbackTexture { gpu }{
-            std::tie(imageBasedLightingDescriptorSet, skyboxDescriptorSet)
-                = vku::allocateDescriptorSets(*gpu.device, *descriptorPool, std::tie(
-                    imageBasedLightingDescriptorSetLayout,
-                    skyboxDescriptorSetLayout));
+            std::tie(imageBasedLightingDescriptorSet, skyboxDescriptorSet) = vku::allocateDescriptorSets(
+                *descriptorPool, std::tie(imageBasedLightingDescriptorSetLayout, skyboxDescriptorSetLayout));
         }
 
         // --------------------
@@ -289,7 +287,7 @@ namespace vk_gltf_viewer::vulkan {
                         gpu.device,
                         getPoolSizes(assetDescriptorSetLayout)
                             .getDescriptorPoolCreateInfo(vk::DescriptorPoolCreateFlagBits::eUpdateAfterBind));
-                    std::tie(assetDescriptorSet) = vku::allocateDescriptorSets(*gpu.device, inner, std::tie(assetDescriptorSetLayout));
+                    std::tie(assetDescriptorSet) = vku::allocateDescriptorSets(inner, std::tie(assetDescriptorSetLayout));
                 }
             }
 

--- a/interface/vulkan/generator/MipmappedCubemapGenerator.cppm
+++ b/interface/vulkan/generator/MipmappedCubemapGenerator.cppm
@@ -88,12 +88,11 @@ namespace vk_gltf_viewer::vulkan::inline generator {
                 });
 
             // Generate cubemap from eqmapImage.
-            vku::DescriptorSet<CubemapComputer::DescriptorSetLayout> cubemapComputerSet;
             pipelines.cubemapComputer.compute(
                 computeCommandBuffer,
                 {
-                    cubemapComputerSet.getWriteOne<0>({ {}, *intermediateResources->eqmapImageView, vk::ImageLayout::eShaderReadOnlyOptimal }),
-                    cubemapComputerSet.getWriteOne<1>({ {}, *intermediateResources->cubemapMipImageViews[0], vk::ImageLayout::eGeneral}),
+                    CubemapComputer::DescriptorSetLayout::getWriteOne<0>({ {}, *intermediateResources->eqmapImageView, vk::ImageLayout::eShaderReadOnlyOptimal }),
+                    CubemapComputer::DescriptorSetLayout::getWriteOne<1>({ {}, *intermediateResources->cubemapMipImageViews[0], vk::ImageLayout::eGeneral}),
                 },
                 cubemapImage.extent.width);
 
@@ -105,10 +104,9 @@ namespace vk_gltf_viewer::vulkan::inline generator {
                 {}, {});
 
             // Generate cubemapImage mipmaps.
-            vku::DescriptorSet<SubgroupMipmapComputer::DescriptorSetLayout> subgroupMipmapComputerSet;
             pipelines.subgroupMipmapComputer.compute(
                 computeCommandBuffer,
-                subgroupMipmapComputerSet.getWrite<0>(vku::unsafeProxy(
+                SubgroupMipmapComputer::DescriptorSetLayout::getWrite<0>(vku::unsafeProxy(
                     intermediateResources->cubemapMipImageViews
                         | std::views::transform([](vk::ImageView view) {
                             return vk::DescriptorImageInfo { {}, view, vk::ImageLayout::eGeneral };

--- a/overlays/vulkan/vcpkg.json
+++ b/overlays/vulkan/vcpkg.json
@@ -1,4 +1,4 @@
 {
   "name": "vulkan",
-  "version": "1.3.296"
+  "version": "1.4.309"
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,13 +1,13 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "1a66c32c6f90c2f646529975c3c076ed3dbdae0c",
+    "baseline": "117524bad2789b8aa6954324a1bee4bffb7d6d09",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [
     {
       "kind": "git",
-      "baseline": "23dc743e35900a8f14d73aabb8546e8cc4229f9f",
+      "baseline": "f99329d0c758476e58167ab9889fe44a95ded54d",
       "reference": "main",
       "repository": "https://github.com/stripe2933/vcpkg-registry",
       "packages": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -23,8 +23,7 @@
     {
       "name": "vku",
       "features": [
-        "dynamic-dispatcher",
-        "std-module"
+        "dynamic-dispatcher"
       ]
     },
     "bshoshany-thread-pool"


### PR DESCRIPTION
Since [malformed `vulkan.cppm` issue](https://github.com/KhronosGroup/Vulkan-Hpp/issues/2045) fixed in Vulkan SDK 1.4.309, we can use the latest Vulkan SDK.

Also, it bumps up the [vku](https://github.com/stripe2933/vku) version and introduces several improved features.