### PR TITLE
Make some dependencies optional.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Configure
         run: |
-          vcpkg add port cgal
+          vcpkg add port cgal ktx
           mv .github/workflows/scripts/* .
           cmake --preset=${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Configure
         run: |
-          vcpkg add port cgal ktx
+          vcpkg add port cgal ktx openexr
           mv .github/workflows/scripts/* .
           cmake --preset=${{ matrix.os }}
 

--- a/.github/workflows/scripts/CMakeUserPresets.json
+++ b/.github/workflows/scripts/CMakeUserPresets.json
@@ -6,8 +6,7 @@
       "inherits": "default",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "/EHsc /wd5050",
-        "VCPKG_TARGET_TRIPLET": "x64-windows-release",
-        "EXACT_BOUNDING_VOLUME_USING_CGAL": "ON"
+        "VCPKG_TARGET_TRIPLET": "x64-windows-release"
       }
     },
     {
@@ -16,8 +15,7 @@
       "cacheVariables": {
         "CMAKE_C_COMPILER": "/opt/homebrew/opt/llvm/bin/clang",
         "CMAKE_CXX_COMPILER": "/opt/homebrew/opt/llvm/bin/clang++",
-        "VCPKG_TARGET_TRIPLET": "arm64-macos-clang-release",
-        "EXACT_BOUNDING_VOLUME_USING_CGAL": "ON"
+        "VCPKG_TARGET_TRIPLET": "arm64-macos-clang-release"
       }
     },
     {
@@ -28,8 +26,7 @@
         "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
         "CMAKE_CXX_FLAGS": "-stdlib=libc++ -Wno-deprecated-declarations",
         "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++ -lc++abi",
-        "VCPKG_TARGET_TRIPLET": "x64-linux-clang-release",
-        "EXACT_BOUNDING_VOLUME_USING_CGAL": "ON"
+        "VCPKG_TARGET_TRIPLET": "x64-linux-clang-release"
       },
       "environment": {
         "VCPKG_ROOT": "$env{VCPKG_INSTALLATION_ROOT}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ find_package(imgui CONFIG REQUIRED)
 find_package(imguizmo CONFIG REQUIRED)
 find_package(mikktspace CONFIG REQUIRED)
 find_package(nfd CONFIG REQUIRED)
-find_package(OpenEXR CONFIG REQUIRED)
 find_package(Stb REQUIRED)
 find_package(vku CONFIG REQUIRED)
 
@@ -34,6 +33,7 @@ find_package(vku CONFIG REQUIRED)
 
 find_package(CGAL CONFIG)
 find_package(Ktx CONFIG)
+find_package(OpenEXR CONFIG)
 
 # --------------------
 # Module configurations for the external dependencies.
@@ -237,7 +237,6 @@ target_link_libraries(vk-gltf-viewer PRIVATE
     imguizmo::imguizmo
     mikktspace::mikktspace
     nfd::nfd
-    OpenEXR::OpenEXR
     vku::vku
     vk-gltf-viewer::asset
 )
@@ -257,6 +256,13 @@ if (Ktx_FOUND)
     target_compile_definitions(vk-gltf-viewer PRIVATE SUPPORT_KHR_TEXTURE_BASISU)
 else()
     message(STATUS "KTX not found, KHR_texture_basisu extension will not be supported.")
+endif()
+
+if (OpenEXR_FOUND)
+    target_link_libraries(vk-gltf-viewer PRIVATE OpenEXR::OpenEXR)
+    target_compile_definitions(vk-gltf-viewer PRIVATE SUPPORT_EXR_SKYBOX)
+else()
+    message(STATUS "OpenEXR not found, loading EXR skybox will not be supported.")
 endif()
 
 if (APPLE AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,6 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_MODULE_STD 1)
 
 # --------------------
-# Build options.
-# --------------------
-
-option(EXACT_BOUNDING_VOLUME_USING_CGAL "Calculate bounding volume of the scene nodes with exact algorithm using CGAL.")
-
-# --------------------
 # External dependencies.
 # --------------------
 
@@ -35,9 +29,11 @@ find_package(OpenEXR CONFIG REQUIRED)
 find_package(Stb REQUIRED)
 find_package(vku CONFIG REQUIRED)
 
-if (EXACT_BOUNDING_VOLUME_USING_CGAL)
-    find_package(CGAL CONFIG REQUIRED)
-endif()
+# --------------------
+# Optional external dependencies.
+# --------------------
+
+find_package(CGAL CONFIG)
 
 # --------------------
 # Module configurations for the external dependencies.
@@ -250,9 +246,11 @@ target_compile_definitions(vk-gltf-viewer PRIVATE
     GLFW_INCLUDE_NONE
 )
 
-if (EXACT_BOUNDING_VOLUME_USING_CGAL)
+if (CGAL_FOUND)
     target_link_libraries(vk-gltf-viewer PRIVATE CGAL::CGAL)
     target_compile_definitions(vk-gltf-viewer PRIVATE EXACT_BOUNDING_VOLUME_USING_CGAL)
+else()
+    message(STATUS "CGAL not found, using approximate bounding volume calculation.")
 endif()
 
 if (APPLE AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ find_package(fastgltf CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
 find_package(imguizmo CONFIG REQUIRED)
-find_package(Ktx CONFIG REQUIRED)
 find_package(mikktspace CONFIG REQUIRED)
 find_package(nfd CONFIG REQUIRED)
 find_package(OpenEXR CONFIG REQUIRED)
@@ -34,6 +33,7 @@ find_package(vku CONFIG REQUIRED)
 # --------------------
 
 find_package(CGAL CONFIG)
+find_package(Ktx CONFIG)
 
 # --------------------
 # Module configurations for the external dependencies.
@@ -234,7 +234,6 @@ target_link_libraries(vk-gltf-viewer PRIVATE
     fastgltf::module
     glm::module
     imgui::imgui
-    KTX::ktx
     imguizmo::imguizmo
     mikktspace::mikktspace
     nfd::nfd
@@ -251,6 +250,13 @@ if (CGAL_FOUND)
     target_compile_definitions(vk-gltf-viewer PRIVATE EXACT_BOUNDING_VOLUME_USING_CGAL)
 else()
     message(STATUS "CGAL not found, using approximate bounding volume calculation.")
+endif()
+
+if (Ktx_FOUND)
+    target_link_libraries(vk-gltf-viewer PRIVATE KTX::ktx)
+    target_compile_definitions(vk-gltf-viewer PRIVATE SUPPORT_KHR_TEXTURE_BASISU)
+else()
+    message(STATUS "KTX not found, KHR_texture_basisu extension will not be supported.")
 endif()
 
 if (APPLE AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ This project depends on:
 - [glm](https://github.com/g-truc/glm)
 - [ImGui](https://github.com/ocornut/imgui)
 - [ImGuizmo](https://github.com/CedricGuillemet/ImGuizmo)
-- [KTX-Software](https://github.com/KhronosGroup/KTX-Software)
 - [MikkTSpace](http://www.mikktspace.com)
 - [Native File Dialog Extended](https://github.com/btzy/nativefiledialog-extended)
 - [OpenEXR](https://openexr.com/en/latest/)
@@ -162,6 +161,7 @@ This project depends on:
 
 Also, there are some optional dependencies that can be configured via CMake options. These are disabled by default.
 - [CGAL](https://www.cgal.org) for exact bounding volume calculation (due to its usage, **this project is licensed under GPL**.)
+- [KTX-Software](https://github.com/KhronosGroup/KTX-Software) for support `KHR_texture_basisu` extension.
 
 Dependencies will be automatically fetched via vcpkg.
 

--- a/README.md
+++ b/README.md
@@ -158,12 +158,26 @@ This project depends on:
   - [Vulkan-Hpp](https://github.com/KhronosGroup/Vulkan-Hpp)
   - [VulkanMemoryAllocator-Hpp](https://github.com/YaaZ/VulkanMemoryAllocator-Hpp)
 
-Also, there are some optional dependencies that can be configured via CMake options. These are disabled by default.
+Dependencies will be automatically fetched via vcpkg.
+
+Also, there are some optional dependencies that are enabling the features. These are not included in `vcpkg.json` by default.
 - [CGAL](https://www.cgal.org) for exact bounding volume calculation (due to its usage, **this project is licensed under GPL**.)
 - [KTX-Software](https://github.com/KhronosGroup/KTX-Software) for support `KHR_texture_basisu` extension.
 - [OpenEXR](https://openexr.com/en/latest/) if you want to use `.exr` skybox.
 
-Dependencies will be automatically fetched via vcpkg.
+You can provide the dependencies at the CMake configuration time to enable the corresponding features. Followings are some ways to provide.
+
+```sh
+# Provide all optional dependencies, with platform agnostic way (most recommended).
+# Be aware that fetching cgal will be extremely slow since it fetches all of the boost dependencies and build gmp and mpfr.
+vcpkg add port cgal ktx openexr
+
+# Provide CGAL, if you're using Ubuntu and apt system package manager.
+sudo apt install libcgal-dev
+
+# Provide OpenEXR, if you're using macOS and Homebrew system package manager.
+brew install openexr
+```
 
 #### Build Steps
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ This project depends on:
 - [ImGuizmo](https://github.com/CedricGuillemet/ImGuizmo)
 - [MikkTSpace](http://www.mikktspace.com)
 - [Native File Dialog Extended](https://github.com/btzy/nativefiledialog-extended)
-- [OpenEXR](https://openexr.com/en/latest/)
 - [stb_image](https://github.com/nothings/stb/blob/master/stb_image.h)
 - [thread-pool](https://github.com/bshoshany/thread-pool)
 - My own Vulkan-Hpp helper library, [vku](https://github.com/stripe2933/vku/tree/module) (branch `module`), which has the following dependencies:
@@ -162,6 +161,7 @@ This project depends on:
 Also, there are some optional dependencies that can be configured via CMake options. These are disabled by default.
 - [CGAL](https://www.cgal.org) for exact bounding volume calculation (due to its usage, **this project is licensed under GPL**.)
 - [KTX-Software](https://github.com/KhronosGroup/KTX-Software) for support `KHR_texture_basisu` extension.
+- [OpenEXR](https://openexr.com/en/latest/) if you want to use `.exr` skybox.
 
 Dependencies will be automatically fetched via vcpkg.
 

--- a/impl/control/AppWindow.cpp
+++ b/impl/control/AppWindow.cpp
@@ -172,6 +172,13 @@ void vk_gltf_viewer::control::AppWindow::onKeyCallback(int key, int scancode, in
 void vk_gltf_viewer::control::AppWindow::onDropCallback(std::span<const char * const> paths) {
     if (paths.empty()) return;
 
+    static constexpr auto supportedSkyboxExtensions = {
+        ".hdr",
+#ifdef SUPPORT_EXR_SKYBOX
+        ".exr",
+#endif
+    };
+
     const std::filesystem::path path = paths[0];
     if (std::filesystem::is_directory(path)) {
         // If directory contains glTF file, load it.
@@ -185,7 +192,7 @@ void vk_gltf_viewer::control::AppWindow::onDropCallback(std::span<const char * c
     else if (const std::filesystem::path extension = path.extension(); ranges::one_of(extension, ".gltf", ".glb")) {
         pTasks->emplace_back(std::in_place_type<task::LoadGltf>, path);
     }
-    else if (ranges::one_of(extension, ".hdr", ".exr")) {
+    else if (std::ranges::contains(supportedSkyboxExtensions, extension)) {
         pTasks->emplace_back(std::in_place_type<task::LoadEqmap>, path);
     }
 }

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -556,9 +556,17 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::menuBar(
         if (ImGui::BeginMenu("Skybox")) {
             if (ImGui::MenuItem("Open Skybox")) {
                 constexpr std::array filterItems {
-                    nfdfilteritem_t { "All Supported Images", "hdr,exr" },
+                    nfdfilteritem_t { 
+                        "All Supported Images", 
+                        "hdr"
+#ifdef SUPPORT_EXR_SKYBOX
+                        ",exr",
+#endif
+                    },
                     nfdfilteritem_t { "HDR Image", "hdr" },
+#ifdef SUPPORT_EXR_SKYBOX
                     nfdfilteritem_t { "EXR Image", "exr" },
+#endif
                 };
 
                 if (auto filename = processFileDialog(filterItems, windowHandle)) {

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -28,7 +28,9 @@ namespace vk_gltf_viewer {
             = fastgltf::Extensions::KHR_materials_unlit
             | fastgltf::Extensions::KHR_materials_variants
             | fastgltf::Extensions::KHR_mesh_quantization
+#ifdef SUPPORT_KHR_TEXTURE_BASISU
             | fastgltf::Extensions::KHR_texture_basisu
+#endif
             | fastgltf::Extensions::KHR_texture_transform
             | fastgltf::Extensions::EXT_mesh_gpu_instancing;
         static constexpr std::uint32_t FRAMES_IN_FLIGHT = 2;

--- a/interface/vulkan/image/Images.cppm
+++ b/interface/vulkan/image/Images.cppm
@@ -1,6 +1,8 @@
 module;
 
+#ifdef SUPPORT_KHR_TEXTURE_BASISU
 #include <ktx.h>
+#endif
 #include <stb_image.h>
 #include <vulkan/vulkan_hpp_macros.hpp>
 
@@ -201,6 +203,7 @@ namespace vk_gltf_viewer::vulkan::image {
                         return processNonCompressedImageFromLoadResult(width, height, channels, std::move(data));
                     };
 
+#ifdef SUPPORT_KHR_TEXTURE_BASISU
                     // WARNING: texture WOULD BE DESTROYED IN THE FUNCTION (for reducing memory footprint)!
                     // Therefore, I explicitly marked the parameter type of texture as ktxTexture2*&& (which force the user to
                     // pass it like std::move(texture).
@@ -288,14 +291,17 @@ namespace vk_gltf_viewer::vulkan::image {
 
                         return processCompressedImageFromLoadResult(std::move(texture));
                     };
+#endif
 
                     vku::AllocatedImage image = visit(fastgltf::visitor {
                         [&](const fastgltf::sources::Array& array) {
                             switch (array.mimeType) {
                                 case fastgltf::MimeType::JPEG: case fastgltf::MimeType::PNG:
                                     return processNonCompressedImageFromMemory(reinterpret_span<const stbi_uc>(std::span { array.bytes }));
+#ifdef SUPPORT_KHR_TEXTURE_BASISU
                                 case fastgltf::MimeType::KTX2:
                                     return processCompressedImageFromMemory(reinterpret_span<const ktx_uint8_t>(std::span { array.bytes }));
+#endif
                                 default:
                                     throw gltf::AssetProcessError::IndeterminateImageMimeType;
                             }
@@ -304,8 +310,10 @@ namespace vk_gltf_viewer::vulkan::image {
                             switch (byteView.mimeType) {
                                 case fastgltf::MimeType::JPEG: case fastgltf::MimeType::PNG:
                                     return processNonCompressedImageFromMemory(reinterpret_span<const stbi_uc>(static_cast<std::span<const std::byte>>(byteView.bytes)));
+#ifdef SUPPORT_KHR_TEXTURE_BASISU
                                 case fastgltf::MimeType::KTX2:
                                     return processCompressedImageFromMemory(reinterpret_span<const ktx_uint8_t>(static_cast<std::span<const std::byte>>(byteView.bytes)));
+#endif
                                 default:
                                     throw gltf::AssetProcessError::IndeterminateImageMimeType;
                             }
@@ -328,6 +336,7 @@ namespace vk_gltf_viewer::vulkan::image {
                                     return processNonCompressedImageFromMemory(reinterpret_span<const stbi_uc>(std::span { data }));
                                 }
                             }
+#ifdef SUPPORT_KHR_TEXTURE_BASISU
                             else if (uri.mimeType == fastgltf::MimeType::KTX2 || extension == ".ktx2") {
                                 if (uri.fileByteOffset == 0) {
                                     return processCompressedImageFromFile(PATH_C_STR(assetDir / uri.uri.fspath()));
@@ -338,6 +347,7 @@ namespace vk_gltf_viewer::vulkan::image {
                                     return processCompressedImageFromMemory(reinterpret_span<const ktx_uint8_t>(std::span { data }));
                                 }
                             }
+#endif
                             else {
                                 throw gltf::AssetProcessError::IndeterminateImageMimeType;
                             }
@@ -346,8 +356,10 @@ namespace vk_gltf_viewer::vulkan::image {
                             switch (bufferView.mimeType) {
                                 case fastgltf::MimeType::JPEG: case fastgltf::MimeType::PNG:
                                     return processNonCompressedImageFromMemory(reinterpret_span<const stbi_uc>(adapter(asset, bufferView.bufferViewIndex)));
+#ifdef SUPPORT_KHR_TEXTURE_BASISU
                                 case fastgltf::MimeType::KTX2:
                                     return processCompressedImageFromMemory(reinterpret_span<const ktx_uint8_t>(adapter(asset, bufferView.bufferViewIndex)));
+#endif
                                 default:
                                     throw gltf::AssetProcessError::IndeterminateImageMimeType;
                             }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "dependencies": [
     "boost-container",
     "boost-container-hash",
+    "bshoshany-thread-pool",
     "cstring-view",
     "fastgltf",
     "glfw3",
@@ -17,14 +18,12 @@
     "imguizmo",
     "mikktspace",
     "nativefiledialog-extended",
-    "openexr",
     "stb",
     {
       "name": "vku",
       "features": [
         "dynamic-dispatcher"
       ]
-    },
-    "bshoshany-thread-pool"
+    }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,7 +15,6 @@
       ]
     },
     "imguizmo",
-    "ktx",
     "mikktspace",
     "nativefiledialog-extended",
     "openexr",


### PR DESCRIPTION
libktx and OpenEXR being optional, specifically:

- libktx being optional and `KHR_texture_basisu` support is enabled only if it is provided.
- OpenEXR being optional and enable `.exr` skybox loading if it is provided.

CGAL related feature enabling mechanism changed:

- `EXACT_BOUNDING_VOLUME_USING_CGAL` CMake option is replaced with `CGAL_FOUND`, automatically set when CGAL provided.