### PR TITLE
Add support for subgroup size of 128, optimize shared memory usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The extensions and feature used in this application are quite common in the mode
   - `VkPhysicalDeviceExtendedDynamicStateFeaturesEXT`
   - (optional) `VkPhysicalDeviceIndexTypeUint8FeaturesEXT` (if not presented, unsigned byte primitive indices will re-generated with `uint16_t`s)
 - Device Limits
-  - Subgroup size must be at least 16 and 64 at maximum.
+  - Subgroup size must be at least 16.
   - Sampler anisotropy must support 16x.
   - Loading asset texture count must be less than `maxDescriptorSetUpdateAfterBindSampledImages`
 

--- a/cubemap/interface/SubgroupMipmapComputer.cppm
+++ b/cubemap/interface/SubgroupMipmapComputer.cppm
@@ -13,7 +13,7 @@ namespace cubemap {
     public:
         struct Config {
             /**
-             * @brief Subgroup size of <tt>vk::PhysicalDevice</tt>. Must be either one of 16, 32 or 64.
+             * @brief Subgroup size of <tt>vk::PhysicalDevice</tt>. Must be greater than or equal to 16.
              */
             std::uint32_t subgroupSize;
 

--- a/cubemap/shader/subgroup_mipmap.comp
+++ b/cubemap/shader/subgroup_mipmap.comp
@@ -192,4 +192,59 @@ void main(){
             imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 5, averageColor);
         }
     }
+    else if (SUBGROUP_SIZE == 128) {
+        ivec2 firstMipStoreCoordinate = ivec2(gl_GlobalInvocationID.xy);
+        vec2 sampleCoordinate = (2 * vec2(firstMipStoreCoordinate) + 1) / textureSize(inputTexture, pc.baseLevel).xy;
+
+        vec4 averageColor = textureLod(inputTexture, vec3(sampleCoordinate, gl_GlobalInvocationID.z), pc.baseLevel);
+        imageStoreWithLod(ivec3(firstMipStoreCoordinate, gl_GlobalInvocationID.z), pc.baseLevel + 1, averageColor);
+        if (pc.remainingMipLevels == 1U){
+            return;
+        }
+
+        averageColor += subgroupShuffleXor(averageColor, 1U /* 0b00001 */);
+        averageColor += subgroupShuffleXor(averageColor, 16U /* 0b10000 */);
+        averageColor /= 4.f;
+        if ((gl_SubgroupInvocationID & 17U /* 0b10001 */) == 17U) {
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 1, gl_GlobalInvocationID.z), pc.baseLevel + 2, averageColor);
+        }
+        if (pc.remainingMipLevels == 2U){
+            return;
+        }
+
+        averageColor += subgroupShuffleXor(averageColor, 2U /* 0b000010 */);
+        averageColor += subgroupShuffleXor(averageColor, 32U /* 0b100000 */);
+        averageColor /= 4.f;
+
+        if ((gl_SubgroupInvocationID & 51U /* 0b110011 */) == 51U) {
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 2, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
+        }
+        if (pc.remainingMipLevels == 3U){
+            return;
+        }
+
+        averageColor += subgroupShuffleXor(averageColor, 4U /* 0b0000100 */);
+        averageColor += subgroupShuffleXor(averageColor, 64U /* 0b1000000 */);
+        averageColor /= 4.f;
+
+        if ((gl_SubgroupInvocationID & 119U /* 0b1110111 */) == 119U) {
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 3, gl_GlobalInvocationID.z), pc.baseLevel + 3, averageColor);
+        }
+        if (pc.remainingMipLevels == 4U){
+            return;
+        }
+
+        averageColor += subgroupShuffleXor(averageColor, 8U /* 0b001000 */);
+        if (subgroupElect()){
+            sharedData[gl_SubgroupID] = averageColor;
+        }
+
+        memoryBarrierShared();
+        barrier();
+
+        if (gl_LocalInvocationIndex == 0U) {
+            averageColor = (sharedData[0] + sharedData[1]) / 4.f;
+            imageStoreWithLod(ivec3(firstMipStoreCoordinate >> 4, gl_GlobalInvocationID.z), pc.baseLevel + 4, averageColor);
+        }
+    }
 }

--- a/ibl/shader/spherical_harmonic_coefficient_buffer_to_buffer.comp
+++ b/ibl/shader/spherical_harmonic_coefficient_buffer_to_buffer.comp
@@ -4,6 +4,8 @@
 
 const vec3[9] _9_ZERO_VEC3S = vec3[9](vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), vec3(0));
 
+layout (constant_id = 0) const uint SUBGROUP_SIZE = 32;
+
 layout (set = 0, binding = 0, scalar) buffer PingPongBuffer {
     vec3 data[][9];
 };
