### PR TITLE
Support for various mesh primitive types.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/helpers/tristate.cppm
         interface/helpers/type_map.cppm
         interface/helpers/type_variant.cppm
+        interface/helpers/vulkan.cppm
         interface/MainApp.cppm
         interface/math/extended_arithmetic.cppm
         interface/math/Frustum.cppm

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Blazingly fast[^1] Vulkan glTF viewer.
 
 ## Features
 
-- Support glTF 2.0, including:
+- **glTF 2.0 conformant**, especially:
   - PBR material rendering with runtime IBL resources (spherical harmonics + pre-filtered environment map) generation from input equirectangular map.
   - Runtime missing tangent attribute generation using MikkTSpace algorithm for indexed geometry.
   - Runtime missing per-face normal and tangent attribute generation for non-indexed geometry.
   - `OPAQUE`, `MASK` (using alpha testing and Alpha To Coverage) and `BLEND` (using Weighted Blended OIT) materials.
+  - All primitive modes, including emulated `LINE_LOOP` support as Vulkan does not support it natively.
   - Normalized and sparse accessors.
   - Infinite morph targets and skinning attributes.
   - Multiple scenes.
@@ -31,10 +32,6 @@ Blazingly fast[^1] Vulkan glTF viewer.
 - Arbitrary sized outline rendering using [Jump Flooding Algorithm](https://en.wikipedia.org/wiki/Jump_flooding_algorithm).
 - Conditionally render a node with three-state visibility in scene hierarchy tree.
 - GUI for used asset resources (buffers, images, samplers, etc.) list with docking support.
-
-Followings are not supported:
-
-- Line Loops primitive topology, as Vulkan does not support it natively.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Blazingly fast[^1] Vulkan glTF viewer.
 
 Followings are not supported:
 
-- Primitive Type except for `TRIANGLES`.
+- Line Loops primitive topology, as Vulkan does not support it natively.
 
 ## Performance
 

--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -260,6 +260,7 @@ auto vk_gltf_viewer::vulkan::Gpu::createDevice() -> vk::raii::Device {
         vk::PhysicalDeviceIndexTypeUint8FeaturesKHR { supportUint8Index },
 #if __APPLE__
         vk::PhysicalDevicePortabilitySubsetFeaturesKHR{}
+            .setTriangleFans(true)
             .setImageViewFormatSwizzle(true),
 #endif
     };

--- a/interface/gltf/algorithm/MikktSpaceInterface.cppm
+++ b/interface/gltf/algorithm/MikktSpaceInterface.cppm
@@ -6,66 +6,93 @@ export module vk_gltf_viewer:gltf.algorithm.MikktSpaceInterface;
 
 import std;
 export import fastgltf;
+import :helpers.fastgltf;
 
 namespace vk_gltf_viewer::gltf::algorithm {
     export template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
-    struct MikktSpaceMesh {
-        const fastgltf::Asset &asset;
-        const fastgltf::Accessor &indicesAccessor, &positionAccessor, &normalAccessor, &texcoordAccessor;
-        const BufferDataAdapter &bufferDataAdapter;
-        std::vector<fastgltf::math::fvec4> tangents = std::vector<fastgltf::math::fvec4>(positionAccessor.count);
+    class MikktSpaceMesh {
+    public:
+        std::reference_wrapper<const fastgltf::Asset> asset;
+        std::reference_wrapper<const fastgltf::Primitive> primitive;
+
+        std::vector<fastgltf::math::fvec4> tangents;
+
+        MikktSpaceMesh(const fastgltf::Asset &asset, const fastgltf::Primitive &primitive, const BufferDataAdapter &adapter = {})
+            : asset { asset }
+            , primitive { primitive }
+            , indicesAccessor { asset.accessors[primitive.indicesAccessor.value()] }
+            , positionAccessor { asset.accessors[primitive.findAttribute("POSITION")->accessorIndex] }
+            , normalAccessor { asset.accessors[primitive.findAttribute("NORMAL")->accessorIndex] }
+            , texcoordAccessor { [&]() -> const fastgltf::Accessor& {
+                const std::size_t normalTexcoordIndex = getTexcoordIndex(asset.materials[primitive.materialIndex.value()].normalTexture.value());
+                return asset.accessors[primitive.findAttribute(std::format("TEXCOORD_{}", normalTexcoordIndex))->accessorIndex];
+            }() }
+            , bufferDataAdapter { adapter } {
+            tangents.resize(positionAccessor.get().count);
+        }
+
+        [[nodiscard]] int getFaceCount() const noexcept {
+            return indicesAccessor.get().count / 3; // TODO: support for non-triangle list primitive?
+        }
+
+        [[nodiscard]] int getNumVertexPerFaceCount() const noexcept {
+            return 3; // TODO: support for non-triangle list primitive?
+        }
+
+        [[nodiscard]] std::uint32_t getIndex(int face, int vertex) const {
+            // TODO: support for non-triangle list primitive?
+            return fastgltf::getAccessorElement<std::uint32_t>(asset, indicesAccessor, 3 * face + vertex, bufferDataAdapter);
+        }
+
+        [[nodiscard]] fastgltf::math::fvec3 getPosition(std::size_t n) const {
+            return fastgltf::getAccessorElement<fastgltf::math::fvec3>(asset, positionAccessor, n, bufferDataAdapter);
+        }
+
+        [[nodiscard]] fastgltf::math::fvec3 getNormal(std::size_t n) const {
+            return fastgltf::getAccessorElement<fastgltf::math::fvec3>(asset, normalAccessor, n, bufferDataAdapter);
+        }
+
+        [[nodiscard]] fastgltf::math::fvec2 getTexcoord(std::size_t n) const {
+            return fastgltf::getAccessorElement<fastgltf::math::fvec2>(asset, texcoordAccessor, n, bufferDataAdapter);
+        }
+
+    private:
+        std::reference_wrapper<const fastgltf::Accessor> indicesAccessor;
+        std::reference_wrapper<const fastgltf::Accessor> positionAccessor;
+        std::reference_wrapper<const fastgltf::Accessor> normalAccessor;
+        std::reference_wrapper<const fastgltf::Accessor> texcoordAccessor;
+
+        std::reference_wrapper<const BufferDataAdapter> bufferDataAdapter;
     };
 
-    template <std::unsigned_integral IndexType, typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
+    export template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
     struct MikktSpaceInterface : SMikkTSpaceInterface {
         constexpr MikktSpaceInterface()
             : SMikkTSpaceInterface {
                 .m_getNumFaces = [](const SMikkTSpaceContext *pContext) -> int {
                     const auto *meshData = static_cast<const MikktSpaceMesh<BufferDataAdapter>*>(pContext->m_pUserData);
-                    return meshData->indicesAccessor.count / 3;
+                    return meshData->getFaceCount();
                 },
-                .m_getNumVerticesOfFace = [](const SMikkTSpaceContext*, int) {
-                    return 3; // TODO: support for non-triangle primitive?
+                .m_getNumVerticesOfFace = [](const SMikkTSpaceContext *pContext, int) {
+                    const auto *meshData = static_cast<const MikktSpaceMesh<BufferDataAdapter>*>(pContext->m_pUserData);
+                    return meshData->getNumVertexPerFaceCount();
                 },
                 .m_getPosition = [](const SMikkTSpaceContext *pContext, float fvPosOut[], int iFace, int iVert) {
                     const auto *meshData = static_cast<const MikktSpaceMesh<BufferDataAdapter>*>(pContext->m_pUserData);
-                    const fastgltf::math::fvec3 position = fastgltf::getAccessorElement<fastgltf::math::fvec3>(
-                        meshData->asset,
-                        meshData->positionAccessor,
-                        getIndex(*meshData, iFace, iVert),
-                        meshData->bufferDataAdapter);
-                    std::copy_n(position.data(), 3, fvPosOut);
+                    std::copy_n(meshData->getPosition(meshData->getIndex(iFace, iVert)).data(), 3, fvPosOut);
                 },
                 .m_getNormal = [](const SMikkTSpaceContext *pContext, float fvNormOut[], int iFace, int iVert) {
                     const auto *meshData = static_cast<const MikktSpaceMesh<BufferDataAdapter>*>(pContext->m_pUserData);
-                    const fastgltf::math::fvec3 normal = fastgltf::getAccessorElement<fastgltf::math::fvec3>(
-                        meshData->asset,
-                        meshData->normalAccessor,
-                        getIndex(*meshData, iFace, iVert),
-                        meshData->bufferDataAdapter);
-                    std::copy_n(normal.data(), 3, fvNormOut);
+                    std::copy_n(meshData->getNormal(meshData->getIndex(iFace, iVert)).data(), 3, fvNormOut);
                 },
                 .m_getTexCoord = [](const SMikkTSpaceContext *pContext, float fvTexcOut[], int iFace, int iVert) {
                     const auto *meshData = static_cast<const MikktSpaceMesh<BufferDataAdapter>*>(pContext->m_pUserData);
-                    const fastgltf::math::fvec2 texcoord = fastgltf::getAccessorElement<fastgltf::math::fvec2>(
-                        meshData->asset,
-                        meshData->texcoordAccessor,
-                        getIndex(*meshData, iFace, iVert),
-                        meshData->bufferDataAdapter);
-                    std::copy_n(texcoord.data(), 2, fvTexcOut);
+                    std::copy_n(meshData->getTexcoord(meshData->getIndex(iFace, iVert)).data(), 2, fvTexcOut);
                 },
                 .m_setTSpaceBasic = [](const SMikkTSpaceContext *pContext, const float *fvTangent, float fSign, int iFace, int iVert) {
                     auto *meshData = static_cast<MikktSpaceMesh<BufferDataAdapter>*>(pContext->m_pUserData);
-                    *std::copy_n(fvTangent, 3, meshData->tangents[getIndex(*meshData, iFace, iVert)].data()) = fSign;
+                    *std::copy_n(fvTangent, 3, meshData->tangents[meshData->getIndex(iFace, iVert)].data()) = fSign;
                 },
             } { }
-
-        [[nodiscard]] static auto getIndex(const MikktSpaceMesh<BufferDataAdapter> &meshData, int iFace, int iVert) -> int {
-            return fastgltf::getAccessorElement<IndexType>(
-                meshData.asset, meshData.indicesAccessor, 3 * iFace + iVert, meshData.bufferDataAdapter);
-        }
     };
-
-    export template <std::unsigned_integral T, typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
-    MikktSpaceInterface<T, BufferDataAdapter> mikktSpaceInterface;
 }

--- a/interface/helpers/vulkan.cppm
+++ b/interface/helpers/vulkan.cppm
@@ -1,0 +1,68 @@
+export module vk_gltf_viewer:helpers.vulkan;
+
+import std;
+export import vulkan_hpp;
+
+export enum class TopologyClass : std::uint8_t {
+    Point,
+    Line,
+    Triangle,
+    Patch,
+};
+
+/**
+ * Get topology class from \p primitiveTopology.
+ *
+ * You can find more information about the term "Topology Class" from Vulkan specification.
+ * https://vkdoc.net/chapters/drawing#drawing-primitive-topology-class
+ *
+ * @param primitiveTopology Primitive topology.
+ * @return Topology class.
+ */
+export
+[[nodiscard]] TopologyClass getTopologyClass(vk::PrimitiveTopology primitiveTopology) noexcept {
+    switch (primitiveTopology) {
+    case vk::PrimitiveTopology::ePointList:
+        return TopologyClass::Point;
+    case vk::PrimitiveTopology::eLineList:
+    case vk::PrimitiveTopology::eLineStrip:
+    case vk::PrimitiveTopology::eLineListWithAdjacency:
+    case vk::PrimitiveTopology::eLineStripWithAdjacency:
+        return TopologyClass::Line;
+    case vk::PrimitiveTopology::eTriangleList:
+    case vk::PrimitiveTopology::eTriangleStrip:
+    case vk::PrimitiveTopology::eTriangleFan:
+    case vk::PrimitiveTopology::eTriangleListWithAdjacency:
+    case vk::PrimitiveTopology::eTriangleStripWithAdjacency:
+        return TopologyClass::Triangle;
+    case vk::PrimitiveTopology::ePatchList:
+        return TopologyClass::Patch;
+    }
+    std::unreachable();
+}
+
+/**
+ * @brief Get one of the <tt>vk::PrimitiveTopology</tt> type that is match to the given \p topologyClass.
+ *
+ * This function is useful when you're using dynamic state for primitive topology (VK_EXT_extended_dynamic_state), and
+ * system GPU does not support <tt>VkPhysicalDeviceExtendedDynamicState3PropertiesEXT::dynamicPrimitiveTopologyUnrestricted</tt>.
+ * You can pass the representative primitive topology to the PSO initialization and change the primitive topology dynamically.
+ *
+ * @param topologyClass Topology class.
+ * @return One of the <tt>vk::PrimitiveTopology</tt> type that is match to the given \p topologyClass.
+ * @note Currently its implementation returns XXXList type of primitive topology, but you should not rely on this behavior.
+ */
+export
+[[nodiscard]] vk::PrimitiveTopology getRepresentativePrimitiveTopology(TopologyClass topologyClass) noexcept {
+    switch (topologyClass) {
+    case TopologyClass::Point:
+        return vk::PrimitiveTopology::ePointList;
+    case TopologyClass::Line:
+        return vk::PrimitiveTopology::eLineList;
+    case TopologyClass::Triangle:
+        return vk::PrimitiveTopology::eTriangleList;
+    case TopologyClass::Patch:
+        return vk::PrimitiveTopology::ePatchList;
+    }
+    std::unreachable();
+}

--- a/interface/vulkan/Frame.cppm
+++ b/interface/vulkan/Frame.cppm
@@ -35,6 +35,7 @@ struct CommandSeparationCriteria {
     std::uint32_t subpass;
     vk::Pipeline pipeline;
     std::optional<vk::IndexType> indexType;
+    vk::PrimitiveTopology primitiveTopology;
     vk::CullModeFlagBits cullMode;
 
     [[nodiscard]] std::strong_ordering operator<=>(const CommandSeparationCriteria&) const noexcept = default;
@@ -52,6 +53,7 @@ struct std::less<CommandSeparationCriteria> {
 struct CommandSeparationCriteriaNoShading {
     vk::Pipeline pipeline;
     std::optional<vk::IndexType> indexType;
+    vk::PrimitiveTopology primitiveTopology;
     vk::CullModeFlagBits cullMode;
 
     [[nodiscard]] std::strong_ordering operator<=>(const CommandSeparationCriteriaNoShading&) const noexcept = default;

--- a/interface/vulkan/buffer/CombinedIndices.cppm
+++ b/interface/vulkan/buffer/CombinedIndices.cppm
@@ -15,6 +15,12 @@ export import :vulkan.buffer.StagingBufferStorage;
 export import :vulkan.Gpu;
 import :vulkan.trait.PostTransferObject;
 
+constexpr type_map indexTypeMap {
+    make_type_map_entry<std::uint8_t>(fastgltf::ComponentType::UnsignedByte),
+    make_type_map_entry<std::uint16_t>(fastgltf::ComponentType::UnsignedShort),
+    make_type_map_entry<std::uint32_t>(fastgltf::ComponentType::UnsignedInt),
+};
+
 [[nodiscard]] constexpr vk::IndexType getIndexType(fastgltf::ComponentType componentType) {
     switch (componentType) {
     case fastgltf::ComponentType::UnsignedByte:
@@ -53,14 +59,21 @@ namespace vk_gltf_viewer::vulkan::buffer {
             StagingBufferStorage &stagingBufferStorage,
             const BufferDataAdapter &adapter = {}
         ) : PostTransferObject { stagingBufferStorage } {
-            // Primitives that are contain an indices accessor.
-            auto indexedPrimitives
-                = asset.meshes
+            auto primitives = asset.meshes
                 | std::views::transform(&fastgltf::Mesh::primitives)
-                | std::views::join
-                | std::views::filter([](const fastgltf::Primitive &primitive) {
-                    return primitive.indicesAccessor.has_value();
-                });
+                | std::views::join;
+
+            // Primitives that are having an indices accessor.
+            auto indexedPrimitives = primitives | std::views::filter([](const fastgltf::Primitive &primitive) {
+                return primitive.indicesAccessor.has_value();
+            });
+
+            // Primitives whose type is LINE_LOOP.
+            auto lineLoopPrimitives = indexedPrimitives | std::views::filter([](const fastgltf::Primitive &primitive) {
+                // As GL_LINE_LOOP does not supported in Vulkan natively, it should be emulated as line strip, with
+                // additional first vertex at the end, using indexed draw.
+                return primitive.type == fastgltf::PrimitiveType::LineLoop;
+            });
 
             // Index data is either
             // - span of the buffer view region, or
@@ -76,12 +89,6 @@ namespace vk_gltf_viewer::vulkan::buffer {
                         .emplace_back(&primitive, getByteRegion(asset, accessor, adapter));
                 }
                 else {
-                    constexpr type_map indexTypeMap {
-                        make_type_map_entry<std::uint8_t>(fastgltf::ComponentType::UnsignedByte),
-                        make_type_map_entry<std::uint16_t>(fastgltf::ComponentType::UnsignedShort),
-                        make_type_map_entry<std::uint32_t>(fastgltf::ComponentType::UnsignedInt),
-                    };
-
                     // Copy accessor data as uint16_t if GPU does not support VK_KHR_index_type_uint8.
                     fastgltf::ComponentType componentType = accessor.componentType;
                     if (componentType == fastgltf::ComponentType::UnsignedByte && !gpu.supportUint8Index) {
@@ -92,6 +99,69 @@ namespace vk_gltf_viewer::vulkan::buffer {
                         const std::size_t dataSize = sizeof(T) * accessor.count;
                         std::unique_ptr<std::byte[]> indexBytes = std::make_unique_for_overwrite<std::byte[]>(dataSize);
                         copyFromAccessor<T>(asset, accessor, indexBytes.get(), adapter);
+
+                        indexBufferBytesByType[vk::IndexTypeValue<T>::value].emplace_back(
+                            &primitive,
+                            std::span { generatedIndexBytes.emplace_back(std::move(indexBytes)).get(), dataSize });
+                    }, indexTypeMap.get_variant(componentType));
+                }
+            }
+
+            for (const fastgltf::Primitive &primitive : lineLoopPrimitives) {
+                if (primitive.indicesAccessor) {
+                    // If LINE_LOOP primitive has an indices accessor (whose indices are i1...in), new indices are
+                    // generated like: [i1, i2, ..., in, i1].
+                    const fastgltf::Accessor &accessor = asset.accessors[*primitive.indicesAccessor];
+
+                    // Copy accessor data as uint16_t if GPU does not support VK_KHR_index_type_uint8.
+                    fastgltf::ComponentType componentType = accessor.componentType;
+                    if (componentType == fastgltf::ComponentType::UnsignedByte && !gpu.supportUint8Index) {
+                        componentType = fastgltf::ComponentType::UnsignedShort;
+                    }
+
+                    visit([&]<typename T>(std::type_identity<T>) {
+                        const std::size_t dataSize = sizeof(T) * (accessor.count + 1); // +1 for i1 at the end
+                        std::unique_ptr<std::byte[]> indexBytes = std::make_unique_for_overwrite<std::byte[]>(dataSize);
+
+                        // Copy accessor to [i1, i2, ..., in].
+                        copyFromAccessor<T>(asset, accessor, indexBytes.get(), adapter);
+
+                        // Additional index i1 at the end.
+                        std::ranges::copy(
+                            std::bit_cast<std::array<std::byte, sizeof(T)>>(getAccessorElement<T>(asset, accessor, 0, adapter)),
+                            &indexBytes[sizeof(T) * accessor.count]);
+
+                        indexBufferBytesByType[vk::IndexTypeValue<T>::value].emplace_back(
+                            &primitive,
+                            std::span { generatedIndexBytes.emplace_back(std::move(indexBytes)).get(), dataSize });
+                    }, indexTypeMap.get_variant(componentType));
+                }
+                else {
+                    // If LINE_LOOP primitive does not have an indices accessor, it is emulated with indexed drawing,
+                    // whose indices are [0, 1, ..., n, 0] (n is total vertex count).
+                    const std::size_t drawCount = asset.accessors[primitive.findAttribute("POSITION")->accessorIndex].count;
+                    const fastgltf::ComponentType componentType = [&]() {
+                        if (gpu.supportUint8Index && drawCount < 256) {
+                            return fastgltf::ComponentType::UnsignedByte;
+                        }
+                        else if (drawCount < 65536) {
+                            return fastgltf::ComponentType::UnsignedShort;
+                        }
+                        else {
+                            return fastgltf::ComponentType::UnsignedInt;
+                        }
+                    }();
+
+                    visit([&]<typename T>(std::type_identity<T>) {
+                        const std::size_t dataSize = sizeof(T) * (drawCount + 1); // +1 for 0 at the end
+                        std::unique_ptr<std::byte[]> indexBytes = std::make_unique_for_overwrite<std::byte[]>(dataSize);
+
+                        // Generate indices as [0, 1, ..., n].
+                        T *cursor = reinterpret_cast<T*>(indexBytes.get());
+                        std::iota(cursor, cursor + drawCount, T { 0 });
+
+                        // Additional index 0 at the end.
+                        *(cursor + drawCount) = 0;
 
                         indexBufferBytesByType[vk::IndexTypeValue<T>::value].emplace_back(
                             &primitive,

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -2,6 +2,7 @@ export module vk_gltf_viewer:vulkan.pipeline.DepthRenderer;
 
 import std;
 import vku;
+export import :helpers.vulkan;
 import :shader.depth_vert;
 import :shader.depth_frag;
 import :shader_selector.mask_depth_vert;
@@ -16,6 +17,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class DepthRendererSpecialization {
     public:
+        TopologyClass topologyClass;
         std::uint8_t positionComponentType = 0;
         std::uint32_t positionMorphTargetWeightCount = 0;
         std::uint32_t skinAttributeCount = 0;
@@ -40,6 +42,18 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                         },
                         vku::Shader { shader::depth_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                     *pipelineLayout, 1, true)
+                    .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
+                        {},
+                        [this]() {
+                            switch (topologyClass) {
+                                case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
+                                case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
+                                case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
+                                case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
+                            }
+                            std::unreachable();
+                        }(),
+                    }))
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},
                         true, true, vk::CompareOp::eGreater, // Use reverse Z.
@@ -49,6 +63,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                         vku::unsafeProxy({
                             vk::DynamicState::eViewport,
                             vk::DynamicState::eScissor,
+                            vk::DynamicState::ePrimitiveTopology,
                             vk::DynamicState::eCullMode,
                         }),
                     })),
@@ -74,6 +89,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     class MaskDepthRendererSpecialization {
     public:
+        TopologyClass topologyClass;
         std::uint8_t positionComponentType;
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
@@ -108,6 +124,18 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                             }),
                         }).get(),
                     *pipelineLayout, 1, true)
+                    .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
+                        {},
+                        [this]() {
+                            switch (topologyClass) {
+                                case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
+                                case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
+                                case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
+                                case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
+                            }
+                            std::unreachable();
+                        }(),
+                    }))
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},
                         true, true, vk::CompareOp::eGreater, // Use reverse Z.
