### PR TITLE
Remove shaderInt64 physical device feature requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The extensions and feature used in this application are quite common in the mode
   - `VkPhysicalDeviceFeatures`
     - `samplerAnistropy`
     - `shaderInt16`
-    - `shaderInt64`
     - `multiDrawIndirect`
     - `shaderStorageImageWriteWithoutFormat`
     - `independentBlend` (Weighted Blended OIT)

--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -28,7 +28,6 @@ constexpr std::array optionalExtensions {
 constexpr vk::PhysicalDeviceFeatures requiredFeatures = vk::PhysicalDeviceFeatures{}
     .setSamplerAnisotropy(true)
     .setShaderInt16(true)
-    .setShaderInt64(true)
     .setMultiDrawIndirect(true)
     .setShaderStorageImageWriteWithoutFormat(true)
     .setIndependentBlend(true);
@@ -138,7 +137,6 @@ auto vk_gltf_viewer::vulkan::Gpu::selectPhysicalDevice(const vk::raii::Instance 
         const vk::PhysicalDeviceVulkan12Features &vulkan12Features = availableFeatures.get<vk::PhysicalDeviceVulkan12Features>();
         if (!features.samplerAnisotropy ||
             !features.shaderInt16 ||
-            !features.shaderInt64 ||
             !features.multiDrawIndirect ||
             !features.shaderStorageImageWriteWithoutFormat ||
             !features.independentBlend ||

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -2,11 +2,9 @@
 #extension GL_GOOGLE_include_directive : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
-#extension GL_EXT_buffer_reference : require
-#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_buffer_reference_uvec2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
-#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
 
 #define VERTEX_SHADER
 #include "indexing.glsl"

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -2,11 +2,9 @@
 #extension GL_GOOGLE_include_directive : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
-#extension GL_EXT_buffer_reference : require
-#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_buffer_reference_uvec2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
-#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
 
 #define VERTEX_SHADER
 #include "indexing.glsl"

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -2,11 +2,9 @@
 #extension GL_GOOGLE_include_directive : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
-#extension GL_EXT_buffer_reference : require
-#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_buffer_reference_uvec2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
-#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
 
 #define VERTEX_SHADER
 #include "indexing.glsl"

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -2,11 +2,9 @@
 #extension GL_GOOGLE_include_directive : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
-#extension GL_EXT_buffer_reference : require
-#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_buffer_reference_uvec2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
-#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
 
 #define VERTEX_SHADER
 #include "indexing.glsl"

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -2,11 +2,9 @@
 #extension GL_GOOGLE_include_directive : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
-#extension GL_EXT_buffer_reference : require
-#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_buffer_reference_uvec2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
-#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
 
 #define VERTEX_SHADER
 #include "indexing.glsl"

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -42,27 +42,34 @@ struct Node {
 };
 
 struct Accessor {
-    uint64_t bufferAddress;
+    uvec2 bufferAddress;
     uint8_t componentType;
     uint8_t componentCount;
     uint8_t stride;
     uint8_t _padding_[5];
 };
 
-uint64_t getFetchAddress(Accessor accessor, uint index) {
-    return accessor.bufferAddress + uint(accessor.stride) * index;
+uvec2 add64(uvec2 lhs, uint rhs) {
+    uint carry;
+    uint lo = uaddCarry(lhs.x, rhs, carry);
+    uint hi = lhs.y + carry;
+    return uvec2(lo, hi);
+}
+
+uvec2 getFetchAddress(Accessor accessor, uint index) {
+    return add64(accessor.bufferAddress, uint(accessor.stride) * index);
 }
 
 layout (std430, buffer_reference, buffer_reference_align = 16) readonly buffer Accessors { Accessor data[]; };
 
 struct Primitive {
-    uint64_t pPositionBuffer;
+    uvec2 pPositionBuffer;
     Accessors positionMorphTargetAccessors;
-    uint64_t pNormalBuffer;
+    uvec2 pNormalBuffer;
     Accessors normalMorphTargetAccessors;
-    uint64_t pTangentBuffer;
+    uvec2 pTangentBuffer;
     Accessors tangentMorphTargetAccessors;
-    uint64_t pColorBuffer;
+    uvec2 pColorBuffer;
     Accessors texcoordAccessors;
     Accessors jointsAccessors;
     Accessors weightsAccessors;

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -2,11 +2,9 @@
 #extension GL_GOOGLE_include_directive : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
-#extension GL_EXT_buffer_reference : require
-#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_buffer_reference_uvec2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
-#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
 
 #define VERTEX_SHADER
 #include "indexing.glsl"

--- a/shaders/vertex_pulling.glsl
+++ b/shaders/vertex_pulling.glsl
@@ -27,7 +27,7 @@ layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Ve
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Vec4Ref { vec4 data; };
 
 vec3 getPosition(uint componentType, uint morphTargetWeightCount) {
-    uint64_t fetchAddress = PRIMITIVE.pPositionBuffer + uint(PRIMITIVE.positionByteStride) * uint(gl_VertexIndex);
+    uvec2 fetchAddress = add64(PRIMITIVE.pPositionBuffer, uint(PRIMITIVE.positionByteStride) * uint(gl_VertexIndex));
     vec3 position;
     switch (componentType) {
     case 0U: // BYTE
@@ -87,7 +87,7 @@ vec3 getPosition(uint componentType, uint morphTargetWeightCount) {
 }
 
 vec3 getNormal(uint componentType, uint morphTargetWeightCount) {
-    uint64_t fetchAddress = PRIMITIVE.pNormalBuffer + uint(PRIMITIVE.normalByteStride) * uint(gl_VertexIndex);
+    uvec2 fetchAddress = add64(PRIMITIVE.pNormalBuffer, uint(PRIMITIVE.normalByteStride) * uint(gl_VertexIndex));
     vec3 normal;
     switch (componentType) {
     case 6U: // FLOAT
@@ -123,7 +123,7 @@ vec3 getNormal(uint componentType, uint morphTargetWeightCount) {
 }
 
 vec4 getTangent(uint componentType, uint morphTargetWeightCount) {
-    uint64_t fetchAddress = PRIMITIVE.pTangentBuffer + uint(PRIMITIVE.tangentByteStride) * uint(gl_VertexIndex);
+    uvec2 fetchAddress = add64(PRIMITIVE.pTangentBuffer, uint(PRIMITIVE.tangentByteStride) * uint(gl_VertexIndex));
     vec4 tangent;
     switch (componentType) {
     case 6U: // FLOAT
@@ -162,7 +162,7 @@ vec4 getTangent(uint componentType, uint morphTargetWeightCount) {
 #if TEXCOORD_COUNT >= 1 || HAS_BASE_COLOR_TEXTURE
 vec2 getTexcoord(uint texcoordIndex, uint componentType){
     Accessor texcoordAccessor = PRIMITIVE.texcoordAccessors.data[texcoordIndex];
-    uint64_t fetchAddress = getFetchAddress(texcoordAccessor, gl_VertexIndex);
+    uvec2 fetchAddress = getFetchAddress(texcoordAccessor, gl_VertexIndex);
 
     switch (componentType) {
     case 0U: // BYTE
@@ -190,7 +190,7 @@ vec2 getTexcoord(uint texcoordIndex, uint componentType){
 
 #if HAS_COLOR_ATTRIBUTE
 vec4 getColor(uint componentType) {
-    uint64_t fetchAddress = PRIMITIVE.pColorBuffer + uint(PRIMITIVE.colorByteStride) * uint(gl_VertexIndex);
+    uvec2 fetchAddress = add64(PRIMITIVE.pColorBuffer, uint(PRIMITIVE.colorByteStride) * uint(gl_VertexIndex));
     if (COLOR_COMPONENT_COUNT == 3U) {
         switch (componentType) {
         case 6U: // FLOAT
@@ -223,13 +223,13 @@ float getColorAlpha(uint componentType) {
     switch (componentType) {
     case 6U: // FLOAT
         fetchIndex += 12; // sizeof(vec3)
-        return FloatRef(PRIMITIVE.pColorBuffer + fetchIndex).data;
+        return FloatRef(add64(PRIMITIVE.pColorBuffer, fetchIndex)).data;
     case 9U: // UNSIGNED BYTE normalized
         fetchIndex += 3U; // sizeof(u8vec3)
-        return dequantize(Uint8Ref(PRIMITIVE.pColorBuffer + fetchIndex).data);
+        return dequantize(Uint8Ref(add64(PRIMITIVE.pColorBuffer, fetchIndex)).data);
     case 11U: // UNSIGNED SHORT normalized
         fetchIndex += 6U; // sizeof(u16vec3)
-        return dequantize(Uint16Ref(PRIMITIVE.pColorBuffer + fetchIndex).data);
+        return dequantize(Uint16Ref(add64(PRIMITIVE.pColorBuffer, fetchIndex)).data);
     }
     return 1.0; // unreachable.
 }
@@ -237,7 +237,7 @@ float getColorAlpha(uint componentType) {
 
 uvec4 getJoints(uint jointIndex){
     Accessor jointsAccessor = PRIMITIVE.jointsAccessors.data[jointIndex];
-    uint64_t fetchAddress = getFetchAddress(jointsAccessor, gl_VertexIndex);
+    uvec2 fetchAddress = getFetchAddress(jointsAccessor, gl_VertexIndex);
 
     switch (uint(jointsAccessor.componentType)) {
     case 1U: // UNSIGNED BYTE
@@ -250,7 +250,7 @@ uvec4 getJoints(uint jointIndex){
 
 vec4 getWeights(uint weightIndex){
     Accessor weightsAccessor = PRIMITIVE.weightsAccessors.data[weightIndex];
-    uint64_t fetchAddress = getFetchAddress(weightsAccessor, gl_VertexIndex);
+    uvec2 fetchAddress = getFetchAddress(weightsAccessor, gl_VertexIndex);
 
     switch (uint(weightsAccessor.componentType)) {
     case 6U: // FLOAT


### PR DESCRIPTION
`shaderInt64` physical device feature is [not widely supported](https://vulkan.gpuinfo.org/listdevicescoverage.php?feature=shaderInt64&platform=all), and can be workarounded (and maybe could be more performant) using [`GL_EXT_buffer_reference_uvec2`](https://github.com/KhronosGroup/GLSL/blob/main/extensions/ext/GLSL_EXT_buffer_reference_uvec2.txt).