@@ -16,7 +18,7 @@ layout (push_constant, std430) uniform PushConstant{
 
 layout (local_size_x = 256) in;
 
-shared vec3 subgroupReduction[16][9]; // gl_NumSubgroups ≤ 16 (subgroup size must be at least 16).
+shared vec3 subgroupReduction[256 / SUBGROUP_SIZE][9];
 
 void main(){
     vec3 pingPongData[] = gl_GlobalInvocationID.x < pc.count ? data[pc.srcOffset + gl_GlobalInvocationID.x] : _9_ZERO_VEC3S;

--- a/ibl/shader/spherical_harmonic_coefficient_buffer_to_buffer.comp
+++ b/ibl/shader/spherical_harmonic_coefficient_buffer_to_buffer.comp
@@ -16,7 +16,7 @@ layout (push_constant, std430) uniform PushConstant{
 
 layout (local_size_x = 256) in;
 
-shared vec3 subgroupReduction[32][9]; // gl_NumSubgroups ≤ 32 (subgroup size must be at least 8).
+shared vec3 subgroupReduction[16][9]; // gl_NumSubgroups ≤ 16 (subgroup size must be at least 16).
 
 void main(){
     vec3 pingPongData[] = gl_GlobalInvocationID.x < pc.count ? data[pc.srcOffset + gl_GlobalInvocationID.x] : _9_ZERO_VEC3S;
@@ -38,31 +38,8 @@ void main(){
     memoryBarrierShared();
     barrier();
 
-    // For subgroup size 8, use subgroup whose ID is 0..4 to reduce the data one more time.
-    // TODO: this code is not tested yet.
-    if ((gl_SubgroupSize == 8U) && (gl_SubgroupID < 4U)){
-        reductions = vec3[9](
-            subgroupAdd(pingPongData[0]),
-            subgroupAdd(pingPongData[1]),
-            subgroupAdd(pingPongData[2]),
-            subgroupAdd(pingPongData[3]),
-            subgroupAdd(pingPongData[4]),
-            subgroupAdd(pingPongData[5]),
-            subgroupAdd(pingPongData[6]),
-            subgroupAdd(pingPongData[7]),
-            subgroupAdd(pingPongData[8])
-        );
-        if (subgroupElect()){
-            subgroupReduction[gl_SubgroupID] = reductions;
-        }
-
-        memoryBarrierShared();
-        barrier();
-    }
-    uint pingPongDataElementCount = (gl_SubgroupSize == 8U) ? 4U : gl_NumSubgroups;
-
     if (gl_SubgroupID == 0U){
-        pingPongData = gl_SubgroupInvocationID < pingPongDataElementCount ? subgroupReduction[gl_SubgroupInvocationID] : _9_ZERO_VEC3S;
+        pingPongData = gl_SubgroupInvocationID < gl_NumSubgroups ? subgroupReduction[gl_SubgroupInvocationID] : _9_ZERO_VEC3S;
         // TODO: Following code compile successfully in glslc, but failed in SPIRV-Cross (SPIR-V -> MSL). Fix when available.
         // data[pc.dstOffset + gl_WorkGroupID.x] = vec3[](
         //     subgroupAdd(pingPongData[0]),

--- a/ibl/shader/spherical_harmonic_coefficient_image_to_buffer.comp
+++ b/ibl/shader/spherical_harmonic_coefficient_image_to_buffer.comp
@@ -12,6 +12,8 @@ const ivec2 gatherOffsets[] = {
     { 0, 0 }, // i0_j0
 };
 
+layout (constant_id = 0) const uint SUBGROUP_SIZE = 32;
+
 struct SphericalHarmonicBasis{
     float band0[1];
     float band1[3];
@@ -25,7 +27,7 @@ layout (set = 0, binding = 1, scalar) writeonly buffer ReductionBuffer {
 
 layout (local_size_x = 16, local_size_y = 16) in;
 
-shared vec3 sharedData[16][9]; // For gl_SubgroupSize = 16 (minimum requirement)
+shared vec3 sharedData[256 / SUBGROUP_SIZE][9];
 
 // --------------------
 // Functions.

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -1020,6 +1020,9 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
 
     const ibl::SphericalHarmonicCoefficientComputer sphericalHarmonicCoefficientComputer { gpu.device, gpu.allocator, cubemapImage, sphericalHarmonicsBuffer, {
         .sampleMipLevel = 0,
+        .specializationConstants = {
+            .subgroupSize = gpu.subgroupSize,
+        },
     } };
     const ibl::PrefilteredmapComputer prefilteredmapComputer { gpu.device, cubemapImage, prefilteredmapImage, {
         .useShaderImageLoadStoreLod = gpu.supportShaderImageLoadStoreLod,


### PR DESCRIPTION
- Support subgroup size of 128 for some Adreno GPUs.
- Instead of setting shared memory size as the largest possibly needed, now subgroup size is passed to the shaders using specialization constants and their sizes adjusted optimally.
- Drop support for subgroup size of 8.