### PR TITLE
Several bug fixes.

### DIFF
--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -50,7 +50,6 @@ import :vulkan.Frame;
 import :vulkan.mipmap;
 import :vulkan.pipeline.CubemapToneMappingRenderer;
 
-#define MOVE_CAP(x) x = std::move(x)
 #ifdef _WIN32
 #define PATH_C_STR(...) (__VA_ARGS__).string().c_str()
 #else

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -35,6 +35,7 @@ import ibl;
 import imgui.glfw;
 import imgui.vulkan;
 import :control.AppWindow;
+import :gltf.algorithm.miniball;
 import :gltf.algorithm.misc;
 import :gltf.Animation;
 import :gltf.AssetExternalBuffers;

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -50,6 +50,8 @@ import :vulkan.Frame;
 import :vulkan.mipmap;
 import :vulkan.pipeline.CubemapToneMappingRenderer;
 
+#define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+#define LIFT(...) [&](auto &&...xs) { return __VA_ARGS__(FWD(xs)...); }
 #ifdef _WIN32
 #define PATH_C_STR(...) (__VA_ARGS__).string().c_str()
 #else
@@ -285,7 +287,7 @@ void vk_gltf_viewer::MainApp::run() {
                                 [&](auto i) -> decltype(auto) { return gltf->asset.nodes[i].children; },
                                 task.nodeIndex, visibilities);
                             tristate::propagateBottomUp(
-                                [&](auto i) { return gltf->sceneInverseHierarchy.getParentNodeIndex(i).value_or(i); },
+                                LIFT(gltf->sceneInverseHierarchy.parentNodeIndices.operator[]),
                                 [&](auto i) -> decltype(auto) { return gltf->asset.nodes[i].children; },
                                 task.nodeIndex, visibilities);
                         },
