### PR TITLE
Minor fixes.

### DIFF
--- a/interface/helpers/fastgltf.cppm
+++ b/interface/helpers/fastgltf.cppm
@@ -263,7 +263,7 @@ namespace fastgltf {
      * @return The value of the expected if it is not an error.
      * @throw fastgltf::Error If the expected is an error.
      */
-    template <std::move_constructible T>
+    export template <std::move_constructible T>
     [[nodiscard]] T get_checked(Expected<T> expected) {
         if (expected) {
             return std::move(expected.get());

--- a/interface/helpers/optional.cppm
+++ b/interface/helpers/optional.cppm
@@ -69,13 +69,19 @@ export template <typename... Ts, std::invocable<const Ts&...> F>
 
 struct to_range_fn {
     template <typename T>
-    constexpr auto operator()(const std::optional<T> &opt) const -> std::span<const T> {
-        return { &*opt, opt.has_value() ? std::size_t{ 1 } : std::size_t{ 0 } };
+    [[nodiscard]] constexpr std::span<const T> operator()(const std::optional<T> &opt) const noexcept {
+        if (opt) {
+            return { std::addressof(*opt), 1 };
+        }
+        return {};
     }
 
     template <typename T>
-    constexpr auto operator()(std::optional<T> &opt) const -> std::span<T> {
-        return { &*opt, opt.has_value() ? std::size_t{ 1 } : std::size_t{ 0 } };
+    [[nodiscard]] constexpr std::span<T> operator()(std::optional<T> &opt) const noexcept {
+        if (opt) {
+            return { std::addressof(*opt), 1 };
+        }
+        return {};
     }
 };
 


### PR DESCRIPTION
- Missing symbol export `fastgltf::get_checked`, which fixes build error in Clang 20.
- Fix dereferencing `std::nullopt` when calling `to_range`.