### PR TITLE
Use hardware filtering for SubgroupMipmapComptuer and SphericalHarmonicCoefficientComputer.

### DIFF
--- a/cubemap/shader/subgroup_mipmap.comp
+++ b/cubemap/shader/subgroup_mipmap.comp
@@ -7,7 +7,8 @@
 
 layout (constant_id = 0) const uint SUBGROUP_SIZE = 32;
 
-layout (set = 0, binding = 0, rgba32f) uniform image2DArray mipImages[];
+layout (set = 0, binding = 0) uniform sampler2DArray inputTexture;
+layout (set = 0, binding = 1) writeonly uniform imageCube mipImages[];
 
 layout (push_constant, std430) uniform PushConstant {
     int baseLevel;
@@ -17,14 +18,6 @@ layout (push_constant, std430) uniform PushConstant {
 layout (local_size_x = 16, local_size_y = 16) in;
 
 shared vec4 sharedData[256 / SUBGROUP_SIZE];
-
-vec4 imageLoadWithLod(ivec3 coordinate, int lod) {
-#if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
-    return imageLoadLodAMD(mipImages[0], coordinate, lod);
-#else
-    return imageLoad(mipImages[lod], coordinate);
-#endif
-}
 
 void imageStoreWithLod(ivec3 coordinate, int lod, vec4 color) {
 #if AMD_SHADER_IMAGE_LOAD_STORE_LOD == 1
@@ -36,18 +29,14 @@ void imageStoreWithLod(ivec3 coordinate, int lod, vec4 color) {
 
 void main(){
     if (SUBGROUP_SIZE == 16) {
-        ivec2 sampleCoordinate = ivec2(gl_WorkGroupSize.xy * gl_WorkGroupID.xy + uvec2(
+        ivec2 firstMipStoreCoordinate = ivec2(gl_WorkGroupSize.xy * gl_WorkGroupID.xy + uvec2(
             (gl_LocalInvocationID.x & 3U) | (gl_LocalInvocationID.y & ~3U),
             ((gl_LocalInvocationID.y << 2U) | (gl_LocalInvocationID.x >> 2U)) & 15U
         ));
+        vec2 sampleCoordinate = (2 * vec2(firstMipStoreCoordinate) + 1) / textureSize(inputTexture, pc.baseLevel).xy;
 
-        vec4 averageColor
-            = imageLoadWithLod(ivec3(2 * sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel)
-            + imageLoadWithLod(ivec3(2 * sampleCoordinate + ivec2(1, 0), gl_GlobalInvocationID.z), pc.baseLevel)
-            + imageLoadWithLod(ivec3(2 * sampleCoordinate + ivec2(0, 1), gl_GlobalInvocationID.z), pc.baseLevel)
-            + imageLoadWithLod(ivec3(2 * sampleCoordinate + ivec2(1, 1), gl_GlobalInvocationID.z), pc.baseLevel);
-        averageColor /= 4.0;
-        imageStoreWithLod(ivec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
+        vec4 averageColor = textureLod(inputTexture, vec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel);
+        imageStoreWithLod(ivec3(firstMipStoreCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
         if (pc.remainingMipLevels == 1U){
             return;
         }
@@ -56,7 +45,7 @@ void main(){
         averageColor += subgroupShuffleXor(averageColor, 4U /* 0b0100 */);
         averageColor /= 4.f;
         if ((gl_SubgroupInvocationID & 5U /* 0b101 */) == 5U) {
-            imageStoreWithLod(ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
         }
         if (pc.remainingMipLevels == 2U){
             return;
@@ -67,7 +56,7 @@ void main(){
         averageColor /= 4.f;
 
         if ((gl_SubgroupInvocationID & 15U /* 0b1111 */) == 15U) {
-            imageStoreWithLod(ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
         }
         if (pc.remainingMipLevels == 3U){
             return;
@@ -82,7 +71,7 @@ void main(){
 
         if ((gl_SubgroupID & 5U) == 5U){
             averageColor = (sharedData[gl_SubgroupID] + sharedData[gl_SubgroupID ^ 1U] + sharedData[gl_SubgroupID ^ 4U] + sharedData[gl_SubgroupID ^ 5U]) / 4.f;
-            imageStoreWithLod(ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
         }
         if (pc.remainingMipLevels == 4U){
             return;
@@ -90,22 +79,18 @@ void main(){
 
         if (gl_LocalInvocationIndex == 0U){
             averageColor = (sharedData[0] + sharedData[1] + sharedData[2] + sharedData[3] + sharedData[4] + sharedData[5] + sharedData[6] + sharedData[7] + sharedData[8] + sharedData[9] + sharedData[10] + sharedData[11] + sharedData[12] + sharedData[13] + sharedData[14] + sharedData[15]) / 16.f;
-            imageStoreWithLod(ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
         }
     }
     else if (SUBGROUP_SIZE == 32) {
-        ivec2 sampleCoordinate = ivec2(gl_WorkGroupSize.xy * gl_WorkGroupID.xy + uvec2(
+        ivec2 firstMipStoreCoordinate = ivec2(gl_WorkGroupSize.xy * gl_WorkGroupID.xy + uvec2(
             (gl_LocalInvocationID.x & 7U) | (gl_LocalInvocationID.y & ~7U),
             ((gl_LocalInvocationID.y << 1U) | (gl_LocalInvocationID.x >> 3U)) & 15U
         ));
+        vec2 sampleCoordinate = (2 * vec2(firstMipStoreCoordinate) + 1) / textureSize(inputTexture, pc.baseLevel).xy;
 
-        vec4 averageColor
-            = imageLoadWithLod(ivec3(2 * sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel)
-            + imageLoadWithLod(ivec3(2 * sampleCoordinate + ivec2(1, 0), gl_GlobalInvocationID.z), pc.baseLevel)
-            + imageLoadWithLod(ivec3(2 * sampleCoordinate + ivec2(0, 1), gl_GlobalInvocationID.z), pc.baseLevel)
-            + imageLoadWithLod(ivec3(2 * sampleCoordinate + ivec2(1, 1), gl_GlobalInvocationID.z), pc.baseLevel);
-        averageColor /= 4.0;
-        imageStoreWithLod(ivec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
+        vec4 averageColor = textureLod(inputTexture, vec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel);
+        imageStoreWithLod(ivec3(firstMipStoreCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
         if (pc.remainingMipLevels == 1U){
             return;
         }
@@ -114,7 +99,7 @@ void main(){
         averageColor += subgroupShuffleXor(averageColor, 8U /* 0b1000 */);
         averageColor /= 4.f;
         if ((gl_SubgroupInvocationID & 9U /* 0b1001 */) == 9U) {
-            imageStoreWithLod(ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
         }
         if (pc.remainingMipLevels == 2U){
             return;
@@ -125,7 +110,7 @@ void main(){
         averageColor /= 4.f;
 
         if ((gl_SubgroupInvocationID & 27U /* 0b11011 */) == 27U) {
-            imageStoreWithLod(ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
         }
         if (pc.remainingMipLevels == 3U){
             return;
@@ -141,7 +126,7 @@ void main(){
 
         if ((gl_SubgroupID & 1U) == 1U){
             averageColor = (sharedData[gl_SubgroupID] + sharedData[gl_SubgroupID ^ 1U]) / 4.f;
-            imageStoreWithLod(ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
         }
         if (pc.remainingMipLevels == 4U){
             return;
@@ -149,22 +134,18 @@ void main(){
 
         if (gl_LocalInvocationIndex == 0U){
             averageColor = (sharedData[0] + sharedData[1] + sharedData[2] + sharedData[3] + sharedData[4] + sharedData[5] + sharedData[6] + sharedData[7]) / 16.f;
-            imageStoreWithLod(ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
         }
     }
     else if (SUBGROUP_SIZE == 64) {
-        ivec2 sampleCoordinate = ivec2(gl_WorkGroupSize.xy * gl_WorkGroupID.xy + uvec2(
+        ivec2 firstMipStoreCoordinate = ivec2(gl_WorkGroupSize.xy * gl_WorkGroupID.xy + uvec2(
             (gl_LocalInvocationID.x & 7U) | (gl_LocalInvocationID.y & ~7U),
             ((gl_LocalInvocationID.y << 1U) | (gl_LocalInvocationID.x >> 3U)) & 15U
         ));
+        vec2 sampleCoordinate = (2 * vec2(firstMipStoreCoordinate) + 1) / textureSize(inputTexture, pc.baseLevel).xy;
 
-        vec4 averageColor
-            = imageLoadWithLod(ivec3(2 * sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel)
-            + imageLoadWithLod(ivec3(2 * sampleCoordinate + ivec2(1, 0), gl_GlobalInvocationID.z), pc.baseLevel)
-            + imageLoadWithLod(ivec3(2 * sampleCoordinate + ivec2(0, 1), gl_GlobalInvocationID.z), pc.baseLevel)
-            + imageLoadWithLod(ivec3(2 * sampleCoordinate + ivec2(1, 1), gl_GlobalInvocationID.z), pc.baseLevel);
-        averageColor /= 4.0;
-        imageStoreWithLod(ivec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
+        vec4 averageColor = textureLod(inputTexture, vec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel);
+        imageStoreWithLod(ivec3(firstMipStoreCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
         if (pc.remainingMipLevels == 1U){
             return;
         }
@@ -173,7 +154,7 @@ void main(){
         averageColor += subgroupShuffleXor(averageColor, 8U /* 0b1000 */);
         averageColor /= 4.f;
         if ((gl_SubgroupInvocationID & 9U /* 0b1001 */) == 9U) {
-            imageStoreWithLod(ivec3(sampleCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
         }
         if (pc.remainingMipLevels == 2U){
             return;
@@ -184,7 +165,7 @@ void main(){
         averageColor /= 4.f;
 
         if ((gl_SubgroupInvocationID & 27U /* 0b11011 */) == 27U) {
-            imageStoreWithLod(ivec3(sampleCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
         }
         if (pc.remainingMipLevels == 3U){
             return;
@@ -195,7 +176,7 @@ void main(){
         averageColor /= 4.f;
 
         if (subgroupElect()) {
-            imageStoreWithLod(ivec3(sampleCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
         }
         if (pc.remainingMipLevels == 4U){
             return;
@@ -208,7 +189,7 @@ void main(){
 
         if (gl_LocalInvocationIndex == 0U){
             averageColor = (sharedData[0] + sharedData[1] + sharedData[2] + sharedData[3]) / 4.f;
-            imageStoreWithLod(ivec3(sampleCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
         }
     }
 }

--- a/ibl/shader/spherical_harmonic_coefficient_image_to_buffer.comp
+++ b/ibl/shader/spherical_harmonic_coefficient_image_to_buffer.comp
@@ -1,10 +1,16 @@
 #version 460
 #extension GL_GOOGLE_include_directive : require
-#extension GL_EXT_samplerless_texture_functions : require
 #extension GL_KHR_shader_subgroup_arithmetic : require
 #extension GL_EXT_scalar_block_layout : require
 
 #include "cubemap.glsl"
+
+const ivec2 gatherOffsets[] = {
+    { 0, 1 }, // i0_j1
+    { 1, 1 }, // i1_j1
+    { 1, 0 }, // i1_j0
+    { 0, 0 }, // i0_j0
+};
 
 struct SphericalHarmonicBasis{
     float band0[1];
@@ -12,7 +18,7 @@ struct SphericalHarmonicBasis{
     float band2[5];
 };
 
-layout (set = 0, binding = 0) uniform texture2DArray cubemapTexture;
+layout (set = 0, binding = 0) uniform sampler2DArray cubemapSampler;
 layout (set = 0, binding = 1, scalar) writeonly buffer ReductionBuffer {
     vec3 coefficients[][9];
 } reduction;
@@ -25,6 +31,15 @@ shared vec3 sharedData[16][9]; // For gl_SubgroupSize = 16 (minimum requirement)
 // Functions.
 // --------------------
 
+float getComponent(vec4 v, uint i) {
+    switch (i) {
+        case 0U: return v.x;
+        case 1U: return v.y;
+        case 2U: return v.z;
+        case 3U: return v.w;
+    }
+}
+
 SphericalHarmonicBasis getSphericalHarmonicBasis(vec3 v){
     return SphericalHarmonicBasis(
         float[1](0.282095),
@@ -36,22 +51,37 @@ SphericalHarmonicBasis getSphericalHarmonicBasis(vec3 v){
 void main(){
     vec3 coefficients[9] = vec3[9](vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), vec3(0));
 
-    uint cubemapTextureSize = textureSize(cubemapTexture, 0).x;
-    float solidAngle = texelSolidAngle(gl_GlobalInvocationID.xy, 1.0 / cubemapTextureSize);
-    for (uint faceIndex = 0; faceIndex < 6U; ++faceIndex){
-        vec3 L = solidAngle * texelFetch(cubemapTexture, ivec3(gl_GlobalInvocationID.xy, faceIndex), 0).rgb;
-        vec3 normal = getWorldDirection(ivec3(gl_GlobalInvocationID.xy, faceIndex), cubemapTextureSize);
-        SphericalHarmonicBasis basis = getSphericalHarmonicBasis(normal);
+    uint cubemapTextureSize = textureSize(cubemapSampler, 0).x;
+    float cubemapTextureSizeRcp = 1.0 / float(cubemapTextureSize);
+    vec2 globalInvocationId2 = 2 * vec2(gl_GlobalInvocationID.xy);
+    vec4 solidAngles = vec4(
+        texelSolidAngle(globalInvocationId2 + gatherOffsets[0], cubemapTextureSizeRcp),
+        texelSolidAngle(globalInvocationId2 + gatherOffsets[1], cubemapTextureSizeRcp),
+        texelSolidAngle(globalInvocationId2 + gatherOffsets[2], cubemapTextureSizeRcp),
+        texelSolidAngle(globalInvocationId2 + gatherOffsets[3], cubemapTextureSizeRcp)
+    );
 
-        coefficients[0] += L * basis.band0[0];
-        coefficients[1] += L * basis.band1[0];
-        coefficients[2] += L * basis.band1[1];
-        coefficients[3] += L * basis.band1[2];
-        coefficients[4] += L * basis.band2[0];
-        coefficients[5] += L * basis.band2[1];
-        coefficients[6] += L * basis.band2[2];
-        coefficients[7] += L * basis.band2[3];
-        coefficients[8] += L * basis.band2[4];
+    for (int faceIndex = 0; faceIndex < 6; ++faceIndex){
+        vec3 gatherCoordinate = vec3((globalInvocationId2 + 1.0) * cubemapTextureSizeRcp, faceIndex);
+        vec4 textureGatherRed = textureGather(cubemapSampler, gatherCoordinate, 0);
+        vec4 textureGatherGreen = textureGather(cubemapSampler, gatherCoordinate, 1);
+        vec4 textureGatherBlue = textureGather(cubemapSampler, gatherCoordinate, 2);
+
+        for (uint i = 0; i < 4; ++i) {
+            vec3 L = getComponent(solidAngles, i) * vec3(getComponent(textureGatherRed, i), getComponent(textureGatherGreen, i), getComponent(textureGatherBlue, i));
+            ivec3 coordinate = ivec3(2 * gl_GlobalInvocationID.xy + gatherOffsets[i], faceIndex);
+            SphericalHarmonicBasis basis = getSphericalHarmonicBasis(getWorldDirection(coordinate, cubemapTextureSize));
+
+            coefficients[0] += L * basis.band0[0];
+            coefficients[1] += L * basis.band1[0];
+            coefficients[2] += L * basis.band1[1];
+            coefficients[3] += L * basis.band1[2];
+            coefficients[4] += L * basis.band2[0];
+            coefficients[5] += L * basis.band2[1];
+            coefficients[6] += L * basis.band2[2];
+            coefficients[7] += L * basis.band2[3];
+            coefficients[8] += L * basis.band2[4];
+        }
     }
 
     vec3 subgroupCoefficients[9] = vec3[9](


### PR DESCRIPTION
- `SubgroupMipmapComputer` fetches 2x2 quad texels and calculate sum, which can be improved by texel filtering with linear sampler.
- `SphericalHarmonicCoefficientComputer`'s image -> buffer reduction phase also fetches a single texel and reduce them using subgroup arithmetic operation, which can be improved by using GLSL's `textureGather` operation. This can reduce the total workgroup dispatch count by 4x.