### PR TITLE
Implemented transformation/morph target animation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/gltf/algorithm/miniball.cppm
         interface/gltf/algorithm/misc.cppm
         interface/gltf/algorithm/traversal.cppm
+        interface/gltf/data_structure/NodeInstanceCountExclusiveScanWithCount.cppm
+        interface/gltf/data_structure/TargetWeightCountExclusiveScan.cppm
         interface/gltf/AssetExternalBuffers.cppm
         interface/gltf/AssetProcessError.cppm
         interface/gltf/SceneInverseHierarchy.cppm
@@ -134,6 +136,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/gltf/OrderedPrimitives.cppm
         interface/gltf/TextureUsage.cppm
         interface/helpers/AggregateHasher.cppm
+        interface/helpers/algorithm.cppm
         interface/helpers/concepts.cppm
         interface/helpers/enums/FlagTraits.cppm
         interface/helpers/enums/Flags.cppm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/gltf/algorithm/miniball.cppm
         interface/gltf/algorithm/misc.cppm
         interface/gltf/algorithm/traversal.cppm
+        interface/gltf/Animation.cppm
         interface/gltf/data_structure/NodeInstanceCountExclusiveScanWithCount.cppm
         interface/gltf/data_structure/TargetWeightCountExclusiveScan.cppm
         interface/gltf/AssetExternalBuffers.cppm

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Blazingly fast[^1] Vulkan glTF viewer.
 Followings are not supported:
 
 - Primitive Type except for `TRIANGLES`.
-- Animation.
+- Skinning.
 
 ## Performance
 
@@ -308,12 +308,13 @@ All shaders are located in the [shaders](/shaders) folder and will be automatica
 
 - [x] Basis Universal texture support (`KHR_texture_basisu`).
 - [x] Automatic camera position adjustment based on the bounding sphere calculation.
+- [x] Animations.
 - [ ] Frustum culling
   - [x] CPU frustum culling (Note: still experimental; unexpected popped in/out may happened.)
   - [ ] GPU frustum culling
 - [ ] Occlusion culling
 - [ ] Reduce skybox memory usage with BC6H compressed cubemap.