@@ -310,7 +312,7 @@ void vk_gltf_viewer::MainApp::run() {
                 },
                 [&](const control::task::ChangeNodeLocalTransform &task) {
                     fastgltf::math::fmat4x4 baseMatrix { 1.f };
-                    if (auto parentNodeIndex = gltf->sceneInverseHierarchy.getParentNodeIndex(task.nodeIndex)) {
+                    if (const auto &parentNodeIndex = gltf->sceneInverseHierarchy.parentNodeIndices[task.nodeIndex]) {
                         baseMatrix = gltf->nodeWorldTransforms[*parentNodeIndex];
                     }
                     const fastgltf::math::fmat4x4 nodeWorldTransform = fastgltf::getTransformMatrix(gltf->asset.nodes[task.nodeIndex], baseMatrix);
@@ -359,7 +361,7 @@ void vk_gltf_viewer::MainApp::run() {
 
                     visit(fastgltf::visitor {
                         [&](fastgltf::math::fmat4x4 &transformMatrix) {
-                            if (auto parentNodeIndex = gltf->sceneInverseHierarchy.getParentNodeIndex(selectedNodeIndex)) {
+                            if (const auto &parentNodeIndex = gltf->sceneInverseHierarchy.parentNodeIndices[selectedNodeIndex]) {
                                 transformMatrix = affineInverse(gltf->nodeWorldTransforms[*parentNodeIndex]) * selectedNodeWorldTransform;
                             }
                             else {
@@ -367,7 +369,7 @@ void vk_gltf_viewer::MainApp::run() {
                             }
                         },
                         [&](fastgltf::TRS &trs) {
-                            if (auto parentNodeIndex = gltf->sceneInverseHierarchy.getParentNodeIndex(selectedNodeIndex)) {
+                            if (const auto &parentNodeIndex = gltf->sceneInverseHierarchy.parentNodeIndices[selectedNodeIndex]) {
                                 const fastgltf::math::fmat4x4 transformMatrix = affineInverse(gltf->nodeWorldTransforms[*parentNodeIndex]) * selectedNodeWorldTransform;
                                 decomposeTransformMatrix(transformMatrix, trs.scale, trs.rotation, trs.translation);
                             }

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -721,8 +721,8 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                             return { OcclusionTextureTransformEnabled, OcclusionTextureTransform };
                         case MaterialProperty::Emissive:
                             return { EmissiveTextureTransformEnabled, EmissiveTextureTransform };
-                        std::unreachable();
                     }
+                    std::unreachable();
                 }();
 
                 bool useTextureTransform = textureInfo.transform != nullptr;

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -366,9 +366,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::assetTextures(
             ImGui::WithGroup([&]() {
                 fastgltf::Texture &texture = asset.textures[*textureIndex];
                 ImGui::InputTextWithHint("Name", "<empty>", &texture.name);
-                ImGui::LabelText("Image Index", "%zu",
-                    // TODO: same code in gltf::AssetGpuTextures.
-                    to_optional(texture.basisuImageIndex).or_else([&]() { return to_optional(texture.imageIndex); }).value());
+                ImGui::LabelText("Image Index", "%zu", getPreferredImageIndex(texture));
                 if (texture.samplerIndex) {
                     ImGui::LabelText("Sampler Index", "%zu", texture.samplerIndex.value_or(-1));
                 }

--- a/interface/AppState.cppm
+++ b/interface/AppState.cppm
@@ -85,7 +85,7 @@ namespace vk_gltf_viewer {
                         return tristateVisibilities
                             | ranges::views::enumerate
                             | std::views::filter(decomposer([this](auto nodeIndex, std::optional<bool> visibility) {
-                                return visibility.value_or(false) && asset.nodes[nodeIndex].meshIndex.has_value();
+                                return visibility.value_or(true) && asset.nodes[nodeIndex].meshIndex.has_value();
                             }))
                             | std::views::keys
                             | std::views::transform([](auto nodeIndex) { return static_cast<std::uint16_t>(nodeIndex); })

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -2,7 +2,6 @@ export module vk_gltf_viewer:MainApp;
 
 import std;
 import :control.AppWindow;
-import :gltf.algorithm.miniball;
 import :gltf.Animation;
 import :gltf.AssetExternalBuffers;
 import :gltf.data_structure.MaterialVariantsMapping;

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -64,7 +64,7 @@ namespace vk_gltf_viewer {
              */
             gltf::ds::MaterialVariantsMapping materialVariantsMapping { asset };
 
-            gltf::TextureUsage textureUsage { asset, fastgltf::getPreferredImageIndex };
+            gltf::TextureUsage textureUsage { asset };
 
             /**
 			 * @brief External buffers that are not embedded in the glTF file, such like .bin files.

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -4,7 +4,7 @@ import std;
 export import imgui.internal;
 
 namespace vk_gltf_viewer::control {
-    namespace task {
+    export namespace task {
         struct ChangePassthruRect { ImRect newRect; };
         struct LoadGltf { std::filesystem::path path; };
         struct CloseGltf { };

--- a/interface/gltf/TextureUsage.cppm
+++ b/interface/gltf/TextureUsage.cppm
@@ -17,28 +17,23 @@ namespace vk_gltf_viewer::gltf {
             Emissive = 16,
         };
 
-        TextureUsage(const fastgltf::Asset &asset, std::invocable<const fastgltf::Texture&> auto const &textureIndexGetter)
+        explicit TextureUsage(const fastgltf::Asset &asset)
             : usages { asset.textures.size() } {
             for (const auto &[i, material] : asset.materials | ranges::views::enumerate) {
                 if (material.pbrData.baseColorTexture) {
-                    const fastgltf::Texture &texture = asset.textures[material.pbrData.baseColorTexture->textureIndex];
-                    usages[textureIndexGetter(texture)][i] |= Type::BaseColor;
+                    usages[material.pbrData.baseColorTexture->textureIndex][i] |= Type::BaseColor;
                 }
                 if (material.pbrData.metallicRoughnessTexture) {
-                    const fastgltf::Texture &texture = asset.textures[material.pbrData.metallicRoughnessTexture->textureIndex];
-                    usages[textureIndexGetter(texture)][i] |= Type::MetallicRoughness;
+                    usages[material.pbrData.metallicRoughnessTexture->textureIndex][i] |= Type::MetallicRoughness;
                 }
                 if (material.normalTexture) {
-                    const fastgltf::Texture &texture = asset.textures[material.normalTexture->textureIndex];
-                    usages[textureIndexGetter(texture)][i] |= Type::Normal;
+                    usages[material.normalTexture->textureIndex][i] |= Type::Normal;
                 }
                 if (material.occlusionTexture) {
-                    const fastgltf::Texture &texture = asset.textures[material.occlusionTexture->textureIndex];
-                    usages[textureIndexGetter(texture)][i] |= Type::Occlusion;
+                    usages[material.occlusionTexture->textureIndex][i] |= Type::Occlusion;
                 }
                 if (material.emissiveTexture) {
-                    const fastgltf::Texture &texture = asset.textures[material.emissiveTexture->textureIndex];
-                    usages[textureIndexGetter(texture)][i] |= Type::Emissive;
+                    usages[material.emissiveTexture->textureIndex][i] |= Type::Emissive;
                 }
             }
         }

--- a/interface/gltf/TextureUsage.cppm
+++ b/interface/gltf/TextureUsage.cppm
@@ -3,11 +3,11 @@ export module vk_gltf_viewer:gltf.TextureUsage;
 import std;
 export import cstring_view;
 export import fastgltf;
-import :helpers.enums.Flags;
+export import :helpers.enums.Flags;
 import :helpers.ranges;
 
 namespace vk_gltf_viewer::gltf {
-    class TextureUsage {
+    export class TextureUsage {
     public:
         enum class Type : std::uint8_t {
             BaseColor = 1,

--- a/interface/gltf/algorithm/miniball.cppm
+++ b/interface/gltf/algorithm/miniball.cppm
@@ -25,7 +25,7 @@ namespace vk_gltf_viewer::gltf::algorithm {
      * @param nodeWorldTransforms Pre-calculated world transforms for each node in the scene.
      * @return The pair of the miniball's center and radius.
      */
-    template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
+    export template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
     [[nodiscard]] std::pair<fastgltf::math::dvec3, double> getMiniball(
         const fastgltf::Asset &asset,
         const fastgltf::Scene &scene,

--- a/interface/gltf/data_structure/MaterialVariantsMapping.cppm
+++ b/interface/gltf/data_structure/MaterialVariantsMapping.cppm
@@ -14,7 +14,7 @@ namespace vk_gltf_viewer::gltf::ds {
      *
      * KHR_materials_variants extension defines the material variants for each primitive. For each variant index, you can call `at` to get the list of primitives and their material indices that use the corresponding material variant.
      */
-    struct MaterialVariantsMapping : std::unordered_map<std::size_t, std::vector<std::pair<fastgltf::Primitive*, std::size_t>>> {
+    export struct MaterialVariantsMapping : std::unordered_map<std::size_t, std::vector<std::pair<fastgltf::Primitive*, std::size_t>>> {
         explicit MaterialVariantsMapping(fastgltf::Asset &asset LIFETIMEBOUND) noexcept {
             for (fastgltf::Mesh &mesh : asset.meshes) {
                 for (fastgltf::Primitive &primitive : mesh.primitives) {

--- a/interface/gltf/data_structure/SceneInverseHierarchy.cppm
+++ b/interface/gltf/data_structure/SceneInverseHierarchy.cppm
@@ -13,34 +13,22 @@ namespace vk_gltf_viewer::gltf::ds {
     /**
      * @brief Cached data structure of every node's parent node index in a scene.
      */
-    export class SceneInverseHierarchy {
+    export struct SceneInverseHierarchy {
         /**
-         * @brief Index of the parent node for each node. If the node is root node, the value is as same as the node index.
-         *
-         * You should use getParentNodeIndex() method to get the parent node index with proper root node handling.
+         * @brief Index of the parent node for each node. If the node is root node, <tt>std::nullopt</tt> will be used.
          */
-        std::vector<std::size_t> parentNodeIndices;
+        std::vector<std::optional<std::size_t>> parentNodeIndices;
 
-    public:
         SceneInverseHierarchy(
             const fastgltf::Asset &asset LIFETIMEBOUND,
             const fastgltf::Scene &scene
-        ) : parentNodeIndices { std::vector<std::size_t>(asset.nodes.size()) } {
+        ) {
+            parentNodeIndices.resize(asset.nodes.size());
             algorithm::traverseScene(asset, scene, [&](std::size_t nodeIndex) {
                 for (std::size_t childIndex : asset.nodes[nodeIndex].children) {
-                    parentNodeIndices[childIndex] = nodeIndex;
+                    parentNodeIndices[childIndex].emplace(nodeIndex);
                 }
             });
-        }
-
-        /**
-         * @brief Get parent node index from current node index.
-         * @param nodeIndex Index of the node.
-         * @return Index of the parent node if the current node is not root node, otherwise <tt>std::nullopt</tt>.
-         */
-        [[nodiscard]] std::optional<std::size_t> getParentNodeIndex(std::size_t nodeIndex) const noexcept {
-            const std::size_t parentNodeIndex = parentNodeIndices[nodeIndex];
-            return value_if(parentNodeIndex != nodeIndex, parentNodeIndex);
         }
     };
 }

--- a/interface/helpers/enums/FlagTraits.cppm
+++ b/interface/helpers/enums/FlagTraits.cppm
@@ -1,6 +1,6 @@
 export module vk_gltf_viewer:helpers.enums.FlagTraits;
 
-template <typename>
+export template <typename>
 struct FlagTraits {
     static constexpr bool isBitmask = false;
 };

--- a/interface/helpers/fastgltf.cppm
+++ b/interface/helpers/fastgltf.cppm
@@ -3,7 +3,7 @@ export module vk_gltf_viewer:helpers.fastgltf;
 import std;
 export import cstring_view;
 export import fastgltf;
-export import :helpers.optional;
+import :helpers.optional;
 import :helpers.type_map;
 
 #define INDEX_SEQ(Is, N, ...) [&]<std::size_t ...Is>(std::index_sequence<Is...>) __VA_ARGS__ (std::make_index_sequence<N>{})

--- a/interface/helpers/ranges/mod.cppm
+++ b/interface/helpers/ranges/mod.cppm
@@ -11,7 +11,6 @@ import std;
 import :helpers.concepts;
 
 #define INDEX_SEQ(Is, N, ...) [&]<std::size_t ...Is>(std::index_sequence<Is...>) __VA_ARGS__ (std::make_index_sequence<N>{})
-#define ARRAY_OF(N, ...) INDEX_SEQ(Is, N, { return std::array { ((void)Is, __VA_ARGS__)... }; })
 #define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 #define NOEXCEPT_IF(...) noexcept(noexcept(__VA_ARGS__))
 

--- a/interface/helpers/tristate.cppm
+++ b/interface/helpers/tristate.cppm
@@ -5,6 +5,7 @@ module;
 export module vk_gltf_viewer:helpers.tristate;
 
 import std;
+import :helpers.concepts;
 
 #define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 
@@ -32,7 +33,7 @@ namespace tristate {
 
     /**
      * Propagate the current node (in \p nodeIndex) state to all its ancestors.
-     * @param parentIndexGetter A function that returns the parent index of a node with the given index. If the current node is a root node, it should return the current node index.
+     * @param parentIndexGetter A function that returns the parent index of a node with the given index. If the current node is a root node, it must return <tt>std::nullopt</tt>.
      * @param childrenIndicesGetter A function that returns the children indices of a node with the given index.
      * @param nodeIndex Current node index.
      * @param tristates Tri-state values of all nodes. Indeterminate state is represented by <tt>std::nullopt</tt>.
@@ -43,13 +44,13 @@ namespace tristate {
      *   - Otherwise, the parent node state is indeterminate.
      */
     export auto propagateBottomUp(
-        std::invocable<std::size_t> auto &&parentIndexGetter,
+        concepts::compatible_signature_of<std::optional<std::size_t>, std::size_t> auto &&parentIndexGetter,
         std::invocable<std::size_t> auto &&childrenIndicesGetter,
         std::size_t nodeIndex,
         std::span<std::optional<bool>> tristates
     ) -> void {
-        const std::size_t parentNodeIndex = parentIndexGetter(nodeIndex);
-        if (nodeIndex == parentNodeIndex) {
+        std::optional<std::size_t> parentNodeIndex = parentIndexGetter(nodeIndex);
+        if (!parentNodeIndex) {
             // Current node is a root node.
             return;
         }
@@ -58,24 +59,24 @@ namespace tristate {
         if (!currentState) {
             // If current node state is indeterminate, so do all its ancestors.
             do {
-                tristates[nodeIndex = parentIndexGetter(nodeIndex)].reset();
-            } while (nodeIndex != parentIndexGetter(nodeIndex));
+                tristates[*parentNodeIndex].reset();
+            } while ((parentNodeIndex = parentIndexGetter(*parentNodeIndex)));
             return;
         }
 
-        const auto &siblingIndices = childrenIndicesGetter(parentNodeIndex);
+        const auto &siblingIndices = childrenIndicesGetter(*parentNodeIndex);
         const bool isSiblingStatesEqual = std::ranges::adjacent_find(
             siblingIndices, std::ranges::not_equal_to{},
             [=](auto siblingIndex) { return tristates[siblingIndex]; }) == siblingIndices.end();
         if (isSiblingStatesEqual) {
             // If all siblings have the same state, parent node should have the same state (regardless of on/off).
-            tristates[parentNodeIndex] = currentState;
+            tristates[*parentNodeIndex].emplace(*currentState);
         }
         else {
             // Otherwise, parent node state is indeterminate.
-            tristates[parentNodeIndex].reset();
+            tristates[*parentNodeIndex].reset();
         }
 
-        propagateBottomUp(FWD(parentIndexGetter), FWD(childrenIndicesGetter), parentNodeIndex, tristates);
+        propagateBottomUp(FWD(parentIndexGetter), FWD(childrenIndicesGetter), *parentNodeIndex, tristates);
     }
 }

--- a/interface/math/Frustum.cppm
+++ b/interface/math/Frustum.cppm
@@ -7,7 +7,7 @@ namespace vk_gltf_viewer::math {
     /**
      * @brief Frustum in the 3-dimensional space.
      */
-    struct Frustum {
+    export struct Frustum {
         /**
          * @brief Planes of the frustum.
          *

--- a/interface/math/Plane.cppm
+++ b/interface/math/Plane.cppm
@@ -12,7 +12,7 @@ namespace vk_gltf_viewer::math {
     /**
      * @brief Plane in the 3-dimensional space.
      */
-    struct Plane {
+    export struct Plane {
         /**
          * @brief Normal vector of the plane.
          */

--- a/interface/shader_selector/primitive_frag.cppm
+++ b/interface/shader_selector/primitive_frag.cppm
@@ -5,6 +5,7 @@ import :shader.primitive_frag;
 import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
+    export
     [[nodiscard]] std::span<const unsigned int> primitive_frag(int TEXCOORD_COUNT, int HAS_COLOR_ATTRIBUTE, int FRAGMENT_SHADER_GENERATED_TBN, int ALPHA_MODE) {
         constexpr iota_map<5> texcoordCountMap;
         constexpr iota_map<2> hasColorAttributeMap;

--- a/interface/shader_selector/primitive_vert.cppm
+++ b/interface/shader_selector/primitive_vert.cppm
@@ -5,6 +5,7 @@ import :shader.primitive_vert;
 import :helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
+    export
     [[nodiscard]] std::span<const unsigned int> primitive_vert(int TEXCOORD_COUNT, int HAS_COLOR_ATTRIBUTE, int FRAGMENT_SHADER_GENERATED_TBN) {
         constexpr iota_map<5> texcoordCountMap;
         constexpr iota_map<2> hasColorAttributeMap;

--- a/interface/vulkan/buffer/StagingBufferStorage.cppm
+++ b/interface/vulkan/buffer/StagingBufferStorage.cppm
@@ -9,7 +9,7 @@ import std;
 export import vku;
 
 namespace vk_gltf_viewer::vulkan::buffer {
-    class StagingBufferStorage {
+    export class StagingBufferStorage {
     public:
         /**
          * @brief Assign the device local buffer to the \p buffer and add staging task to the storage.

--- a/interface/vulkan/buffer/mod.cppm
+++ b/interface/vulkan/buffer/mod.cppm
@@ -23,7 +23,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
      * @param usage Usage flags of the result buffer.
      * @return Pair of buffer and each segments' start offsets vector.
      */
-    template <bool Unmap = false, std::ranges::forward_range R> requires (
+    export template <bool Unmap = false, std::ranges::forward_range R> requires (
         // Each segments must be a sized range.
         std::ranges::sized_range<std::ranges::range_value_t<R>>
         // Each segments must be either

--- a/interface/vulkan/pipeline/DepthRenderer.cppm
+++ b/interface/vulkan/pipeline/DepthRenderer.cppm
@@ -86,7 +86,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         }
     };
 
-    class MaskDepthRendererSpecialization {
+    export class MaskDepthRendererSpecialization {
     public:
         TopologyClass topologyClass;
         std::uint8_t positionComponentType;

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -86,7 +86,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         }
     };
 
-    class MaskJumpFloodSeedRendererSpecialization {
+    export class MaskJumpFloodSeedRendererSpecialization {
     public:
         TopologyClass topologyClass;
         std::uint8_t positionComponentType;

--- a/interface/vulkan/trait/PostTransferObject.cppm
+++ b/interface/vulkan/trait/PostTransferObject.cppm
@@ -4,7 +4,7 @@ import std;
 export import :vulkan.buffer.StagingBufferStorage;
 
 namespace vk_gltf_viewer::vulkan::trait {
-    struct PostTransferObject {
+    export struct PostTransferObject {
         std::reference_wrapper<buffer::StagingBufferStorage> stagingBufferStorage;
     };
 }


### PR DESCRIPTION
- `gltf::TextureUsage` indexed by texture index, but image index was used. Fixed and now its constructor doesn't requires texture index -> image index conversion functor.
- `gltf::SceneInverseHierarchy` zero-initialized the parent node indices and assumed a node is a root node if its node index is equal to the parent, therefore zero node is always regarded to a root node, and toggling node visibility always toggle the zero node visibility. Fixed by using `std::nullopt` for root node to distinguish it.
- Fix bug that indeterminate visibility node is not shown.
- Fix bug that toggling node visibility type generates wrong data.
- Missing exports and minor fixes. 