### PR TITLE
Use upstream main version of ImGuizmo to fix the ViewManipulate()'s mouse capturing behavior.

### DIFF
--- a/overlays/imguizmo/CMakeLists.txt
+++ b/overlays/imguizmo/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.8)
+project(imguizmo)
+
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(imgui CONFIG REQUIRED)
+get_target_property(IMGUI_INCLUDE_DIRS imgui::imgui
+    INTERFACE_INCLUDE_DIRECTORIES
+)
+
+add_library(${PROJECT_NAME} "")
+
+target_include_directories(
+	${PROJECT_NAME}
+	PUBLIC
+	   	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<INSTALL_INTERFACE:include>
+	PRIVATE
+		${IMGUI_INCLUDE_DIRS}
+)
+
+target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
+        GraphEditor.cpp
+        ImCurveEdit.cpp
+        ImGradient.cpp
+        ImGuizmo.cpp
+        ImSequencer.cpp
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-target
+    ARCHIVE DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+if (NOT IMGUIZMO_SKIP_HEADERS)
+    install(
+        FILES
+            GraphEditor.h
+            ImCurveEdit.h
+            ImGradient.h
+            ImGuizmo.h
+            ImSequencer.h
+            ImZoomSlider.h
+        DESTINATION include
+    )
+endif()
+
+install(
+    EXPORT ${PROJECT_NAME}-target
+    NAMESPACE ${PROJECT_NAME}::
+    FILE ${PROJECT_NAME}-config.cmake
+    DESTINATION share/${PROJECT_NAME}
+)

--- a/overlays/imguizmo/portfile.cmake
+++ b/overlays/imguizmo/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO CedricGuillemet/ImGuizmo
+    REF 2310acda820d7383d4c4884b7945ada92cd16a47
+    SHA512 989dc593d3bc36e8efc9480e9d665310a73d811a9ce7111598083f836efe6efe27c66a4717de53a923411605d65355af6cad5a62cf7ddeff2c9803570d1eaa41
+    HEAD_REF master
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS_DEBUG
+        -DIMGUIZMO_SKIP_HEADERS=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME ${PORT} CONFIG_PATH share/${PORT})
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/overlays/imguizmo/vcpkg.json
+++ b/overlays/imguizmo/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "imguizmo",
+  "version-date": "2025-04-05",
+  "port-version": 0,
+  "description": "Immediate mode 3D gizmo for scene editing and other controls based on Dear ImGui",
+  "homepage": "https://github.com/CedricGuillemet/ImGuizmo",
+  "license": "MIT",
+  "dependencies": [
+    "imgui",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
This change fixes bug that the selected node is deselected when manipulating `ViewManipulate`.