@@ -117,6 +145,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                         vku::unsafeProxy({
                             vk::DynamicState::eViewport,
                             vk::DynamicState::eScissor,
+                            vk::DynamicState::ePrimitiveTopology,
                             vk::DynamicState::eCullMode,
                         }),
                     })),

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -2,6 +2,7 @@ export module vk_gltf_viewer:vulkan.pipeline.JumpFloodSeedRenderer;
 
 import std;
 import vku;
+export import :helpers.vulkan;
 import :shader.jump_flood_seed_vert;
 import :shader.jump_flood_seed_frag;
 import :shader_selector.mask_jump_flood_seed_vert;
@@ -16,6 +17,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class JumpFloodSeedRendererSpecialization {
     public:
+        TopologyClass topologyClass;
         std::uint8_t positionComponentType = 0;
         std::uint32_t positionMorphTargetWeightCount = 0;
         std::uint32_t skinAttributeCount = 0;
@@ -40,6 +42,18 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                         },
                         vku::Shader { shader::jump_flood_seed_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                     *pipelineLayout, 1, true)
+                    .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
+                        {},
+                        [this]() {
+                            switch (topologyClass) {
+                                case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
+                                case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
+                                case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
+                                case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
+                            }
+                            std::unreachable();
+                        }(),
+                    }))
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},
                         true, true, vk::CompareOp::eGreater, // Use reverse Z.
