### PR TITLE
Implemented vertex skinning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/gltf/algorithm/misc.cppm
         interface/gltf/algorithm/traversal.cppm
         interface/gltf/Animation.cppm
+        interface/gltf/data_structure/SkinJointCountExclusiveScan.cppm
         interface/gltf/data_structure/NodeInstanceCountExclusiveScanWithCount.cppm
         interface/gltf/data_structure/TargetWeightCountExclusiveScan.cppm
         interface/gltf/AssetExternalBuffers.cppm
@@ -177,11 +178,13 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/buffer/CubeIndices.cppm
         interface/vulkan/buffer/IndirectDrawCommands.cppm
         interface/vulkan/buffer/InstancedNodeWorldTransforms.cppm
+        interface/vulkan/buffer/InverseBindMatrices.cppm
         interface/vulkan/buffer/Materials.cppm
         interface/vulkan/buffer/MorphTargetWeights.cppm
         interface/vulkan/buffer/Nodes.cppm
         interface/vulkan/buffer/PrimitiveAttributes.cppm
         interface/vulkan/buffer/Primitives.cppm
+        interface/vulkan/buffer/SkinJointIndices.cppm
         interface/vulkan/buffer/StagingBufferStorage.cppm
         interface/vulkan/descriptor_set_layout/Asset.cppm
         interface/vulkan/descriptor_set_layout/ImageBasedLighting.cppm

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Blazingly fast[^1] Vulkan glTF viewer.
   - Runtime missing per-face normal and tangent attribute generation for non-indexed geometry.
   - `OPAQUE`, `MASK` (using alpha testing and Alpha To Coverage) and `BLEND` (using Weighted Blended OIT) materials.
   - Normalized and sparse accessors.
+  - Infinite morph targets and skinning attributes.
   - Multiple scenes.
   - Binary format (`.glb`).
 - Support glTF 2.0 extensions:
@@ -34,7 +35,6 @@ Blazingly fast[^1] Vulkan glTF viewer.
 Followings are not supported:
 
 - Primitive Type except for `TRIANGLES`.
-- Skinning.
 
 ## Performance
 
@@ -315,12 +315,12 @@ All shaders are located in the [shaders](/shaders) folder and will be automatica
 - [x] Basis Universal texture support (`KHR_texture_basisu`).
 - [x] Automatic camera position adjustment based on the bounding sphere calculation.
 - [x] Animations.
+- [x] Skinning
 - [ ] Frustum culling
   - [x] CPU frustum culling (Note: still experimental; unexpected popped in/out may happened.)
   - [ ] GPU frustum culling
 - [ ] Occlusion culling
 - [ ] Reduce skybox memory usage with BC6H compressed cubemap.
-- [ ] Skinning
 
 ## License
 

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -156,6 +156,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         return std::pair { info.componentCount, info.componentType };
                     }),
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
+                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
                     .baseColorTextureTransform = material.pbrData.baseColorTexture
                         .transform(fetchTextureTransform)
                         .value_or(shader_type::TextureTransform::None),
@@ -189,6 +190,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                     .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
                     .hasNormalMorphTarget = !accessors.normalMorphTargetAccessors.empty(),
                     .hasTangentMorphTarget = !accessors.tangentMorphTargetAccessors.empty(),
+                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
                     .baseColorTextureTransform = material.pbrData.baseColorTexture
                         .transform(fetchTextureTransform)
                         .value_or(shader_type::TextureTransform::None),
@@ -236,6 +238,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                 .hasPositionMorphTarget = !accessors.positionMorphTargetAccessors.empty(),
                 .hasNormalMorphTarget = !accessors.normalMorphTargetAccessors.empty(),
                 .hasTangentMorphTarget = !accessors.tangentMorphTargetAccessors.empty(),
+                .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
             });
         }
         return result;
@@ -263,6 +266,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         return value_if(info.componentCount == 4, info.componentType);
                     }),
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
+                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
                     .baseColorTextureTransform = material.pbrData.baseColorTexture
                         .transform(fetchTextureTransform)
                         .value_or(shader_type::TextureTransform::None),
@@ -272,6 +276,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                 result.pipeline = sharedData.getDepthRenderer({
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
+                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
                 });
             }
             result.cullMode = material.doubleSided ? vk::CullModeFlagBits::eNone : vk::CullModeFlagBits::eBack;
@@ -280,6 +285,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
             result.pipeline = sharedData.getDepthRenderer({
                 .positionComponentType = accessors.positionAccessor.componentType,
                 .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
+                .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
             });
         }
         return result;
@@ -307,6 +313,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                         return value_if(info.componentCount == 4, info.componentType);
                     }),
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
+                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
                     .baseColorTextureTransform = material.pbrData.baseColorTexture
                         .transform(fetchTextureTransform)
                         .value_or(shader_type::TextureTransform::None),
@@ -316,6 +323,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
                 result.pipeline = sharedData.getJumpFloodSeedRenderer({
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
+                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
                 });
             }
             result.cullMode = material.doubleSided ? vk::CullModeFlagBits::eNone : vk::CullModeFlagBits::eBack;
@@ -324,6 +332,7 @@ auto vk_gltf_viewer::vulkan::Frame::update(const ExecutionTask &task) -> UpdateR
             result.pipeline = sharedData.getJumpFloodSeedRenderer({
                 .positionComponentType = accessors.positionAccessor.componentType,
                 .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
+                .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
             });
         }
         return result;

