### PR TITLE
Workaround build error regression for Visual Studio 2022 17.13

### DIFF
--- a/interface/vulkan/Gpu.cppm
+++ b/interface/vulkan/Gpu.cppm
@@ -14,48 +14,18 @@ namespace vk_gltf_viewer::vulkan {
         std::uint32_t compute, graphicsPresent, transfer;
         std::vector<std::uint32_t> uniqueIndices;
 
-        QueueFamilies(vk::PhysicalDevice physicalDevice, vk::SurfaceKHR surface) {
-            const std::vector queueFamilyProperties = physicalDevice.getQueueFamilyProperties();
-
-            compute = vku::getComputeSpecializedQueueFamily(queueFamilyProperties)
-                .or_else([&]() { return vku::getComputeQueueFamily(queueFamilyProperties); })
-                .value();
-            graphicsPresent = vku::getGraphicsPresentQueueFamily(physicalDevice, surface, queueFamilyProperties).value();
-            transfer = vku::getTransferSpecializedQueueFamily(queueFamilyProperties).value_or(compute);
-
-            // Calculate unique queue family indices.
-            uniqueIndices = { compute, graphicsPresent, transfer };
-            std::ranges::sort(uniqueIndices);
-            const auto ret = std::ranges::unique(uniqueIndices);
-            uniqueIndices.erase(ret.begin(), ret.end());
-        }
+        QueueFamilies(vk::PhysicalDevice physicalDevice, vk::SurfaceKHR surface);
     };
 
     export struct Queues {
         vk::Queue compute, graphicsPresent, transfer;
 
-        Queues(vk::Device device, const QueueFamilies& queueFamilies) noexcept
-            : compute { device.getQueue(queueFamilies.compute, 0) }
-            , graphicsPresent{ device.getQueue(queueFamilies.graphicsPresent, 0) }
-            , transfer { device.getQueue(queueFamilies.transfer, 0) } { }
+        Queues(vk::Device device, const QueueFamilies& queueFamilies) noexcept;
 
         [[nodiscard]] static vku::RefHolder<std::vector<vk::DeviceQueueCreateInfo>> getCreateInfos(
             vk::PhysicalDevice,
             const QueueFamilies &queueFamilies
-        ) noexcept {
-            return vku::RefHolder { [&]() {
-                static constexpr std::array priorities { 1.f };
-                return queueFamilies.uniqueIndices
-                    | std::views::transform([=](std::uint32_t queueFamilyIndex) {
-                        return vk::DeviceQueueCreateInfo {
-                            {},
-                            queueFamilyIndex,
-                            priorities,
-                        };
-                    })
-                    | std::ranges::to<std::vector>();
-            } };
-        }
+        ) noexcept;
     };
 
     export class Gpu {


### PR DESCRIPTION
As tracked in [Microsoft Visual Studio Developer Community](https://developercommunity.visualstudio.com/t/ICE-regression-of-module-based-project-a/10861101#T-ND10864228), VS 2022 17.13 has a build regression when using C++ modules. This change can workaround for it.