@@ -49,6 +63,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                         vku::unsafeProxy({
                             vk::DynamicState::eViewport,
                             vk::DynamicState::eScissor,
+                            vk::DynamicState::ePrimitiveTopology,
                             vk::DynamicState::eCullMode,
                         }),
                     })),
@@ -74,6 +89,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     class MaskJumpFloodSeedRendererSpecialization {
     public:
+        TopologyClass topologyClass;
         std::uint8_t positionComponentType;
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
@@ -108,6 +124,18 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                             }),
                         }).get(),
                     *pipelineLayout, 1, true)
+                    .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
+                        {},
+                        [this]() {
+                            switch (topologyClass) {
+                                case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
+                                case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
+                                case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
+                                case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
+                            }
+                            std::unreachable();
+                        }(),
+                    }))
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},
                         true, true, vk::CompareOp::eGreater, // Use reverse Z.
@@ -117,6 +145,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                         vku::unsafeProxy({
                             vk::DynamicState::eViewport,
                             vk::DynamicState::eScissor,
+                            vk::DynamicState::ePrimitiveTopology,
                             vk::DynamicState::eCullMode,
                         }),
                     })),

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -11,6 +11,7 @@ import std;
 export import fastgltf;
 import vku;
 import :helpers.ranges;
+export import :helpers.vulkan;
 import :shader_selector.primitive_vert;
 import :shader_selector.primitive_frag;
 export import :vulkan.pl.Primitive;