--- a/interface/gltf/data_structure/NodeInstanceCountExclusiveScanWithCount.cppm
+++ b/interface/gltf/data_structure/NodeInstanceCountExclusiveScanWithCount.cppm
@@ -11,9 +11,6 @@ namespace vk_gltf_viewer::gltf::ds {
     export struct NodeInstanceCountExclusiveScanWithCount final : std::vector<std::uint32_t> {
         explicit NodeInstanceCountExclusiveScanWithCount(const fastgltf::Asset &asset)
             : vector { exclusive_scan_with_count(asset.nodes | std::views::transform([&](const fastgltf::Node &node) -> std::uint32_t {
-                if (!node.meshIndex) {
-                    return 0;
-                }
                 if (node.instancingAttributes.empty()) {
                     return 1;
                 }

--- a/interface/gltf/data_structure/SkinJointCountExclusiveScan.cppm
+++ b/interface/gltf/data_structure/SkinJointCountExclusiveScan.cppm
@@ -1,0 +1,17 @@
+export module vk_gltf_viewer:gltf.data_structure.SkinJointCountExclusiveScan;
+
+import std;
+export import fastgltf;
+import :helpers.algorithm;
+
+namespace vk_gltf_viewer::gltf::ds {
+    /**
+     * @brief Exclusive scan of skin joints count in an asset.
+     */
+    export struct SkinJointCountExclusiveScan final : std::vector<std::uint32_t> {
+        explicit SkinJointCountExclusiveScan(const fastgltf::Asset &asset)
+            : vector { exclusive_scan(asset.skins | std::views::transform([](const fastgltf::Skin &skin) -> std::uint32_t {
+                return skin.joints.size();
+            })) } { }
+    };
+}

--- a/interface/vulkan/Frame.cppm
+++ b/interface/vulkan/Frame.cppm
@@ -228,8 +228,10 @@ namespace vk_gltf_viewer::vulkan {
                 assetDescriptorSet.getWrite<1>(sharedData.gltfAsset->nodeBuffer.getDescriptorInfo()),
                 assetDescriptorSet.getWrite<2>(inner.instancedNodeWorldTransformBuffer.getDescriptorInfo()),
                 assetDescriptorSet.getWrite<3>(inner.morphTargetWeightBuffer.getDescriptorInfo()),
-                assetDescriptorSet.getWrite<4>(sharedData.gltfAsset->materialBuffer.getDescriptorInfo()),
-                assetDescriptorSet.getWrite<5>(imageInfos),
+                assetDescriptorSet.getWrite<4>(sharedData.gltfAsset->skinJointIndices.getDescriptorInfo()),
+                assetDescriptorSet.getWrite<5>(sharedData.gltfAsset->inverseBindMatrixBuffer.getDescriptorInfo()),
+                assetDescriptorSet.getWrite<6>(sharedData.gltfAsset->materialBuffer.getDescriptorInfo()),
+                assetDescriptorSet.getWrite<7>(imageInfos),
             }, {});
         }
 

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -16,10 +16,12 @@ import :helpers.fastgltf;
 import :helpers.ranges;
 export import :vulkan.ag.Swapchain;
 import :vulkan.buffer.CombinedIndices;
+import :vulkan.buffer.InverseBindMatrices;
 import :vulkan.buffer.Materials;
 import :vulkan.buffer.Nodes;
 import :vulkan.buffer.PrimitiveAttributes;
 import :vulkan.buffer.Primitives;
+import :vulkan.buffer.SkinJointIndices;
 import :vulkan.buffer.StagingBufferStorage;
 export import :vulkan.Gpu;
 export import :vulkan.pipeline.DepthRenderer;
@@ -47,6 +49,8 @@ namespace vk_gltf_viewer::vulkan {
             buffer::CombinedIndices combinedIndexBuffers;
             buffer::PrimitiveAttributes primitiveAttributes;
             buffer::Primitives primitiveBuffer;
+            buffer::SkinJointIndices skinJointIndices;
+            buffer::InverseBindMatrices inverseBindMatrixBuffer;
             texture::Textures textures;
 
             template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
@@ -66,6 +70,8 @@ namespace vk_gltf_viewer::vulkan {
                 combinedIndexBuffers { asset, gpu, stagingBufferStorage, adapter },
                 primitiveAttributes { asset, gpu, stagingBufferStorage, threadPool, adapter },
                 primitiveBuffer { materialBuffer, orderedPrimitives, primitiveAttributes, gpu, stagingBufferStorage },
+                skinJointIndices { asset, gpu.allocator },
+                inverseBindMatrixBuffer { asset, gpu.allocator, adapter },
                 textures { asset, directory, gpu, fallbackTexture, threadPool, adapter } {
                 if (stagingBufferStorage.hasStagingCommands()) {
                     const vk::raii::CommandPool transferCommandPool { gpu.device, vk::CommandPoolCreateInfo { {}, gpu.queueFamilies.transfer } };

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -242,7 +242,7 @@ namespace vk_gltf_viewer::vulkan {
             }
 
             gltfAsset.emplace(asset, directory, orderedPrimitives, gpu, fallbackTexture, adapter);
-            if (!gpu.supportVariableDescriptorCount && assetDescriptorSetLayout.descriptorCounts[5] != textureCount) {
+            if (!gpu.supportVariableDescriptorCount && assetDescriptorSetLayout.descriptorCounts[7] != textureCount) {
                 // If texture count is different, descriptor set layouts, pipeline layouts and pipelines have to be recreated.
                 depthPipelines.clear();
                 maskDepthPipelines.clear();

--- a/interface/vulkan/buffer/InverseBindMatrices.cppm
+++ b/interface/vulkan/buffer/InverseBindMatrices.cppm
@@ -1,0 +1,79 @@
+export module vk_gltf_viewer:vulkan.buffer.InverseBindMatrices;
+
+import std;
+export import fastgltf;
+import glm; // TODO: use fastgltf::math::fmat4x4 when it gets being trivially copyable.
+export import vk_mem_alloc_hpp;
+import :helpers.fastgltf;
+import :vulkan.buffer;
+
+template <typename T, typename U>
+[[nodiscard]] std::span<T> reinterpret_span(std::span<U> span) {
+    if (span.size_bytes() % sizeof(T) != 0) {
+        throw std::invalid_argument { "Span size mismatch: span of T does not fully fit into the current span." };
+    }
+
+    return { reinterpret_cast<T*>(span.data()), span.size_bytes() / sizeof(T) };
+}
+
+namespace vk_gltf_viewer::vulkan::buffer {
+    export class InverseBindMatrices {
+    public:
+        template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
+        InverseBindMatrices(
+            const fastgltf::Asset &asset,
+            vma::Allocator allocator,
+            const BufferDataAdapter &adapter = {}
+        ) : buffer { [&]() {
+                // When a skin's inverseBindMatrices is not defined, identity matrices must be used. It first calculates
+                // the maximum number of skin joints count (=largestContinuousIdentityMatrixCount), and allocate
+                // contiguous identity matrices of size largestContinuousIdentityMatrixCount. Then, each skin's
+                // inverseBindMatrices can use the subspan of the contiguous identity matrices.
+                std::size_t largestContinuousIdentityMatrixCount = 0;
+                for (const fastgltf::Skin &skin : asset.skins) {
+                    if (!skin.inverseBindMatrices && skin.joints.size() > largestContinuousIdentityMatrixCount) {
+                        largestContinuousIdentityMatrixCount = skin.joints.size();
+                    }
+                }
+                const std::vector contiguousIdentityMatrices(largestContinuousIdentityMatrixCount, glm::identity<glm::mat4>());
+
+                std::vector<std::vector<fastgltf::math::fmat4x4>> sparseAccessorData;
+                std::vector<std::span<const glm::mat4>> matrices;
+                for (const fastgltf::Skin &skin : asset.skins) {
+                    if (skin.inverseBindMatrices) {
+                        const fastgltf::Accessor &accessor = asset.accessors[*skin.inverseBindMatrices];
+                        if (accessor.sparse) {
+                            std::vector<fastgltf::math::fmat4x4> &v = sparseAccessorData.emplace_back(accessor.count);
+                            fastgltf::copyFromAccessor<fastgltf::math::fmat4x4>(asset, accessor, v.data(), adapter);
+                            matrices.push_back(reinterpret_span<const glm::mat4>(std::span { v }));
+                        }
+                        else {
+                            matrices.push_back(reinterpret_span<const glm::mat4>(fastgltf::getByteRegion(asset, accessor, adapter)));
+                        }
+                    }
+                    else {
+                        matrices.push_back(contiguousIdentityMatrices);
+                    }
+
+                    // Only first N (=# of joints in a skin) matrices are used.
+                    matrices.back() = matrices.back().subspan(0, skin.joints.size());
+                }
+
+                // A dummy identity matrix for preventing the zero-sized buffer creation.
+                // This will not be actually indexed.
+                constexpr glm::mat4 dummyMatrix{};
+                matrices.emplace_back(&dummyMatrix, 1);
+
+                return createCombinedBuffer(allocator, matrices, vk::BufferUsageFlagBits::eStorageBuffer).first;
+            }() },
+            descriptorInfo { buffer, 0, vk::WholeSize } { }
+
+        [[nodiscard]] const vk::DescriptorBufferInfo &getDescriptorInfo() const noexcept {
+            return descriptorInfo;
+        }
+
+    private:
+        vku::MappedBuffer buffer;
+        vk::DescriptorBufferInfo descriptorInfo;
+    };
+}

--- a/interface/vulkan/buffer/Nodes.cppm
+++ b/interface/vulkan/buffer/Nodes.cppm
@@ -10,6 +10,7 @@ import :helpers.fastgltf;
 import :helpers.ranges;
 export import :gltf.data_structure.NodeInstanceCountExclusiveScanWithCount;
 export import :gltf.data_structure.TargetWeightCountExclusiveScan;
+import :gltf.data_structure.SkinJointCountExclusiveScan;
 export import :vulkan.buffer.StagingBufferStorage;
 import :vulkan.shader_type.Node;
 import :vulkan.trait.PostTransferObject;
@@ -25,12 +26,17 @@ namespace vk_gltf_viewer::vulkan::buffer {
             StagingBufferStorage &stagingBufferStorage
         ) : PostTransferObject { stagingBufferStorage },
             buffer { [&]() {
+                const gltf::ds::SkinJointCountExclusiveScan skinJointCountExclusiveScan { asset };
                 vku::AllocatedBuffer result = vku::MappedBuffer {
                     allocator,
                     std::from_range, ranges::views::upto(asset.nodes.size()) | std::views::transform([&](std::size_t nodeIndex) {
+                        const fastgltf::Node &node = asset.nodes[nodeIndex];
                         return shader_type::Node {
                             .instancedTransformStartIndex = nodeInstanceCountExclusiveScan[nodeIndex],
                             .morphTargetWeightStartIndex = targetWeightCountExclusiveScan[nodeIndex],
+                            .skinJointIndexStartIndex = to_optional(node.skinIndex).transform([&](std::size_t skinIndex) {
+                                return skinJointCountExclusiveScan[skinIndex];
+                            }).value_or(std::numeric_limits<std::uint32_t>::max()),
                         };
                     }),
                     vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc,

--- a/interface/vulkan/buffer/Primitives.cppm
+++ b/interface/vulkan/buffer/Primitives.cppm
@@ -84,6 +84,8 @@ namespace vk_gltf_viewer::vulkan::buffer {
                     shader_type::Primitive result {
                         .pPositionBuffer = accessors.positionAccessor.bufferAddress,
                         .pTexcoordAttributeMappingInfoBuffer = accessors.texcoordAccessorBufferAddress,
+                        .pJointsAttributeMappingInfoBuffer = accessors.jointsAccessorBufferAddress,
+                        .pWeightsAttributeMappingInfoBuffer = accessors.weightsAccessorBufferAddress,
                         .positionByteStride = accessors.positionAccessor.byteStride,
                         .materialIndex = to_optional(pPrimitive->materialIndex).transform(LIFT(materialBuffer.get().padMaterialIndex)).value_or(0U),
                     };

--- a/interface/vulkan/buffer/SkinJointIndices.cppm
+++ b/interface/vulkan/buffer/SkinJointIndices.cppm
@@ -1,0 +1,38 @@
+export module vk_gltf_viewer:vulkan.buffer.SkinJointIndices;
+
+import std;
+export import fastgltf;
+export import vk_mem_alloc_hpp;
+import :vulkan.buffer;
+
+namespace vk_gltf_viewer::vulkan::buffer {
+    export class SkinJointIndices {
+    public:
+        SkinJointIndices(
+            const fastgltf::Asset &asset,
+            vma::Allocator allocator
+        ) : buffer { [&]() {
+                std::vector<std::vector<std::uint32_t>> jointIndices;
+                jointIndices.reserve(std::max<std::size_t>(asset.skins.size(), 1));
+                for (const fastgltf::Skin &skin : asset.skins) {
+                    jointIndices.emplace_back(std::from_range, skin.joints);
+                }
+
+                // Avoid zero-sized buffer
+                if (jointIndices.empty()) {
+                    jointIndices.push_back(std::vector { std::numeric_limits<std::uint32_t>::max() });
+                }
+
+                return createCombinedBuffer(allocator, jointIndices, vk::BufferUsageFlagBits::eStorageBuffer).first;
+            }() },
+            descriptorInfo { buffer, 0, vk::WholeSize } { }
+
+        [[nodiscard]] const vk::DescriptorBufferInfo &getDescriptorInfo() const noexcept {
+            return descriptorInfo;
+        }
+
+    private:
+        vku::MappedBuffer buffer;
+        vk::DescriptorBufferInfo descriptorInfo;
+    };
+}

--- a/interface/vulkan/descriptor_set_layout/Asset.cppm
+++ b/interface/vulkan/descriptor_set_layout/Asset.cppm
@@ -8,7 +8,7 @@ import std;
 export import :vulkan.Gpu;
 
 namespace vk_gltf_viewer::vulkan::dsl {
-    export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
+    export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
         explicit Asset(const Gpu &gpu LIFETIMEBOUND)
             : DescriptorSetLayout { gpu.device, vk::StructureChain {
                 vk::DescriptorSetLayoutCreateInfo {
@@ -18,11 +18,15 @@ namespace vk_gltf_viewer::vulkan::dsl {
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
+                        { 1, vk::ShaderStageFlagBits::eVertex },
+                        { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment },
                         { maxTextureCount(gpu), vk::ShaderStageFlagBits::eFragment })),
                 },
                 vk::DescriptorSetLayoutBindingFlagsCreateInfo {
                     vku::unsafeProxy<vk::DescriptorBindingFlags>({
+                        {},
+                        {},
                         {},
                         {},
                         {},
@@ -42,11 +46,15 @@ namespace vk_gltf_viewer::vulkan::dsl {
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
+                        { 1, vk::ShaderStageFlagBits::eVertex },
+                        { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment },
                         { textureCount, vk::ShaderStageFlagBits::eFragment })),
                 },
                 vk::DescriptorSetLayoutBindingFlagsCreateInfo {
                     vku::unsafeProxy<vk::DescriptorBindingFlags>({
+                        {},
+                        {},
                         {},
                         {},
                         {},

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -18,6 +18,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         std::uint8_t positionComponentType = 0;
         std::uint32_t positionMorphTargetWeightCount = 0;
+        std::uint32_t skinAttributeCount = 0;
 
         [[nodiscard]] bool operator==(const DepthRendererSpecialization&) const = default;
 
@@ -63,10 +64,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         struct VertexShaderSpecializationData {
             std::uint32_t positionComponentType;
             std::uint32_t positionMorphTargetWeightCount;
+            std::uint32_t skinAttributeCount;
         };
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            return { positionComponentType, positionMorphTargetWeightCount };
+            return { positionComponentType, positionMorphTargetWeightCount, skinAttributeCount };
         }
     };
 
@@ -76,6 +78,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
         std::uint32_t positionMorphTargetWeightCount = 0;
+        std::uint32_t skinAttributeCount = 0;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
 
         [[nodiscard]] bool operator==(const MaskDepthRendererSpecialization&) const = default;
@@ -131,6 +134,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentType = 5126; // FLOAT
             std::uint32_t positionMorphTargetWeightCount;
+            std::uint32_t skinAttributeCount;
         };
 
         struct FragmentShaderSpecializationData {
@@ -148,6 +152,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             VertexShaderSpecializationData result {
                 .positionComponentType = positionComponentType,
                 .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
+                .skinAttributeCount = skinAttributeCount,
             };
 
             if (baseColorTexcoordComponentType) {

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -18,6 +18,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     public:
         std::uint8_t positionComponentType = 0;
         std::uint32_t positionMorphTargetWeightCount = 0;
+        std::uint32_t skinAttributeCount = 0;
 
         [[nodiscard]] bool operator==(const JumpFloodSeedRendererSpecialization&) const = default;
 
@@ -63,10 +64,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         struct VertexShaderSpecializationData {
             std::uint32_t positionComponentType;
             std::uint32_t positionMorphTargetWeightCount;
+            std::uint32_t skinAttributeCount;
         };
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            return { positionComponentType, positionMorphTargetWeightCount };
+            return { positionComponentType, positionMorphTargetWeightCount, skinAttributeCount };
         }
     };
 
@@ -76,6 +78,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
         std::uint32_t positionMorphTargetWeightCount = 0;
+        std::uint32_t skinAttributeCount = 0;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
 
         [[nodiscard]] bool operator==(const MaskJumpFloodSeedRendererSpecialization&) const = default;
@@ -131,6 +134,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             std::uint32_t texcoordComponentType = 5126; // FLOAT
             std::uint32_t colorComponentType = 5126; // FLOAT
             std::uint32_t positionMorphTargetWeightCount;
+            std::uint32_t skinAttributeCount;
         };
 
         struct FragmentShaderSpecializationData {
@@ -148,6 +152,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             VertexShaderSpecializationData result {
                 .positionComponentType = positionComponentType,
                 .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
+                .skinAttributeCount = skinAttributeCount,
             };
 
             if (baseColorTexcoordComponentType) {

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -34,6 +34,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         bool hasPositionMorphTarget = false;
         bool hasNormalMorphTarget = false;
         bool hasTangentMorphTarget = false;
+        std::uint32_t skinAttributeCount = 0;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
         shader_type::TextureTransform metallicRoughnessTextureTransform = shader_type::TextureTransform::None;
         shader_type::TextureTransform normalTextureTransform = shader_type::TextureTransform::None;
@@ -165,6 +166,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             std::uint32_t colorComponentCount;
             std::uint32_t morphTargetWeightCount;
             std::uint32_t packedMorphTargetAvailability;
+            std::uint32_t skinAttributeCount;
         };
 
         struct FragmentShaderSpecializationData {
@@ -185,6 +187,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 .packedMorphTargetAvailability = (hasPositionMorphTarget ? 1U : 0U)
                                                | (hasNormalMorphTarget ? 2U : 0U)
                                                | (hasTangentMorphTarget ? 4U : 0U),
+                .skinAttributeCount = skinAttributeCount,
             };
 
             // Packed components types are:

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -25,6 +25,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::pair<std::uint8_t, std::uint8_t>> colorComponentCountAndType;
         std::uint32_t positionMorphTargetWeightCount = 0;
+        std::uint32_t skinAttributeCount = 0;
         shader_type::TextureTransform baseColorTextureTransform = shader_type::TextureTransform::None;
         fastgltf::AlphaMode alphaMode;
 
@@ -153,6 +154,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             std::uint32_t colorComponentCount = 0;
             std::uint32_t colorComponentType = 5126; // FLOAT
             std::uint32_t positionMorphTargetWeightCount;
+            std::uint32_t skinAttributeCount;
         };
 
         struct FragmentShaderSpecializationData {
@@ -170,6 +172,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
             VertexShaderSpecializationData result {
                 .positionComponentType = positionComponentType,
                 .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
+                .skinAttributeCount = skinAttributeCount,
             };
 
             if (baseColorTexcoordComponentType) {

--- a/interface/vulkan/shader_type/Node.cppm
+++ b/interface/vulkan/shader_type/Node.cppm
@@ -10,9 +10,12 @@ namespace vk_gltf_viewer::vulkan::shader_type {
     export struct Node {
         std::uint32_t instancedTransformStartIndex;
         std::uint32_t morphTargetWeightStartIndex;
+        std::uint32_t skinJointIndexStartIndex;
+        std::uint32_t _padding_;
     };
 
-    static_assert(sizeof(Node) == 8);
+    static_assert(sizeof(Node) == 16);
     static_assert(offsetof(Node, instancedTransformStartIndex) == 0);
     static_assert(offsetof(Node, morphTargetWeightStartIndex) == 4);
+    static_assert(offsetof(Node, skinJointIndexStartIndex) == 8);
 }

--- a/interface/vulkan/shader_type/Primitive.cppm
+++ b/interface/vulkan/shader_type/Primitive.cppm
@@ -15,8 +15,10 @@ namespace vk_gltf_viewer::vulkan::shader_type {
         vk::DeviceAddress pNormalMorphTargetAccessorBuffer;
         vk::DeviceAddress pTangentBuffer;
         vk::DeviceAddress pTangentMorphTargetAccessorBuffer;
-        vk::DeviceAddress pTexcoordAttributeMappingInfoBuffer;
         vk::DeviceAddress pColorBuffer;
+        vk::DeviceAddress pTexcoordAttributeMappingInfoBuffer;
+        vk::DeviceAddress pJointsAttributeMappingInfoBuffer;
+        vk::DeviceAddress pWeightsAttributeMappingInfoBuffer;
         std::uint8_t positionByteStride;
         std::uint8_t normalByteStride;
         std::uint8_t tangentByteStride;
@@ -25,7 +27,7 @@ namespace vk_gltf_viewer::vulkan::shader_type {
         std::uint8_t _padding0_[8];
     };
 
-    static_assert(sizeof(Primitive) == 80);
-    static_assert(offsetof(Primitive, positionByteStride) == 64);
-    static_assert(offsetof(Primitive, materialIndex) == 68);
+    static_assert(sizeof(Primitive) == 96);
+    static_assert(offsetof(Primitive, positionByteStride) == 80);
+    static_assert(offsetof(Primitive, materialIndex) == 84);
 }

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -29,16 +29,23 @@ layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
 layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
+layout (set = 0, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+    uint skinJointIndices[];
+};
+layout (set = 0, binding = 5) readonly buffer InverseBindMatrixBuffer {
+    mat4 inverseBindMatrices[];
+};
 
 layout (push_constant) uniform PushConstant {
     mat4 projectionView;
 } pc;
 
 #include "vertex_pulling.glsl"
+#include "transform.glsl"
 
 void main(){
     outNodeIndex = NODE_INDEX;
 
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
-    gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
 }

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -14,6 +14,7 @@
 
 layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
 layout (constant_id = 1) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 2) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) flat out uint outNodeIndex;
 
@@ -47,5 +48,5 @@ void main(){
     outNodeIndex = NODE_INDEX;
 
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
-    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
 }

--- a/shaders/indexing.glsl
+++ b/shaders/indexing.glsl
@@ -8,8 +8,6 @@
 #define PRIMITIVE primitives[PRIMITIVE_INDEX]
 #define NODE_INDEX gl_BaseInstance >> 16U
 #define NODE nodes[NODE_INDEX]
-#define INSTANCE_INDEX gl_InstanceIndex - gl_BaseInstance
-#define TRANSFORM instancedTransforms[NODE.instancedTransformStartIndex + INSTANCE_INDEX]
 #define MATERIAL_INDEX PRIMITIVE.materialIndex
 #define MATERIAL materials[MATERIAL_INDEX]
 

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -14,6 +14,7 @@
 
 layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
 layout (constant_id = 1) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 2) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
@@ -43,5 +44,5 @@ layout (push_constant) uniform PushConstant {
 
 void main(){
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
-    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
 }

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -27,14 +27,21 @@ layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
 layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
+layout (set = 0, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+    uint skinJointIndices[];
+};
+layout (set = 0, binding = 5) readonly buffer InverseBindMatrixBuffer {
+    mat4 inverseBindMatrices[];
+};
 
 layout (push_constant) uniform PushConstant {
     mat4 projectionView;
 } pc;
 
 #include "vertex_pulling.glsl"
+#include "transform.glsl"
 
 void main(){
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
-    gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_depth.frag
+++ b/shaders/mask_depth.frag
@@ -27,10 +27,10 @@ layout (location = 2) in FRAG_VARIADIC_IN {
 
 layout (location = 0) out uint outNodeIndex;
 
-layout (set = 0, binding = 4, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 6, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 0, binding = 5) uniform sampler2D textures[];
+layout (set = 0, binding = 7) uniform sampler2D textures[];
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -18,6 +18,7 @@ layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
 layout (constant_id = 1) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 3) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 4) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) flat out uint outNodeIndex;
 layout (location = 1) flat out uint outMaterialIndex;
@@ -72,5 +73,5 @@ void main(){
 #endif
 
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
-    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -44,7 +44,13 @@ layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
 layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 0, binding = 4, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+    uint skinJointIndices[];
+};
+layout (set = 0, binding = 5) readonly buffer InverseBindMatrixBuffer {
+    mat4 inverseBindMatrices[];
+};
+layout (set = 0, binding = 6, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 
@@ -53,6 +59,7 @@ layout (push_constant) uniform PushConstant {
 } pc;
 
 #include "vertex_pulling.glsl"
+#include "transform.glsl"
 
 void main(){
     outNodeIndex = NODE_INDEX;
@@ -65,5 +72,5 @@ void main(){
 #endif
 
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
-    gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -26,10 +26,10 @@ layout (location = 1) in FRAG_VARIDIC_IN {
 
 layout (location = 0) out uvec2 outCoordinate;
 
-layout (set = 0, binding = 4, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 6, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 0, binding = 5) uniform sampler2D textures[];
+layout (set = 0, binding = 7) uniform sampler2D textures[];
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -18,6 +18,7 @@ layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
 layout (constant_id = 1) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 3) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 4) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -70,5 +71,5 @@ void main(){
 #endif
 
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
-    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
 }

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -43,7 +43,13 @@ layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
 layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 0, binding = 4, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+    uint skinJointIndices[];
+};
+layout (set = 0, binding = 5) readonly buffer InverseBindMatrixBuffer {
+    mat4 inverseBindMatrices[];
+};
+layout (set = 0, binding = 6, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 
@@ -52,6 +58,7 @@ layout (push_constant, std430) uniform PushConstant {
 } pc;
 
 #include "vertex_pulling.glsl"
+#include "transform.glsl"
 
 void main(){
     outMaterialIndex = MATERIAL_INDEX;
@@ -63,5 +70,5 @@ void main(){
 #endif
 
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
-    gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
 }

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -55,10 +55,10 @@ layout (set = 0, binding = 0, scalar) uniform SphericalHarmonicsBuffer {
 layout (set = 0, binding = 1) uniform samplerCube prefilteredmap;
 layout (set = 0, binding = 2) uniform sampler2D brdfmap;
 
-layout (set = 1, binding = 4, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 6, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 1, binding = 5) uniform sampler2D textures[];
+layout (set = 1, binding = 7) uniform sampler2D textures[];
 
 layout (push_constant, std430) uniform PushConstant {
     mat4 projectionView;

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -18,6 +18,7 @@ layout (constant_id = 0) const uint PACKED_ATTRIBUTE_COMPONENT_TYPES = 0;
 layout (constant_id = 1) const uint COLOR_COMPONENT_COUNT = 0;
 layout (constant_id = 2) const uint MORPH_TARGET_WEIGHT_COUNT = 0;
 layout (constant_id = 3) const uint PACKED_MORPH_TARGET_AVAILABILITY = 0;
+layout (constant_id = 4) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) out vec3 outPosition;
 layout (location = 1) flat out uint outMaterialIndex;
@@ -76,7 +77,7 @@ layout (push_constant, std430) uniform PushConstant {
 #include "transform.glsl"
 
 void main(){
-    mat4 transform = getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U);
+    mat4 transform = getTransform(SKIN_ATTRIBUTE_COUNT);
 
     vec3 inPosition = getPosition(PACKED_ATTRIBUTE_COMPONENT_TYPES & 0xFU, (PACKED_MORPH_TARGET_AVAILABILITY & 0x1U) == 0x1U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
     outPosition = (transform * vec4(inPosition, 1.0)).xyz;

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -57,7 +57,13 @@ layout (set = 1, binding = 2) readonly buffer InstancedTransformBuffer {
 layout (set = 1, binding = 3) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 1, binding = 4, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+    uint skinJointIndices[];
+};
+layout (set = 1, binding = 5) readonly buffer InverseBindMatrixBuffer {
+    mat4 inverseBindMatrices[];
+};
+layout (set = 1, binding = 6, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 
@@ -67,20 +73,23 @@ layout (push_constant, std430) uniform PushConstant {
 } pc;
 
 #include "vertex_pulling.glsl"
+#include "transform.glsl"
 
 void main(){
+    mat4 transform = getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U);
+
     vec3 inPosition = getPosition(PACKED_ATTRIBUTE_COMPONENT_TYPES & 0xFU, (PACKED_MORPH_TARGET_AVAILABILITY & 0x1U) == 0x1U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
-    outPosition = (TRANSFORM * vec4(inPosition, 1.0)).xyz;
+    outPosition = (transform * vec4(inPosition, 1.0)).xyz;
 
     outMaterialIndex = MATERIAL_INDEX;
 
 #if !FRAGMENT_SHADER_GENERATED_TBN
     vec3 inNormal = getNormal((PACKED_ATTRIBUTE_COMPONENT_TYPES >> 4U) & 0xFU, (PACKED_MORPH_TARGET_AVAILABILITY & 0x2U) == 0x2U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
-    variadic_out.tbn[2] = normalize(mat3(TRANSFORM) * inNormal); // N
+    variadic_out.tbn[2] = normalize(mat3(transform) * inNormal); // N
 
     if (MATERIAL.normalTextureIndex != 0US){
         vec4 inTangent = getTangent((PACKED_ATTRIBUTE_COMPONENT_TYPES >> 8U) & 0xFU, (PACKED_MORPH_TARGET_AVAILABILITY & 0x4U) == 0x4U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
-        variadic_out.tbn[0] = normalize(mat3(TRANSFORM) * inTangent.xyz); // T
+        variadic_out.tbn[0] = normalize(mat3(transform) * inTangent.xyz); // T
         variadic_out.tbn[1] = cross(variadic_out.tbn[2], variadic_out.tbn[0]) * -inTangent.w; // B
     }
 #endif

--- a/shaders/transform.glsl
+++ b/shaders/transform.glsl
@@ -1,0 +1,28 @@
+#ifndef TRANSFORM_GLSL
+#define TRANSFORM_GLSL
+
+#include "vertex_pulling.glsl"
+
+#ifdef VERTEX_SHADER
+
+mat4 getTransform(uint skinAttributeCount) {
+    if (skinAttributeCount == 0U) {
+        return instancedTransforms[NODE.instancedTransformStartIndex + gl_InstanceIndex - gl_BaseInstance];
+    }
+    else {
+        mat4 skinMatrix = mat4(0.0);
+        for (uint i = 0; i < skinAttributeCount; ++i) {
+            uvec4 jointIndices = getJoints(i) + NODE.skinJointStartIndex;
+            vec4 weights = getWeights(i);
+            skinMatrix += weights.x * instancedTransforms[nodes[skinJointIndices[jointIndices.x]].instancedTransformStartIndex] * inverseBindMatrices[jointIndices.x]
+                        + weights.y * instancedTransforms[nodes[skinJointIndices[jointIndices.y]].instancedTransformStartIndex] * inverseBindMatrices[jointIndices.y]
+                        + weights.z * instancedTransforms[nodes[skinJointIndices[jointIndices.z]].instancedTransformStartIndex] * inverseBindMatrices[jointIndices.z]
+                        + weights.w * instancedTransforms[nodes[skinJointIndices[jointIndices.w]].instancedTransformStartIndex] * inverseBindMatrices[jointIndices.w];
+        }
+        return skinMatrix;
+    }
+}
+
+#endif
+
+#endif

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -37,6 +37,8 @@ struct Material {
 struct Node {
     uint instancedTransformStartIndex;
     uint morphTargetWeightStartIndex;
+    uint skinJointStartIndex;
+    uint _padding_;
 };
 
 struct Accessor {

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -60,8 +60,10 @@ struct Primitive {
     Accessors normalMorphTargetAccessors;
     uint64_t pTangentBuffer;
     Accessors tangentMorphTargetAccessors;
-    Accessors texcoordAccessors;
     uint64_t pColorBuffer;
+    Accessors texcoordAccessors;
+    Accessors jointsAccessors;
+    Accessors weightsAccessors;
     uint8_t positionByteStride;
     uint8_t normalByteStride;
     uint8_t tangentByteStride;

--- a/shaders/unlit_primitive.frag
+++ b/shaders/unlit_primitive.frag
@@ -30,10 +30,10 @@ layout (location = 0) out vec4 outColor;
 layout (location = 1) out float outRevealage;
 #endif
 
-layout (set = 1, binding = 4, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 6, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 1, binding = 5) uniform sampler2D textures[];
+layout (set = 1, binding = 7) uniform sampler2D textures[];
 
 #if ALPHA_MODE == 0 || ALPHA_MODE == 2
 layout (early_fragment_tests) in;

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -19,6 +19,7 @@ layout (constant_id = 1) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 2) const uint COLOR_COMPONENT_COUNT = 0;
 layout (constant_id = 3) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
 layout (constant_id = 4) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
+layout (constant_id = 5) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -75,5 +76,5 @@ void main(){
     variadic_out.color = getColor(COLOR_COMPONENT_TYPE);
 #endif
 
-    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
 }

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -45,7 +45,13 @@ layout (set = 1, binding = 2) readonly buffer InstancedTransformBuffer {
 layout (set = 1, binding = 3) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 1, binding = 4, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+    uint skinJointIndices[];
+};
+layout (set = 1, binding = 5) readonly buffer InverseBindMatrixBuffer {
+    mat4 inverseBindMatrices[];
+};
+layout (set = 1, binding = 6, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 
@@ -55,6 +61,7 @@ layout (push_constant, std430) uniform PushConstant {
 } pc;
 
 #include "vertex_pulling.glsl"
+#include "transform.glsl"
 
 void main(){
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
@@ -68,5 +75,5 @@ void main(){
     variadic_out.color = getColor(COLOR_COMPONENT_TYPE);
 #endif
 
-    gl_Position = pc.projectionView * TRANSFORM * vec4(inPosition, 1.0);
+    gl_Position = pc.projectionView * getTransform((NODE.skinJointStartIndex != 0xFFFFFFFFU) ? 1U : 0U) * vec4(inPosition, 1.0);
 }

--- a/shaders/vertex_pulling.glsl
+++ b/shaders/vertex_pulling.glsl
@@ -235,4 +235,32 @@ float getColorAlpha(uint componentType) {
 }
 #endif
 
+uvec4 getJoints(uint jointIndex){
+    Accessor jointsAccessor = PRIMITIVE.jointsAccessors.data[jointIndex];
+    uint64_t fetchAddress = getFetchAddress(jointsAccessor, gl_VertexIndex);
+
+    switch (uint(jointsAccessor.componentType)) {
+    case 1U: // UNSIGNED BYTE
+        return uvec4(U8Vec4Ref(fetchAddress).data);
+    case 3U: // UNSIGNED SHORT
+        return uvec4(U16Vec4Ref(fetchAddress).data);
+    }
+    return uvec4(0); // unreachable.
+}
+
+vec4 getWeights(uint weightIndex){
+    Accessor weightsAccessor = PRIMITIVE.weightsAccessors.data[weightIndex];
+    uint64_t fetchAddress = getFetchAddress(weightsAccessor, gl_VertexIndex);
+
+    switch (uint(weightsAccessor.componentType)) {
+    case 6U: // FLOAT
+        return Vec4Ref(fetchAddress).data;
+    case 9U: // UNSIGNED BYTE normalized
+        return dequantize(U8Vec4Ref(fetchAddress).data);
+    case 11U: // UNSIGNED SHORT normalized
+        return dequantize(U16Vec4Ref(fetchAddress).data);
+    }
+    return vec4(0.0); // unreachable.
+}
+
 #endif // VERTEX_PULLING_GLSL


### PR DESCRIPTION
- `InstancedNodeWorldTransforms` now contains world transform matrix of a node without mesh, as now the vertex shader requires need to reference it.
- It is assumed that joint node is not instanced, which is not in the specification. Need to be fixed.
- Arbitrary count of skinning attributes are supported.