-- [ ] Animations.
+- [ ] Skinning
 
 ## License
 

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -360,8 +360,10 @@ void vk_gltf_viewer::MainApp::run() {
                     // TODO: I'm aware that there are more good solutions than waitIdle, but I don't have much time for it
                     //  so I'll just use it for now.
                     gpu.device.waitIdle();
-                    sharedData.gltfAsset->instancedNodeWorldTransformBuffer.update(
-                        gltf->asset.scenes[task.newSceneIndex], gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                    for (vulkan::Frame &frame : frames) {
+                        frame.gltfAsset->instancedNodeWorldTransformBuffer.update(
+                            gltf->asset.scenes[task.newSceneIndex], gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                    }
 
                     // Update AppState.
                     appState.gltfAsset->setScene(task.newSceneIndex);
@@ -428,8 +430,10 @@ void vk_gltf_viewer::MainApp::run() {
                     // Update the current and its descendant nodes' world transforms for both host and GPU side data.
                     gltf->nodeWorldTransforms.update(task.nodeIndex, nodeWorldTransform);
                     gpu.device.waitIdle();
-                    sharedData.gltfAsset->instancedNodeWorldTransformBuffer.update(
-                        task.nodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                    for (vulkan::Frame &frame : frames) {
+                        frame.gltfAsset->instancedNodeWorldTransformBuffer.update(
+                            task.nodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                    }
 
                     // Scene enclosing sphere would be changed. Adjust the camera's near/far plane if necessary.
                     if (appState.automaticNearFarPlaneAdjustment) {
@@ -487,8 +491,10 @@ void vk_gltf_viewer::MainApp::run() {
                     // Update the current and its descendant nodes' world transforms for both host and GPU side data.
                     gltf->nodeWorldTransforms.update(selectedNodeIndex, selectedNodeWorldTransform);
                     gpu.device.waitIdle();
-                    sharedData.gltfAsset->instancedNodeWorldTransformBuffer.update(
-                        selectedNodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                    for (vulkan::Frame &frame : frames) {
+                        frame.gltfAsset->instancedNodeWorldTransformBuffer.update(
+                            selectedNodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                    }
 
                     // Scene enclosing sphere would be changed. Adjust the camera's near/far plane if necessary.
                     if (appState.automaticNearFarPlaneAdjustment) {
@@ -537,7 +543,9 @@ void vk_gltf_viewer::MainApp::run() {
                 },
                 [&](const control::task::ChangeMorphTargetWeight &task) {
                     gpu.device.waitIdle();
-                    sharedData.gltfAsset.value().morphTargetWeightBuffer.updateWeight(task.nodeIndex, task.targetWeightIndex, task.newValue);
+                    for (vulkan::Frame &frame : frames) {
+                        frame.gltfAsset.value().morphTargetWeightBuffer.updateWeight(task.nodeIndex, task.targetWeightIndex, task.newValue);
+                    }
 
                     // Scene enclosing sphere would be changed. Adjust the camera's near/far plane if necessary.
                     if (appState.automaticNearFarPlaneAdjustment) {
@@ -802,7 +810,10 @@ void vk_gltf_viewer::MainApp::loadGltf(const std::filesystem::path &path) {
         // TODO: I'm aware that there are better solutions compare to the waitIdle, but I don't have much time for it
         //  so I'll just use it for now.
         gpu.device.waitIdle();
-        sharedData.changeAsset(inner.asset, path.parent_path(), inner.nodeWorldTransforms, inner.orderedPrimitives, inner.assetExternalBuffers);
+        sharedData.changeAsset(inner.asset, path.parent_path(), inner.orderedPrimitives, inner.assetExternalBuffers);
+        for (vulkan::Frame &frame : frames) {
+            frame.changeAsset(inner.asset, inner.nodeWorldTransforms, inner.assetExternalBuffers);
+        }
     }
     catch (gltf::AssetProcessError error) {
         std::println(std::cerr, "The glTF file cannot be processed because of an error: {}", to_string(error));

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -424,6 +424,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::assetTextures(
     // bottomSidebar
     ImGui::DockBuilderDockWindow("Material Editor", bottomSidebar);
     ImGui::DockBuilderDockWindow("Material Variants", bottomSidebar);
+    ImGui::DockBuilderDockWindow("Animations", bottomSidebar);
 
     ImGui::DockBuilderFinish(dockSpaceOverViewport);
 
@@ -552,6 +553,18 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::menuBar(
         }
         ImGui::EndMainMenuBar();
     }
+}
+
+void vk_gltf_viewer::control::ImGuiTaskCollector::animations(const fastgltf::Asset &asset, std::vector<bool> &animationEnabled) {
+    if (ImGui::Begin("Animation")) {
+        for (auto &&[animation, enabled] : std::views::zip(asset.animations, animationEnabled)) {
+            bool enabledBool = enabled;
+            if (ImGui::Checkbox(nonempty_or(animation.name, []() -> cpp_util::cstring_view { return "<Unnamed animation>"; }).c_str(), &enabledBool)) {
+                enabled = enabledBool;
+            }
+        }
+    }
+    ImGui::End();
 }
 
 void vk_gltf_viewer::control::ImGuiTaskCollector::assetInspector(

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -1100,7 +1100,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::nodeInspector(
 
                 for (auto &&[i, weight] : morphTargetWeights | ranges::views::enumerate) {
                     if (ImGui::DragFloat(tempStringBuffer.write("Weight {}", i).view().c_str(), &weight, 0.01f)) {
-                        tasks.emplace_back(std::in_place_type<task::ChangeMorphTargetWeight>, selectedNodeIndex, i, weight);
+                        tasks.emplace_back(std::in_place_type<task::ChangeMorphTargetWeight>, selectedNodeIndex, i, 1);
                     }
                 }
             }

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -3,6 +3,7 @@ export module vk_gltf_viewer:MainApp;
 import std;
 import :control.AppWindow;
 import :gltf.algorithm.miniball;
+import :gltf.Animation;
 import :gltf.AssetExternalBuffers;
 import :gltf.MaterialVariantsMapping;
 import :gltf.NodeWorldTransforms;
@@ -68,6 +69,9 @@ namespace vk_gltf_viewer {
 
             gltf::NodeWorldTransforms nodeWorldTransforms;
             gltf::OrderedPrimitives orderedPrimitives;
+
+            std::vector<gltf::Animation> animations;
+            std::vector<bool> animationEnabled;
 
             /**
              * @brief The glTF scene that is currently used by.

--- a/interface/control/ImGuiTaskCollector.cppm
+++ b/interface/control/ImGuiTaskCollector.cppm
@@ -19,6 +19,7 @@ namespace vk_gltf_viewer::control {
         ~ImGuiTaskCollector();
 
         void menuBar(const std::list<std::filesystem::path> &recentGltfs, const std::list<std::filesystem::path> &recentSkyboxes);
+        void animations(const fastgltf::Asset &asset, std::vector<bool> &animationEnabled);
         void assetInspector(fastgltf::Asset &asset, const std::filesystem::path &assetDir);
         void assetTextures(fastgltf::Asset &asset, std::span<const vk::DescriptorSet> assetTextureImGuiDescriptorSets, const gltf::TextureUsage &textureUsage);
         void materialEditor(fastgltf::Asset &asset, std::span<const vk::DescriptorSet> assetTextureImGuiDescriptorSets);

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -22,7 +22,7 @@ namespace vk_gltf_viewer::control {
         struct ChangeCameraView { };
         struct InvalidateDrawCommandSeparation { };
         struct SelectMaterialVariants { std::size_t variantIndex; };
-        struct ChangeMorphTargetWeight { std::size_t nodeIndex; std::size_t targetWeightIndex; float newValue; };
+        struct ChangeMorphTargetWeight { std::size_t nodeIndex; std::size_t targetWeightStartIndex; std::size_t targetWeightCount; };
     }
 
     export using Task = std::variant<

--- a/interface/gltf/Animation.cppm
+++ b/interface/gltf/Animation.cppm
@@ -1,0 +1,222 @@
+module;
+
+#include <lifetimebound.hpp>
+
+export module vk_gltf_viewer:gltf.Animation;
+
+import std;
+export import fastgltf;
+import :helpers.fastgltf;
+import :helpers.ranges;
+
+/**
+ * @brief Sample value using cubic spline interpolation.
+ * @tparam T Type that supports addition and scalar multiplication.
+ * @param propertyBefore Property value of k-th frame.
+ * @param outTangentBefore Out-tangent of k-th frame.
+ * @param propertyAfter Property value of (k+1)-th frame.
+ * @param inTangentAfter In-tangent of (k+1)-th frame.
+ * @param t Timestamp.
+ * @param dt Time difference between k-th and (k+1)-th frame.
+ * @return Interpolated property value of k-th frame.
+ */
+template <typename T>
+[[nodiscard]] T cubicSpline(const T &propertyBefore, const T &outTangentBefore, const T &propertyAfter, const T &inTangentAfter, float t, float dt) noexcept {
+	const float t2 = t * t;
+	const float t3 = t2 * t;
+	return propertyBefore * (2 * t3 - 3 * t2 + 1)
+		+ outTangentBefore * dt * (t3 - 2 * t2 + t)
+		+ propertyAfter * (-2 * t3 + 3 * t2)
+		+ inTangentAfter * dt * (t3 - t2);
+}
+
+namespace vk_gltf_viewer::gltf {
+    export class Animation {
+        std::reference_wrapper<fastgltf::Asset> asset;
+        std::reference_wrapper<const fastgltf::Animation> animation;
+
+        /**
+         * @brief Copied input accessor floats, indexed by the accessor index.
+         */
+        std::unordered_map<std::size_t, std::vector<float>> inputAccessorData;
+
+    public:
+        template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
+        Animation(
+            fastgltf::Asset &asset LIFETIMEBOUND,
+            const fastgltf::Animation &animation,
+            const BufferDataAdapter &adapter = {}
+        ) : asset { asset },
+    		animation { animation } {
+            for (const fastgltf::AnimationSampler &sampler : animation.samplers) {
+                const fastgltf::Accessor &inputAccessor = asset.accessors[sampler.inputAccessor];
+                if (auto [it, inserted] = inputAccessorData.try_emplace(sampler.inputAccessor, inputAccessor.count); inserted) {
+                    fastgltf::copyFromAccessor<float>(asset, inputAccessor, it->second.data(), adapter);
+                }
+            }
+        }
+
+        /**
+         * @brief Fetch transforms and target weights at given \p time, update asset data using them.
+         * @tparam BufferDataAdapter A functor type that acquires the binary buffer data from a glTF buffer view. If you provided <tt>fastgltf::Options::LoadExternalBuffers</tt> to the <tt>fastgltf::Parser</tt> while loading the glTF, the parameter can be omitted.
+         * @param time Time to sample the animation.
+         * @param transformedNodeIt A LegacyOutputIterator to store the node indices that have been transformed by the animation.
+         * @param morphedNodeIt A LegacyOutputIterator to store the node indices that have been morphed by the animation.
+         * @param adapter Buffer data adapter.
+         */
+        template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
+        void update(
+        	float time,
+        	auto transformedNodeIt,
+        	auto morphedNodeIt,
+            const BufferDataAdapter &adapter = {}
+        ) const {
+        	for (const fastgltf::AnimationChannel &channel : animation.get().channels) {
+				if (!channel.nodeIndex) {
+					continue;
+				}
+
+        		const std::size_t nodeIndex = *channel.nodeIndex;
+        		fastgltf::Node &node = asset.get().nodes[nodeIndex];
+
+        		const fastgltf::AnimationSampler &sampler = animation.get().samplers[channel.samplerIndex];
+        		switch (channel.path) {
+        			case fastgltf::AnimationPath::Translation:
+        				// glTF specification:
+        				// When a node is targeted for animation (referenced by an animation.channel.target), only TRS properties MAY be
+        				// present; matrix MUST NOT be present.
+        				get<fastgltf::TRS>(node.transform).translation = sample<fastgltf::math::fvec3>(sampler, time, adapter);
+        				*transformedNodeIt++ = nodeIndex;
+						break;
+        			case fastgltf::AnimationPath::Rotation:
+	                    get<fastgltf::TRS>(node.transform).rotation = sample<fastgltf::math::fquat>(sampler, time, adapter);
+	                    *transformedNodeIt++ = nodeIndex;
+	                    break;
+        			case fastgltf::AnimationPath::Scale:
+	                    get<fastgltf::TRS>(node.transform).scale = sample<fastgltf::math::fvec3>(sampler, time, adapter);
+	                    *transformedNodeIt++ = nodeIndex;
+	                    break;
+        			case fastgltf::AnimationPath::Weights: {
+        				std::span targetWeights = node.weights;
+        				if (node.meshIndex) {
+        					targetWeights = asset.get().meshes[*node.meshIndex].weights;
+        				}
+        				std::ranges::copy(sample(sampler, time, targetWeights.size(), adapter), targetWeights.data());
+        				*morphedNodeIt++ = nodeIndex;
+        			}
+		        }
+        	}
+        }
+
+    private:
+		template <typename T, typename BufferDataAdapter>
+		[[nodiscard]] T sample(
+			const fastgltf::AnimationSampler &sampler,
+			float time,
+			const BufferDataAdapter &adapter = {}
+		) const {
+			const fastgltf::Accessor &outputAccessor = asset.get().accessors[sampler.outputAccessor];
+
+			// Create functor that returns the output accessor data with the given index.
+			const auto outputAccessorElementAt = [&](std::size_t index) {
+				return fastgltf::getAccessorElement<T>(asset, outputAccessor, index, adapter);
+			};
+
+			const std::span input = inputAccessorData.at(sampler.inputAccessor);
+ 			time = std::fmod(time, input.back()); // Ugly hack to loop animations
+ 			auto it = std::ranges::lower_bound(input, time);
+ 			if (it == input.begin()) {
+ 				return outputAccessorElementAt(sampler.interpolation == fastgltf::AnimationInterpolation::CubicSpline);
+ 			}
+ 			if (it == input.end()) {
+ 				return outputAccessorElementAt(outputAccessor.count - (sampler.interpolation == fastgltf::AnimationInterpolation::CubicSpline ? 2 : 1));
+ 			}
+
+ 			auto i = it - input.begin();
+ 			const float t = (time - input[i - 1]) / (input[i] - input[i - 1]);
+
+ 			switch (sampler.interpolation) {
+ 				case fastgltf::AnimationInterpolation::Step:
+ 					return outputAccessorElementAt(i - 1);
+ 				case fastgltf::AnimationInterpolation::Linear: {
+ 					const auto vk = outputAccessorElementAt(i - 1);
+ 					const auto vk1 = outputAccessorElementAt(i);
+
+ 					if constexpr (std::same_as<T, fastgltf::math::fquat>) {
+ 						return fastgltf::math::slerp(vk, vk1, t);
+ 					}
+ 					else {
+ 						return fastgltf::math::lerp(vk, vk1, t);
+ 					}
+ 				}
+ 				case fastgltf::AnimationInterpolation::CubicSpline: {
+ 					const float dt = input[i] - input[i - 1];
+ 					auto v = cubicSpline(
+ 						outputAccessorElementAt(3 * (i - 1) + 1),
+						outputAccessorElementAt(3 * (i - 1) + 2),
+						outputAccessorElementAt(3 * i + 1),
+						outputAccessorElementAt(3 * i),
+						t, dt);
+
+ 					if constexpr (std::same_as<T, fastgltf::math::fquat>) {
+ 						v = normalize(v);
+ 					}
+ 					return v;
+ 				}
+ 			}
+ 			std::unreachable();
+		}
+    	
+		template <typename BufferDataAdapter>
+		[[nodiscard]] std::valarray<float> sample(
+			const fastgltf::AnimationSampler &sampler,
+			float time,
+			std::size_t targetWeightCount,
+			const BufferDataAdapter &adapter = {}
+		) const {
+			const fastgltf::Accessor &outputAccessor = asset.get().accessors[sampler.outputAccessor];
+
+			// Create functor that returns the output accessor data with the given index.
+			const auto outputAccessorElementsAt = [&](std::size_t index) {
+				std::valarray<float> result(targetWeightCount);
+				for (std::size_t i = 0; i < targetWeightCount; ++i) {
+					result[i] = fastgltf::getAccessorElement<float>(asset, outputAccessor, targetWeightCount * index + i, adapter);
+				}
+				return result;
+			};
+
+			const std::span input = inputAccessorData.at(sampler.inputAccessor);
+ 			time = std::fmod(time, input.back()); // Ugly hack to loop animations
+ 			auto it = std::ranges::lower_bound(input, time);
+ 			if (it == input.begin()) {
+ 				return outputAccessorElementsAt(sampler.interpolation == fastgltf::AnimationInterpolation::CubicSpline);
+ 			}
+ 			if (it == input.end()) {
+ 				return outputAccessorElementsAt(outputAccessor.count - (sampler.interpolation == fastgltf::AnimationInterpolation::CubicSpline ? 2 : 1));
+ 			}
+
+ 			auto i = it - input.begin();
+ 			const float t = (time - input[i - 1]) / (input[i] - input[i - 1]);
+
+ 			switch (sampler.interpolation) {
+ 				case fastgltf::AnimationInterpolation::Step:
+ 					return outputAccessorElementsAt(i - 1);
+ 				case fastgltf::AnimationInterpolation::Linear: {
+ 					const auto vk = outputAccessorElementsAt(i - 1);
+ 					const auto vk1 = outputAccessorElementsAt(i);
+ 					return vk + (vk1 - vk) * t;
+ 				}
+ 				case fastgltf::AnimationInterpolation::CubicSpline: {
+ 					const float dt = input[i] - input[i - 1];
+ 					return cubicSpline(
+ 						outputAccessorElementsAt(3 * (i - 1) + 1),
+						outputAccessorElementsAt(3 * (i - 1) + 2),
+						outputAccessorElementsAt(3 * i + 1),
+						outputAccessorElementsAt(3 * i),
+						t, dt);
+ 				}
+ 			}
+ 			std::unreachable();
+		}
+    };
+}

--- a/interface/gltf/data_structure/NodeInstanceCountExclusiveScanWithCount.cppm
+++ b/interface/gltf/data_structure/NodeInstanceCountExclusiveScanWithCount.cppm
@@ -1,0 +1,27 @@
+export module vk_gltf_viewer:gltf.data_structure.NodeInstanceCountExclusiveScanWithCount;
+
+import std;
+import :helpers.algorithm;
+export import fastgltf;
+
+namespace vk_gltf_viewer::gltf::ds {
+    /**
+     * @brief Exclusive scan of the instance counts (or 1 if the node doesn't have any instance), and additional total instance count at the end.
+     */
+    export struct NodeInstanceCountExclusiveScanWithCount final : std::vector<std::uint32_t> {
+        explicit NodeInstanceCountExclusiveScanWithCount(const fastgltf::Asset &asset)
+            : vector { exclusive_scan_with_count(asset.nodes | std::views::transform([&](const fastgltf::Node &node) -> std::uint32_t {
+                if (!node.meshIndex) {
+                    return 0;
+                }
+                if (node.instancingAttributes.empty()) {
+                    return 1;
+                }
+                else {
+                    // According to the EXT_mesh_gpu_instancing specification, all attribute accessors in a given node
+                    // must have the same count. Therefore, we can use the count of the first attribute accessor.
+                    return asset.accessors[node.instancingAttributes[0].accessorIndex].count;
+                }
+            })) } { }
+    };
+}

--- a/interface/gltf/data_structure/TargetWeightCountExclusiveScan.cppm
+++ b/interface/gltf/data_structure/TargetWeightCountExclusiveScan.cppm
@@ -1,0 +1,25 @@
+export module vk_gltf_viewer:gltf.data_structure.TargetWeightCountExclusiveScan;
+
+import std;
+export import fastgltf;
+import :helpers.algorithm;
+
+namespace vk_gltf_viewer::gltf::ds {
+    /**
+     * @brief Exclusive scan of target weight counts in an asset, ordered by their corresponding nodes.
+     *
+     * If a node has mesh, mesh target weight count is used.
+     */
+    export struct TargetWeightCountExclusiveScan final : std::vector<std::uint32_t> {
+        explicit TargetWeightCountExclusiveScan(const fastgltf::Asset &asset)
+            : vector { exclusive_scan(asset.nodes | std::views::transform([&](const fastgltf::Node &node) {
+                std::uint32_t weightCount = node.weights.size();
+                if (node.meshIndex) {
+                    const fastgltf::Mesh &mesh = asset.meshes[*node.meshIndex];
+                    weightCount = mesh.weights.size();
+                }
+
+                return weightCount;
+            })) } { }
+    };
+}

--- a/interface/helpers/algorithm.cppm
+++ b/interface/helpers/algorithm.cppm
@@ -1,0 +1,54 @@
+export module vk_gltf_viewer:helpers.algorithm;
+
+import std;
+
+#define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+
+/**
+ * @brief Get exclusive scan of the given range.
+ *
+ *  Input: [1, 3, 5, 2, 4]
+ * Output: [0, 1, 4, 9, 11]
+ *
+ * @tparam R Input range type.
+ * @param r Input range.
+ * @return Exclusive scan result.
+ */
+export template <typename R>
+    requires std::ranges::input_range<R>
+        && std::ranges::sized_range<R>
+        && requires(std::ranges::range_value_t<R> e) {
+            { e + e } -> std::same_as<decltype(e)>;
+        } // Must be additive.
+[[nodiscard]] std::vector<std::ranges::range_value_t<R>> exclusive_scan(R &&r) {
+    std::vector result { std::from_range, FWD(r) };
+    std::exclusive_scan(result.begin(), result.end(), result.begin(), 0);
+    return result;
+}
+
+/**
+ * @brief Get exclusive scan of the given range, and append the total summation at the end.
+ *
+ *  Input: [1, 3, 5, 2, 4]
+ * Output: [0, 1, 4, 9, 11, 15] (15 = 1 + 3 + 5 + 2 + 4)
+ *
+ * @tparam R Input range type. Must be a sized range.
+ * @param r Input range.
+ * @return Exclusive scan result.
+ */
+export template <typename R>
+    requires std::ranges::input_range<R>
+        && std::ranges::sized_range<R>
+        && requires(std::ranges::range_value_t<R> e) {
+            { e + e } -> std::same_as<decltype(e)>;
+        } // Must be additive.
+[[nodiscard]] std::vector<std::ranges::range_value_t<R>> exclusive_scan_with_count(R &&r) {
+    std::vector<std::ranges::range_value_t<R>> result;
+    result.reserve(std::ranges::size(r) + 1);
+    result.append_range(FWD(r));
+    result.push_back(0);
+
+    std::exclusive_scan(result.begin(), result.end(), result.begin(), 0);
+
+    return result;
+}

--- a/interface/vulkan/buffer/MorphTargetWeights.cppm
+++ b/interface/vulkan/buffer/MorphTargetWeights.cppm
@@ -6,56 +6,52 @@ export module vk_gltf_viewer:vulkan.buffer.MorphTargetWeights;
 
 import std;
 export import fastgltf;
+export import :gltf.data_structure.TargetWeightCountExclusiveScan;
 import :vulkan.buffer;
 export import :vulkan.Gpu;
 
 namespace vk_gltf_viewer::vulkan::buffer {
     export class MorphTargetWeights {
     public:
-        MorphTargetWeights(const fastgltf::Asset &asset, const Gpu &gpu LIFETIMEBOUND)
-            : buffer { createBuffer(asset, gpu.allocator) }
-            , descriptorInfo { buffer, 0, vk::WholeSize } { }
+        MorphTargetWeights(
+            const fastgltf::Asset &asset,
+            std::shared_ptr<const gltf::ds::TargetWeightCountExclusiveScan> targetWeightCountExclusiveScan,
+            const Gpu &gpu LIFETIMEBOUND
+        ) : buffer { [&]() {
+                // This is workaround for Clang 19's bug that ranges::views::concat causes ambiguous spaceship operator error.
+                // TODO: change it to use ranges::views::concat when available.
+                std::vector<std::span<const float>> weights;
+                weights.reserve(asset.nodes.size() + 1);
 
-        [[nodiscard]] std::uint32_t getStartIndex(std::size_t nodeIndex) const noexcept {
-            return startOffsets[nodeIndex];
-        }
+                weights.append_range(asset.nodes | std::views::transform([&](const fastgltf::Node &node) {
+                    std::span<const float> weights = node.weights;
+                    if (node.meshIndex) {
+                        const fastgltf::Mesh &mesh = asset.meshes[*node.meshIndex];
+                        weights = mesh.weights;
+                    }
+                    return weights;
+                }));
+                // A dummy NaN-valued weight for preventing the zero-sized buffer creation.
+                // This will not affect to the actual weight indexing.
+                constexpr float dummyWeight = std::numeric_limits<float>::quiet_NaN();
+                weights.emplace_back(&dummyWeight, 1);
+
+                return createCombinedBuffer(gpu.allocator, weights, vk::BufferUsageFlagBits::eStorageBuffer).first;
+            }() },
+            descriptorInfo { buffer, 0, vk::WholeSize },
+            targetWeightCountExclusiveScan { std::move(targetWeightCountExclusiveScan) } { }
 
         [[nodiscard]] const vk::DescriptorBufferInfo &getDescriptorInfo() const noexcept {
             return descriptorInfo;
         }
 
         void updateWeight(std::size_t nodeIndex, std::size_t weightIndex, float weight) {
-            buffer.asRange<float>()[startOffsets[nodeIndex] + weightIndex] = weight;
+            buffer.asRange<float>()[(*targetWeightCountExclusiveScan)[nodeIndex] + weightIndex] = weight;
         }
 
     private:
-        std::vector<std::uint32_t> startOffsets;
         vku::MappedBuffer buffer;
         vk::DescriptorBufferInfo descriptorInfo;
-
-        [[nodiscard]] vku::MappedBuffer createBuffer(const fastgltf::Asset &asset, vma::Allocator allocator) {
-            // This is workaround for Clang 19's bug that ranges::views::concat causes ambiguous spaceship operator error.
-            // TODO: change it to use ranges::views::concat when available.
-            std::vector<std::span<const float>> weights;
-            weights.reserve(asset.nodes.size() + 1);
-
-            weights.append_range(asset.nodes | std::views::transform([&](const fastgltf::Node &node) {
-                std::span<const float> weights = node.weights;
-                if (node.meshIndex) {
-                    const fastgltf::Mesh &mesh = asset.meshes[*node.meshIndex];
-                    weights = mesh.weights;
-                }
-                return weights;
-            }));
-            // A dummy NaN-valued weight for preventing the zero-sized buffer creation.
-            // This will not affect to the actual weight indexing.
-            constexpr float dummyWeight = std::numeric_limits<float>::quiet_NaN();
-            weights.emplace_back(&dummyWeight, 1);
-
-            auto [buffer, copyOffsets] = createCombinedBuffer(allocator, weights, vk::BufferUsageFlagBits::eStorageBuffer);
-            startOffsets = { std::from_range, copyOffsets };
-
-            return std::move(buffer);
-        }
+        std::shared_ptr<const gltf::ds::TargetWeightCountExclusiveScan> targetWeightCountExclusiveScan;
     };
 }


### PR DESCRIPTION
This PR implemented glTF animation, which updatesthe transformation or target weights of arbitrary nodes as the time progress.

Some Vulkan resource ownership between `SharedData` and `Frame`. In details,

- Since animation changes transform matrices and target weights every frame, they should not be inside `SharedData` (as modifying them will stall the another frame). Instead, they are moved into each `Frame` and only currently active frame data is modified. The modification task for the another frame (which is still running in GPU) is deferred, by stored in `deferredFrameUpdateTasks` inside the running loop. The next frame will iterate over the vector (therefore can guarantee its modification order) and update the GPU resource.
- As a result, changing node transformation and target weights also being non-stalling actions.

Some animation implementation strategy should be improved, especially,

- Currently it finds the corresponding input accessor indices by time using binary search, which is O(log n), and finds the output accessor values using `fastgltf::getAccessorElement` which is also O(log n). However, animation is done in the forward direction as the time progresses, we can cache the accessor iterator and advance them when the time meets the next value of the input accessor. Due to the implementation complexity, this is not implemented, but it could be a huge win  if there are many animations and large input/output accessor data.
- Animation time is retrieved using `glfwGetTime()`, and animation is looped by calculating the modulo of the time by each input accessor's maximum value. Therefore, when user clicks the animation checkbox, the animation will not be started from the initial value, which is unlikely to be expected.
  - This hack is from [spnda/vk_gltf_viewer](https://github.com/spnda/vk_gltf_viewer/commit/610a25034d408a18865aa05fe223aeeb754b5c06) and most code is copied from it.

Currently GUI only can toggle the animation on/off, which could also be improved.