@@ -24,6 +25,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class PrimitiveRendererSpecialization {
     public:
+        TopologyClass topologyClass;
         std::uint8_t positionComponentType;
         std::optional<std::uint8_t> normalComponentType;
         std::optional<std::uint8_t> tangentComponentType;
@@ -74,10 +76,24 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     &fragmentShaderSpecializationInfo,
                 });
 
+            const vk::PipelineInputAssemblyStateCreateInfo inputAssemblyStateCreateInfo {
+                {},
+                [this]() {
+                    switch (topologyClass) {
+                        case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
+                        case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
+                        case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
+                        case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
+                    }
+                    std::unreachable();
+                }(),
+            };
+
             switch (alphaMode) {
                 case fastgltf::AlphaMode::Opaque:
                     return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                         pipelineStages.get(), *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
+                        .setPInputAssemblyState(&inputAssemblyStateCreateInfo)
                         .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                             {},
                             true, true, vk::CompareOp::eGreater, // Use reverse Z.
@@ -87,6 +103,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                             vku::unsafeProxy({
                                 vk::DynamicState::eViewport,
                                 vk::DynamicState::eScissor,
+                                vk::DynamicState::ePrimitiveTopology,
                                 vk::DynamicState::eCullMode,
                             }),
                         }))
@@ -96,6 +113,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 case fastgltf::AlphaMode::Mask:
                     return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                         pipelineStages.get(), *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
