### PR TITLE
Make ImGui binds the fallback texture descriptor set when the recorded draw command ImTextureID is destroyed by ImGui_ImplVulkan_RemoveTexture.

### DIFF
--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -883,81 +883,16 @@ void vk_gltf_viewer::MainApp::loadGltf(const std::filesystem::path &path) {
         }
     }
 
-    // Here, we need very careful mechanism for descriptor set lifetime management.
-    //
-    // Since this function could be called after ImGui::Render(), descriptor sets of the previously loaded asset textures
-    // may already recorded to the context. Therefore, they MUST NOT be destroyed using ImGui_ImplVulkan_RemoveTexture.
-    // However, since ImGui_ImplVulkan_GetDrawData() is not called yet, so do the descriptor sets are not recorded to the
-    // command buffer, and we can only update the descriptor sets using vkUpdateDescriptorSets. Note that this function is
-    // not exposed as ImGui_ImplVulkan_XXX, therefore their update layout may changed by the ImGui update.
-    //
-    // If assetTextureDescriptorSets.size() <= sharedData.gltfAsset->textures.descriptorInfos.size(), the existing
-    // descriptor sets are updated, and the remaining descriptor sets have to be created via ImGui_ImplVulkan_AddTexture.
-    //
-    // Otherwise, assetTextureDescriptorSets[:sharedData.gltfAsset->textures.descriptorInfos.size()] are updated. The
-    // problematic one is the remaining descriptor sets (=assetTextureDescriptorSets[sharedData.gltfAsset->textures.descriptorInfos.size():]).
-    // Since they are already in the ImGui context, but referring the destroyed textures, we need to fill them with the
-    // fallback texture. After that, we resize the assetTextureDescriptorSets vector to the size of sharedData.gltfAsset->textures.descriptorInfos.
-    // It relies on the behavior of std::vector::resize, which is in the specification:
-    //
-    //   Vector capacity is never reduced when resizing to smaller size because that would invalidate all iterators,
-    //   while the specification only invalidates the iterators to/after the erased elements.
-    //
-    // Therefore, resizing assetTextureDescriptorSets does not destroy the tail elements, and the shrinked descriptor sets
-    // will be used from the next frame.
-    // TODO: due to the ImGui's gamma correction issue, base color/emissive texture is rendered darker than it should be.
-    gpu.device.updateDescriptorSets(
-        ranges::views::zip_transform([&](ImTextureID imGuiTexture, const vk::DescriptorImageInfo &info) {
-            return vk::WriteDescriptorSet {
-                reinterpret_cast<vk::DescriptorSet::CType>(imGuiTexture),
-                0,
-                0,
-                vk::DescriptorType::eCombinedImageSampler,
-                info,
-            };
-        }, assetTextureDescriptorSets, sharedData.gltfAsset->textures.descriptorInfos) | std::ranges::to<std::vector>(),
-        {});
-
-    // Note that the equality operator is preferred in here, otherwise vkUpdateDescriptorSets will be called with zero
-    // descriptorWrites, which still has the driver function calling overhead.
-    if (assetTextureDescriptorSets.size() <= sharedData.gltfAsset->textures.descriptorInfos.size()) {
-        const std::span remainingDescriptorInfos
-            = std::span { sharedData.gltfAsset->textures.descriptorInfos }
-            .subspan(assetTextureDescriptorSets.size());
-        assetTextureDescriptorSets.append_range(
-            remainingDescriptorInfos
-                | std::views::transform([](const vk::DescriptorImageInfo &descriptorInfo) {
-                    return reinterpret_cast<ImTextureID>(ImGui_ImplVulkan_AddTexture(
-                        descriptorInfo.sampler, descriptorInfo.imageView, static_cast<VkImageLayout>(descriptorInfo.imageLayout)));
-                }));
+    for (ImTextureID descriptorSet : assetTextureDescriptorSets) {
+        ImGui_ImplVulkan_RemoveTexture(reinterpret_cast<vk::DescriptorSet::CType>(descriptorSet));
     }
-    else {
-        // Fill the remaining descriptor sets with the fallback texture.
-        const std::span remainingDescriptorSets
-            = std::span { assetTextureDescriptorSets }
-            .subspan(sharedData.gltfAsset->textures.descriptorInfos.size());
-        const vk::DescriptorImageInfo fallbackTextureDescriptorInfo {
-            *sharedData.fallbackTexture.sampler,
-            *sharedData.fallbackTexture.imageView,
-            vk::ImageLayout::eShaderReadOnlyOptimal,
-        };
-        gpu.device.updateDescriptorSets(
-            remainingDescriptorSets
-                | std::views::transform([&](ImTextureID imGuiTexture) {
-                    return vk::WriteDescriptorSet {
-                        reinterpret_cast<vk::DescriptorSet::CType>(imGuiTexture),
-                        0,
-                        0,
-                        vk::DescriptorType::eCombinedImageSampler,
-                        fallbackTextureDescriptorInfo,
-                    };
-                })
-                | std::ranges::to<std::vector>(),
-            {});
-
-        // Resize assetTextureDescriptorSets to the actual asset texture count.
-        assetTextureDescriptorSets.resize(sharedData.gltfAsset->textures.descriptorInfos.size());
-    }
+    assetTextureDescriptorSets.clear();
+    assetTextureDescriptorSets.append_range(
+        sharedData.gltfAsset->textures.descriptorInfos
+        | std::views::transform([](const vk::DescriptorImageInfo &descriptorInfo) -> ImTextureID {
+            return reinterpret_cast<ImTextureID>(ImGui_ImplVulkan_AddTexture(
+                descriptorInfo.sampler, descriptorInfo.imageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
+        }));
 
     // Change window title.
     window.setTitle(PATH_C_STR(path.filename()));

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -103,6 +103,8 @@ namespace vk_gltf_viewer {
             vku::AllocatedImage cubemapImage;
             vk::raii::ImageView cubemapImageView;
             vk::DescriptorSet imGuiEqmapTextureDescriptorSet;
+
+            ~SkyboxResources();
         };
 
         struct ImageBasedLightingResources {
@@ -142,12 +144,6 @@ namespace vk_gltf_viewer {
         vku::AllocatedImage brdfmapImage = createBrdfmapImage();
         vk::raii::ImageView brdfmapImageView { gpu.device, brdfmapImage.getViewCreateInfo() };
         vk::raii::Sampler reducedEqmapSampler = createEqmapSampler();
-
-        // --------------------
-        // Descriptor sets.
-        // --------------------
-
-        std::vector<ImTextureID> assetTextureDescriptorSets;
 
         // --------------------
         // Frames.

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -19,7 +19,6 @@ namespace vk_gltf_viewer {
     export class MainApp {
     public:
         explicit MainApp();
-        ~MainApp();
 
         void run();
 
@@ -34,6 +33,11 @@ namespace vk_gltf_viewer {
             | fastgltf::Extensions::KHR_texture_transform
             | fastgltf::Extensions::EXT_mesh_gpu_instancing;
         static constexpr std::uint32_t FRAMES_IN_FLIGHT = 2;
+
+        struct ImGuiContext {
+            ImGuiContext(const control::AppWindow &window, vk::Instance instance, const vulkan::Gpu &gpu);
+            ~ImGuiContext();
+        };
 
         /**
          * @brief Bundle of glTF asset and additional resources necessary for the rendering.
@@ -119,6 +123,8 @@ namespace vk_gltf_viewer {
         vk::raii::Instance instance = createInstance();
         control::AppWindow window { instance, appState };
         vulkan::Gpu gpu { instance, window.getSurface() };
+
+        ImGuiContext imGuiContext { window, *instance, gpu };
 
         // --------------------
         // Vulkan swapchain.

--- a/overlays/imgui/portfile.cmake
+++ b/overlays/imgui/portfile.cmake
@@ -7,7 +7,7 @@ if ("docking-experimental" IN_LIST FEATURES)
         REF "v${VERSION}-docking"
         SHA512 8c43016957a4811922e2bbf9108eecb0c94944e34b357087b8c989eb8c1155483eeb84af6b5291b3512fcd1bfe3e1a2bc04870594e7e9f4e28b0629e3eecbf25
         HEAD_REF docking
-        PATCHES draw-tree-lines.patch
+        PATCHES draw-tree-lines.patch use-fallback-texture.patch
     )
 else()
     vcpkg_from_github(
@@ -16,7 +16,7 @@ else()
         REF "v${VERSION}"
         SHA512 421aa81b55a85a8c4ea21d1b352e41e916b9e0f3ccfee3dcf415fc69c49a5feffc742c991fe10a19725a3766c92ebc5bff1027d6278ae7b8f1861474e891d6e6
         HEAD_REF master
-        PATCHES draw-tree-lines.patch
+        PATCHES draw-tree-lines.patch use-fallback-texture.patch
     )
 endif()
 

--- a/overlays/imgui/use-fallback-texture.patch
+++ b/overlays/imgui/use-fallback-texture.patch
@@ -1,0 +1,60 @@
+diff --git a/backends/imgui_impl_vulkan.cpp b/backends/imgui_impl_vulkan.cpp
+index 2bd40f6..5a39244 100644
+--- a/backends/imgui_impl_vulkan.cpp
++++ b/backends/imgui_impl_vulkan.cpp
+@@ -86,6 +86,8 @@
+ #ifndef IMGUI_DISABLE
+ #include "imgui_impl_vulkan.h"
+ #include <stdio.h>
++#include <memory>
++#include <unordered_set>
+ #ifndef IM_MAX
+ #define IM_MAX(A, B)    (((A) >= (B)) ? (A) : (B))
+ #endif
+@@ -248,6 +250,8 @@ struct ImGui_ImplVulkan_Data
+     VkCommandPool               TexCommandPool;
+     VkCommandBuffer             TexCommandBuffer;
+ 
++    std::unique_ptr<std::unordered_set<VkDescriptorSet>> allocatedTextures;
++
+     // Render buffers for main window
+     ImGui_ImplVulkan_WindowRenderBuffers MainWindowRenderBuffers;
+ 
+@@ -608,6 +612,9 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
+ 
+                 // Bind DescriptorSet with font or user texture
+                 VkDescriptorSet desc_set = (VkDescriptorSet)pcmd->GetTexID();
++                if (bd->allocatedTextures->find(desc_set) == bd->allocatedTextures->end()) {
++                    desc_set = bd->FontTexture.DescriptorSet;
++                }
+                 vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, bd->PipelineLayout, 0, 1, &desc_set, 0, nullptr);
+ 
+                 // Draw
+@@ -1154,6 +1161,8 @@ bool    ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info)
+     if (info->UseDynamicRendering == false)
+         IM_ASSERT(info->RenderPass != VK_NULL_HANDLE);
+ 
++    bd->allocatedTextures = std::unique_ptr<std::unordered_set<VkDescriptorSet>> { new std::unordered_set<VkDescriptorSet>{} };
++
+     bd->VulkanInitInfo = *info;
+ 
+     ImGui_ImplVulkan_CreateDeviceObjects();
+@@ -1231,6 +1240,9 @@ VkDescriptorSet ImGui_ImplVulkan_AddTexture(VkSampler sampler, VkImageView image
+         write_desc[0].pImageInfo = desc_image;
+         vkUpdateDescriptorSets(v->Device, 1, write_desc, 0, nullptr);
+     }
++
++    bd->allocatedTextures->emplace(descriptor_set);
++
+     return descriptor_set;
+ }
+ 
+@@ -1240,6 +1252,8 @@ void ImGui_ImplVulkan_RemoveTexture(VkDescriptorSet descriptor_set)
+     ImGui_ImplVulkan_InitInfo* v = &bd->VulkanInitInfo;
+     VkDescriptorPool pool = bd->DescriptorPool ? bd->DescriptorPool : v->DescriptorPool;
+     vkFreeDescriptorSets(v->Device, pool, 1, &descriptor_set);
++
++    bd->allocatedTextures->erase(descriptor_set);
+ }
+ 
+ void ImGui_ImplVulkan_DestroyFrameRenderBuffers(VkDevice device, ImGui_ImplVulkan_FrameRenderBuffers* buffers, const VkAllocationCallbacks* allocator)


### PR DESCRIPTION
This PR tweaks the ImGui's internal Vulkan backend by tracking the allocated/destroyed descriptor sets using `std::unordered_set<VkDescriptorSet>`, and checking their validity when executing `ImGui_ImplVulkan_RenderDrawData()`. This can simplify the ImGui texture descriptor set lifetime management by:

- asset ImGui texture descriptor set lifetime doesn't have to be retained using std::vector::resize() trick,
- therefore it can be inside the belonging structure `SharedData::GltfAsset` and can be managed by RAII allocation/destroying (and so do the skybox descriptor set).

To ensure the allocated ImGui texture descriptor set is destroyed before `ImGui_ImplVulkan_Shutdown()` call, ImGui context creation/destroying is reimplemented by RAII structure `ImGuiContext` in `MainApp`.