+                        .setPInputAssemblyState(&inputAssemblyStateCreateInfo)
                         .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                             {},
                             true, true, vk::CompareOp::eGreater, // Use reverse Z.
@@ -111,6 +129,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                             vku::unsafeProxy({
                                 vk::DynamicState::eViewport,
                                 vk::DynamicState::eScissor,
+                                vk::DynamicState::ePrimitiveTopology,
                                 vk::DynamicState::eCullMode,
                             }),
                         }))
@@ -120,6 +139,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 case fastgltf::AlphaMode::Blend:
                     return { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
                         pipelineStages.get(), *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
+                        .setPInputAssemblyState(&inputAssemblyStateCreateInfo)
                         .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                             {},
                             false, false,
@@ -152,6 +172,14 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                                 },
                             }),
                             { 1.f, 1.f, 1.f, 1.f },
+                        }))
+                        .setPDynamicState(vku::unsafeAddress(vk::PipelineDynamicStateCreateInfo {
+                            {},
+                            vku::unsafeProxy({
+                                vk::DynamicState::eViewport,
+                                vk::DynamicState::eScissor,
+                                vk::DynamicState::ePrimitiveTopology,
+                            }),
                         }))
                         .setRenderPass(*sceneRenderPass)
                         .setSubpass(1)

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -181,7 +181,6 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
             if (colorComponentCountAndType) {
                 assert(ranges::one_of(colorComponentCountAndType->first, 3, 4));
-                assert(ranges::one_of(colorComponentCountAndType->second, 1 /* UNSIGNED_BYTE */, 3 /* UNSIGNED_SHORT */, 6 /* FLOAT */));
                 result.colorComponentCount = colorComponentCountAndType->first;
                 result.colorComponentType = colorComponentCountAndType->second;
             }

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -49,4 +49,5 @@ void main(){
 
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
+    gl_PointSize = 1.0;
 }

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -45,4 +45,5 @@ layout (push_constant) uniform PushConstant {
 void main(){
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
+    gl_PointSize = 1.0;
 }

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -74,4 +74,5 @@ void main(){
 
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
+    gl_PointSize = 1.0;
 }

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -72,4 +72,5 @@ void main(){
 
     vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
+    gl_PointSize = 1.0;
 }

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -108,4 +108,5 @@ void main(){
 #endif
 
     gl_Position = pc.projectionView * vec4(outPosition, 1.0);
+    gl_PointSize = 1.0;
 }

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -77,4 +77,5 @@ void main(){
 #endif
 
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
+    gl_PointSize = 1.0;
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "117524bad2789b8aa6954324a1bee4bffb7d6d09",
+    "baseline": "ea2a964f9303270322cf3f2d51c265ba146c422d",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This PR adds support for rendering primitives whose type is not `TRIANGLES`.

- The primitive rendering pipeline now supports dynamic primitive topology, enabled via the [`VK_EXT_extended_dynamic_state`](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_extended_dynamic_state.html) extension. However, since `VkPhysicalDeviceExtendedDynamicState3PropertiesEXT::dynamicPrimitiveTopologyUnrestricted` is not widely supported, pipelines are instantiated with compatible topology classes, and dynamic states are set during command buffer recording.
- Since Vulkan does not natively support `LINE_LOOP`, an additional index buffer is generated to emulate it, regardless of whether the primitive is indexed or not. The `LINE_STRIP` topology is used instead.
  - If the primitive is indexed with indices `[i1, i2, ..., in]`, the new indices will be `[i1, i2, ..., in, i1]`.
  - If the primitive is not indexed, the new indices will be `[0, 1, ..., n, 0]`, where `n` is the count of elements in the `POSITION` accessor.

The `LINE_LOOP` emulation is fully transparent to the user; the GUI will still display the primitive type as originally specified.

Note: with this PR, now the program is conformant to glTF 2.0! 🎉🥳