### PR TITLE
Correct the color of showing glTF asset textures.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/helpers/type_map.cppm
         interface/helpers/type_variant.cppm
         interface/helpers/vulkan.cppm
+        interface/imgui/ColorSpaceAndUsageCorrectedTextures.cppm
         interface/MainApp.cppm
         interface/math/extended_arithmetic.cppm
         interface/math/Frustum.cppm
@@ -231,6 +232,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/SharedData.cppm
         interface/vulkan/specialization_constants/SpecializationMap.cppm
         interface/vulkan/texture/Fallback.cppm
+        interface/vulkan/texture/ImGuiColorSpaceAndUsageCorrectedTextures.cppm
         interface/vulkan/texture/Textures.cppm
         interface/vulkan/trait/PostTransferObject.cppm
 )

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -43,7 +43,6 @@ import :helpers.fastgltf;
 import :helpers.functional;
 import :helpers.optional;
 import :helpers.ranges;
-import :helpers.span;
 import :helpers.tristate;
 import :imgui.TaskCollector;
 import :vulkan.Frame;
@@ -192,8 +191,8 @@ void vk_gltf_viewer::MainApp::run() {
             imguiTaskCollector.menuBar(appState.getRecentGltfPaths(), appState.getRecentSkyboxPaths(), windowHandle);
             if (auto &gltfAsset = appState.gltfAsset) {
                 imguiTaskCollector.assetInspector(gltfAsset->asset, gltf->directory);
-                imguiTaskCollector.assetTextures(gltfAsset->asset, reinterpret_span<ImTextureID>(std::span { sharedData.gltfAsset->imGuiTextureDescriptorSets }), gltf->textureUsage);
-                imguiTaskCollector.materialEditor(gltfAsset->asset, reinterpret_span<ImTextureID>(std::span { sharedData.gltfAsset->imGuiTextureDescriptorSets }));
+                imguiTaskCollector.assetTextures(gltfAsset->asset, sharedData.gltfAsset->imGuiColorSpaceAndUsageCorrectedTextures, gltf->textureUsage);
+                imguiTaskCollector.materialEditor(gltfAsset->asset, sharedData.gltfAsset->imGuiColorSpaceAndUsageCorrectedTextures);
                 if (!gltfAsset->asset.materialVariants.empty()) {
                     imguiTaskCollector.materialVariants(gltfAsset->asset);
                 }

--- a/interface/control/ImGuiTaskCollector.cppm
+++ b/interface/control/ImGuiTaskCollector.cppm
@@ -12,6 +12,7 @@ export import :AppState;
 export import :control.Task;
 export import :gltf.TextureUsage;
 export import :helpers.full_optional;
+export import :imgui.ColorSpaceAndUsageCorrectedTextures;
 
 namespace vk_gltf_viewer::control {
     export class ImGuiTaskCollector {
@@ -24,8 +25,8 @@ namespace vk_gltf_viewer::control {
         void menuBar(const std::list<std::filesystem::path> &recentGltfs, const std::list<std::filesystem::path> &recentSkyboxes, nfdwindowhandle_t windowHandle);
         void animations(const fastgltf::Asset &asset, std::vector<bool> &animationEnabled);
         void assetInspector(fastgltf::Asset &asset, const std::filesystem::path &assetDir);
-        void assetTextures(fastgltf::Asset &asset, std::span<const ImTextureID> assetTextureImGuiDescriptorSets, const gltf::TextureUsage &textureUsage);
-        void materialEditor(fastgltf::Asset &asset, std::span<const ImTextureID> assetTextureImGuiDescriptorSets);
+        void assetTextures(fastgltf::Asset &asset, const imgui::ColorSpaceAndUsageCorrectedTextures &imGuiTextures, const gltf::TextureUsage &textureUsage);
+        void materialEditor(fastgltf::Asset &asset, const imgui::ColorSpaceAndUsageCorrectedTextures &imGuiTextures);
         void materialVariants(const fastgltf::Asset &asset);
         void sceneHierarchy(fastgltf::Asset &asset, std::size_t sceneIndex, std::variant<std::vector<std::optional<bool>>, std::vector<bool>> &visibilities, const std::optional<std::uint16_t> &hoveringNodeIndex, const std::unordered_set<std::uint16_t> &selectedNodeIndices);
         void nodeInspector(fastgltf::Asset &asset, const std::unordered_set<std::uint16_t> &selectedNodeIndices);

--- a/interface/helpers/vulkan.cppm
+++ b/interface/helpers/vulkan.cppm
@@ -2,6 +2,7 @@ export module vk_gltf_viewer:helpers.vulkan;
 
 import std;
 export import vulkan_hpp;
+import :helpers.ranges;
 
 export enum class TopologyClass : std::uint8_t {
     Point,
@@ -65,4 +66,77 @@ export
         return vk::PrimitiveTopology::ePatchList;
     }
     std::unreachable();
+}
+
+/**
+ * @brief Convert sRGB format to linear format, or vice versa.
+ * @param format Format to convert. Must have the corresponding sRGB toggled format.
+ * @return Corresponding sRGB toggled format.
+ * @throw std::invalid_argument If the given format does not have the corresponding sRGB toggled format.
+ */
+export
+[[nodiscard]] vk::Format convertSrgb(vk::Format format) {
+    switch (format) {
+        #define BIMAP(x, y) \
+            case vk::Format::x: return vk::Format::y; \
+            case vk::Format::y: return vk::Format::x
+        BIMAP(eR8Unorm, eR8Srgb);
+        BIMAP(eR8G8Unorm, eR8G8Srgb);
+        BIMAP(eR8G8B8Unorm, eR8G8B8Srgb);
+        BIMAP(eB8G8R8Unorm, eB8G8R8Srgb);
+        BIMAP(eR8G8B8A8Unorm, eR8G8B8A8Srgb);
+        BIMAP(eB8G8R8A8Unorm, eB8G8R8A8Srgb);
+        BIMAP(eA8B8G8R8UnormPack32, eA8B8G8R8SrgbPack32);
+        BIMAP(eBc1RgbUnormBlock, eBc1RgbSrgbBlock);
+        BIMAP(eBc1RgbaUnormBlock, eBc1RgbaSrgbBlock);
+        BIMAP(eBc2UnormBlock, eBc2SrgbBlock);
+        BIMAP(eBc3UnormBlock, eBc3SrgbBlock);
+        BIMAP(eBc7UnormBlock, eBc7SrgbBlock);
+        BIMAP(eEtc2R8G8B8UnormBlock, eEtc2R8G8B8SrgbBlock);
+        BIMAP(eEtc2R8G8B8A1UnormBlock, eEtc2R8G8B8A1SrgbBlock);
+        BIMAP(eEtc2R8G8B8A8UnormBlock, eEtc2R8G8B8A8SrgbBlock);
+        BIMAP(eAstc4x4UnormBlock, eAstc4x4SrgbBlock);
+        BIMAP(eAstc5x4UnormBlock, eAstc5x4SrgbBlock);
+        BIMAP(eAstc5x5UnormBlock, eAstc5x5SrgbBlock);
+        BIMAP(eAstc6x5UnormBlock, eAstc6x5SrgbBlock);
+        BIMAP(eAstc6x6UnormBlock, eAstc6x6SrgbBlock);
+        BIMAP(eAstc8x5UnormBlock, eAstc8x5SrgbBlock);
+        BIMAP(eAstc8x6UnormBlock, eAstc8x6SrgbBlock);
+        BIMAP(eAstc8x8UnormBlock, eAstc8x8SrgbBlock);
+        BIMAP(eAstc10x5UnormBlock, eAstc10x5SrgbBlock);
+        BIMAP(eAstc10x6UnormBlock, eAstc10x6SrgbBlock);
+        BIMAP(eAstc10x8UnormBlock, eAstc10x8SrgbBlock);
+        BIMAP(eAstc10x10UnormBlock, eAstc10x10SrgbBlock);
+        BIMAP(eAstc12x10UnormBlock, eAstc12x10SrgbBlock);
+        BIMAP(eAstc12x12UnormBlock, eAstc12x12SrgbBlock);
+        BIMAP(ePvrtc12BppUnormBlockIMG, ePvrtc12BppSrgbBlockIMG);
+        BIMAP(ePvrtc14BppUnormBlockIMG, ePvrtc14BppSrgbBlockIMG);
+        BIMAP(ePvrtc22BppUnormBlockIMG, ePvrtc22BppSrgbBlockIMG);
+        BIMAP(ePvrtc24BppUnormBlockIMG, ePvrtc24BppSrgbBlockIMG);
+        #undef BIMAP
+        default:
+            throw std::invalid_argument { "No corresponding conversion format" };
+    }
+}
+
+/**
+ * @brief Check if \p format is sRGB format.
+ * @param format Format to check.
+ * @return <tt>true</tt> if \p format is sRGB format, <tt>false</tt> otherwise.
+ */
+export
+[[nodiscard]] bool isSrgbFormat(vk::Format format) noexcept {
+    return ranges::one_of(format, {
+        vk::Format::eR8Srgb, vk::Format::eR8G8Srgb, vk::Format::eR8G8B8Srgb, vk::Format::eB8G8R8Srgb,
+        vk::Format::eR8G8B8A8Srgb, vk::Format::eB8G8R8A8Srgb, vk::Format::eA8B8G8R8SrgbPack32,
+        vk::Format::eBc1RgbSrgbBlock, vk::Format::eBc1RgbaSrgbBlock, vk::Format::eBc2SrgbBlock,
+        vk::Format::eBc3SrgbBlock, vk::Format::eBc7SrgbBlock, vk::Format::eEtc2R8G8B8SrgbBlock,
+        vk::Format::eEtc2R8G8B8A1SrgbBlock, vk::Format::eEtc2R8G8B8A8SrgbBlock, vk::Format::eAstc4x4SrgbBlock,
+        vk::Format::eAstc5x4SrgbBlock, vk::Format::eAstc5x5SrgbBlock, vk::Format::eAstc6x5SrgbBlock,
+        vk::Format::eAstc6x6SrgbBlock, vk::Format::eAstc8x5SrgbBlock, vk::Format::eAstc8x6SrgbBlock,
+        vk::Format::eAstc8x8SrgbBlock, vk::Format::eAstc10x5SrgbBlock, vk::Format::eAstc10x6SrgbBlock,
+        vk::Format::eAstc10x8SrgbBlock, vk::Format::eAstc10x10SrgbBlock, vk::Format::eAstc12x10SrgbBlock,
+        vk::Format::eAstc12x12SrgbBlock, vk::Format::ePvrtc12BppSrgbBlockIMG, vk::Format::ePvrtc14BppSrgbBlockIMG,
+        vk::Format::ePvrtc22BppSrgbBlockIMG, vk::Format::ePvrtc24BppSrgbBlockIMG,
+    });
 }

--- a/interface/imgui/ColorSpaceAndUsageCorrectedTextures.cppm
+++ b/interface/imgui/ColorSpaceAndUsageCorrectedTextures.cppm
@@ -1,0 +1,44 @@
+export module vk_gltf_viewer:imgui.ColorSpaceAndUsageCorrectedTextures;
+
+import std;
+export import imgui;
+
+namespace vk_gltf_viewer::imgui {
+    /**
+     * @brief ImGui textures that are aware of the destination rendering color attachment color space and their usages.
+     *
+     * If ImGui UI is rendered to a color attachment with sRGB color space, non-sRGB textures must be treated as sRGB,
+     * otherwise it will be rendered much vividly than expected. Conversely, if color attachment is not sRGB, sRGB
+     * textures must be treated as non-sRGB, otherwise it will be rendered as washed out.
+     *
+     * Also, if texture is shown for specific material property, such like metallic/roughness/occlusion, only the relevant
+     * channel should be shown. Since metallic roughness texture and occlusion texture can be combined as a single
+     * texture, image view should be swizzled to propagate the channel to the whole RGB channels, and alpha value must
+     * remain as 1.0.
+     *
+     * <tt>getTextureID</tt> returns ImGui texture with corrected color space, and
+     * <tt>get{Metallic,Roughness,Normal,Occlusion,Emissive}TextureID</tt> returns ImGui texture with corrected color
+     * space and usage. Specifically,
+     *
+     * - <tt>getMetallicTextureID</tt> returns the texture that propagates the blue channel,
+     * - <tt>getRoughnessTextureID</tt> returns the texture that propagates the green channel,
+     * - <tt>getOcclusionTextureID</tt> returns the texture that propagates the red channel.
+     *
+     * Note that since base color texture uses all RGBA channels, you can use <tt>getTextureID</tt> when such a things
+     * like <tt>getBaseColorTextureID</tt> is needed.
+     */
+    export struct ColorSpaceAndUsageCorrectedTextures {
+        bool srgbColorAttachment;
+
+        explicit ColorSpaceAndUsageCorrectedTextures(bool srgbColorAttachment) noexcept
+            : srgbColorAttachment { srgbColorAttachment } { }
+        virtual ~ColorSpaceAndUsageCorrectedTextures() = default;
+
+        [[nodiscard]] virtual ImTextureID getTextureID(std::size_t textureIndex) const = 0;
+        [[nodiscard]] virtual ImTextureID getMetallicTextureID(std::size_t materialIndex) const = 0;
+        [[nodiscard]] virtual ImTextureID getRoughnessTextureID(std::size_t materialIndex) const = 0;
+        [[nodiscard]] virtual ImTextureID getNormalTextureID(std::size_t materialIndex) const = 0;
+        [[nodiscard]] virtual ImTextureID getOcclusionTextureID(std::size_t materialIndex) const = 0;
+        [[nodiscard]] virtual ImTextureID getEmissiveTextureID(std::size_t materialIndex) const = 0;
+    };
+}

--- a/interface/imgui/ColorSpaceAndUsageCorrectedTextures.cppm
+++ b/interface/imgui/ColorSpaceAndUsageCorrectedTextures.cppm
@@ -28,10 +28,6 @@ namespace vk_gltf_viewer::imgui {
      * like <tt>getBaseColorTextureID</tt> is needed.
      */
     export struct ColorSpaceAndUsageCorrectedTextures {
-        bool srgbColorAttachment;
-
-        explicit ColorSpaceAndUsageCorrectedTextures(bool srgbColorAttachment) noexcept
-            : srgbColorAttachment { srgbColorAttachment } { }
         virtual ~ColorSpaceAndUsageCorrectedTextures() = default;
 
         [[nodiscard]] virtual ImTextureID getTextureID(std::size_t textureIndex) const = 0;

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -36,6 +36,7 @@ export import :vulkan.pipeline.WeightedBlendedCompositionRenderer;
 export import :vulkan.rp.Scene;
 export import :vulkan.sampler.Samplers;
 export import :vulkan.texture.Fallback;
+export import :vulkan.texture.ImGuiColorSpaceAndUsageCorrectedTextures;
 export import :vulkan.texture.Textures;
 
 namespace vk_gltf_viewer::vulkan {
@@ -53,6 +54,7 @@ namespace vk_gltf_viewer::vulkan {
             buffer::SkinJointIndices skinJointIndices;
             buffer::InverseBindMatrices inverseBindMatrixBuffer;
             texture::Textures textures;
+            texture::ImGuiColorSpaceAndUsageCorrectedTextures imGuiColorSpaceAndUsageCorrectedTextures;
 
             std::vector<vk::DescriptorSet> imGuiTextureDescriptorSets;
 
@@ -75,7 +77,8 @@ namespace vk_gltf_viewer::vulkan {
                 primitiveBuffer { orderedPrimitives, primitiveAttributes, gpu, stagingBufferStorage },
                 skinJointIndices { asset, gpu.allocator },
                 inverseBindMatrixBuffer { asset, gpu.allocator, adapter },
-                textures { asset, directory, gpu, fallbackTexture, threadPool, adapter } {
+                textures { asset, directory, gpu, fallbackTexture, threadPool, adapter },
+                imGuiColorSpaceAndUsageCorrectedTextures { asset, textures, gpu } {
                 if (stagingBufferStorage.hasStagingCommands()) {
                     const vk::raii::CommandPool transferCommandPool { gpu.device, vk::CommandPoolCreateInfo { {}, gpu.queueFamilies.transfer } };
                     const vk::raii::Fence transferFence { gpu.device, vk::FenceCreateInfo{} };

--- a/interface/vulkan/texture/ImGuiColorSpaceAndUsageCorrectedTextures.cppm
+++ b/interface/vulkan/texture/ImGuiColorSpaceAndUsageCorrectedTextures.cppm
@@ -24,14 +24,14 @@ namespace vk_gltf_viewer::vulkan::texture {
             const fastgltf::Asset &asset LIFETIMEBOUND,
             const Textures &textures LIFETIMEBOUND,
             const Gpu &gpu LIFETIMEBOUND
-        ) : ColorSpaceAndUsageCorrectedTextures { !gpu.supportSwapchainMutableFormat } {
+        ) {
             textureDescriptorSets
                 = asset.textures
                 | ranges::views::enumerate
                 | std::views::transform(decomposer([&](std::size_t textureIndex, const fastgltf::Texture &texture) -> vk::DescriptorSet {
                     auto [sampler, imageView, _] = textures.descriptorInfos[textureIndex];
                     const vku::Image &image = get<0>(textures.images.at(getPreferredImageIndex(texture)));
-                    if (srgbColorAttachment != isSrgbFormat(image.format)) {
+                    if (gpu.supportSwapchainMutableFormat == isSrgbFormat(image.format)) {
                         // Image view format is incompatible, need to be regenerated.
                         const vk::ComponentMapping components = [&]() -> vk::ComponentMapping {
                             switch (componentCount(image.format)) {
@@ -68,7 +68,7 @@ namespace vk_gltf_viewer::vulkan::texture {
                     }
                     else {
                         vk::Format colorSpaceCompatibleFormat = image.format;
-                        if (srgbColorAttachment != isSrgbFormat(image.format)) {
+                        if (gpu.supportSwapchainMutableFormat == isSrgbFormat(image.format)) {
                             colorSpaceCompatibleFormat = convertSrgb(image.format);
                         }
 
@@ -99,7 +99,7 @@ namespace vk_gltf_viewer::vulkan::texture {
                         }
                         else {
                             vk::Format colorSpaceCompatibleFormat = image.format;
-                            if (srgbColorAttachment != isSrgbFormat(image.format)) {
+                            if (gpu.supportSwapchainMutableFormat == isSrgbFormat(image.format)) {
                                 colorSpaceCompatibleFormat = convertSrgb(image.format);
                             }
 
@@ -122,7 +122,7 @@ namespace vk_gltf_viewer::vulkan::texture {
                         }
                         else {
                             vk::Format colorSpaceCompatibleFormat = image.format;
-                            if (srgbColorAttachment != isSrgbFormat(image.format)) {
+                            if (gpu.supportSwapchainMutableFormat == isSrgbFormat(image.format)) {
                                 colorSpaceCompatibleFormat = convertSrgb(image.format);
                             }
 
@@ -147,7 +147,7 @@ namespace vk_gltf_viewer::vulkan::texture {
                             // Emissive texture must be sRGB encoded, therefore image view format must be mutated if color space
                             // is not sRGB.
                             vk::Format colorSpaceCompatibleFormat = image.format;
-                            if (!srgbColorAttachment) {
+                            if (gpu.supportSwapchainMutableFormat) {
                                 colorSpaceCompatibleFormat = convertSrgb(image.format);
                             }
 

--- a/interface/vulkan/texture/ImGuiColorSpaceAndUsageCorrectedTextures.cppm
+++ b/interface/vulkan/texture/ImGuiColorSpaceAndUsageCorrectedTextures.cppm
@@ -1,0 +1,195 @@
+module;
+
+#include <lifetimebound.hpp>
+
+export module vk_gltf_viewer:vulkan.texture.ImGuiColorSpaceAndUsageCorrectedTextures;
+
+import std;
+export import imgui.vulkan;
+import :helpers.fastgltf;
+import :helpers.functional;
+import :helpers.ranges;
+import :helpers.vulkan;
+export import :imgui.ColorSpaceAndUsageCorrectedTextures;
+export import :vulkan.texture.Textures;
+
+namespace vk_gltf_viewer::vulkan::texture {
+    export class ImGuiColorSpaceAndUsageCorrectedTextures final : public imgui::ColorSpaceAndUsageCorrectedTextures {
+        std::deque<vk::raii::ImageView> imageViews;
+        std::vector<vk::DescriptorSet> textureDescriptorSets;
+        std::vector<std::array<vk::DescriptorSet, 5>> materialTextureDescriptorSets; // [0] -> metallic, [1] -> roughness, [2] -> normal, [3] -> occlusion, [4] -> emissive
+
+    public:
+        ImGuiColorSpaceAndUsageCorrectedTextures(
+            const fastgltf::Asset &asset LIFETIMEBOUND,
+            const Textures &textures LIFETIMEBOUND,
+            const Gpu &gpu LIFETIMEBOUND
+        ) : ColorSpaceAndUsageCorrectedTextures { !gpu.supportSwapchainMutableFormat } {
+            textureDescriptorSets
+                = asset.textures
+                | ranges::views::enumerate
+                | std::views::transform(decomposer([&](std::size_t textureIndex, const fastgltf::Texture &texture) -> vk::DescriptorSet {
+                    auto [sampler, imageView, _] = textures.descriptorInfos[textureIndex];
+
+                    const vku::Image &image = textures.images.images.at(getPreferredImageIndex(texture));
+                    if (srgbColorAttachment != isSrgbFormat(image.format)) {
+                        // Image view format is incompatible, need to be regenerated.
+                        const vk::ComponentMapping components = [&]() -> vk::ComponentMapping {
+                            switch (componentCount(image.format)) {
+                                case 1:
+                                    // Grayscale: red channel have to be propagated to green/blue channels.
+                                    return { vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eOne };
+                                case 2:
+                                    // Grayscale \w alpha: red channel have to be propagated to green/blue channels, and alpha channel uses given green value.
+                                    return { vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eG };
+                                case 4:
+                                    // RGB or RGBA.
+                                    return {};
+                                default:
+                                    std::unreachable();
+                            }
+                        }();
+                        imageView = *imageViews.emplace_back(
+                            gpu.device,
+                            image.getViewCreateInfo().setFormat(convertSrgb(image.format)).setComponents(components));
+                    }
+
+                    return ImGui_ImplVulkan_AddTexture(sampler, imageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                }))
+                | std::ranges::to<std::vector>();
+
+            const auto getImage = [&](std::size_t textureIndex) -> const vku::Image& {
+                const std::size_t imageIndex = getPreferredImageIndex(asset.textures[textureIndex]);
+                return textures.images.images.at(imageIndex);
+            };
+
+            materialTextureDescriptorSets.resize(asset.materials.size());
+            for (const auto &[materialIndex, material] : asset.materials | ranges::views::enumerate) {
+                if (const auto &textureInfo = material.pbrData.metallicRoughnessTexture) {
+                    const vku::Image &image = getImage(textureInfo->textureIndex);
+
+                    // Metallic/roughness texture is non-sRGB by default, therefore image view format must be mutated
+                    // if color space is sRGB.
+                    vk::Format colorSpaceCompatibleFormat = image.format;
+                    if (srgbColorAttachment) {
+                        colorSpaceCompatibleFormat = convertSrgb(image.format);
+                    }
+
+                    // Metallic.
+                    get<0>(materialTextureDescriptorSets[materialIndex]) = ImGui_ImplVulkan_AddTexture(
+                        textures.descriptorInfos[textureInfo->textureIndex].sampler,
+                        *imageViews.emplace_back(gpu.device, image.getViewCreateInfo()
+                            .setFormat(colorSpaceCompatibleFormat)
+                            .setComponents({ vk::ComponentSwizzle::eB, vk::ComponentSwizzle::eB, vk::ComponentSwizzle::eB, vk::ComponentSwizzle::eOne })),
+                        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+                    // Roughness.
+                    get<1>(materialTextureDescriptorSets[materialIndex]) = ImGui_ImplVulkan_AddTexture(
+                        textures.descriptorInfos[textureInfo->textureIndex].sampler,
+                        *imageViews.emplace_back(gpu.device, image.getViewCreateInfo()
+                            .setFormat(colorSpaceCompatibleFormat)
+                            .setComponents({ vk::ComponentSwizzle::eG, vk::ComponentSwizzle::eG, vk::ComponentSwizzle::eG, vk::ComponentSwizzle::eOne })),
+                        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                }
+
+                if (const auto &textureInfo = material.normalTexture) {
+                    const vku::Image &image = getImage(textureInfo->textureIndex);
+
+                    // Normal texture is non-sRGB by default, therefore image view format must be mutated if color space is sRGB.
+                    vk::Format colorSpaceCompatibleFormat = image.format;
+                    if (srgbColorAttachment) {
+                        colorSpaceCompatibleFormat = convertSrgb(image.format);
+                    }
+
+                    get<2>(materialTextureDescriptorSets[materialIndex]) = ImGui_ImplVulkan_AddTexture(
+                        textures.descriptorInfos[textureInfo->textureIndex].sampler,
+                        *imageViews.emplace_back(gpu.device, image.getViewCreateInfo()
+                            .setFormat(colorSpaceCompatibleFormat)
+                            .setComponents({ {}, {}, {}, vk::ComponentSwizzle::eOne })),
+                        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                }
+
+                if (const auto &textureInfo = material.occlusionTexture) {
+                    const vku::Image &image = getImage(textureInfo->textureIndex);
+
+                    // Occlusion texture is non-sRGB by default, therefore image view format must be mutated if color space is sRGB.
+                    vk::Format colorSpaceCompatibleFormat = image.format;
+                    if (srgbColorAttachment) {
+                        colorSpaceCompatibleFormat = convertSrgb(image.format);
+                    }
+
+                    get<3>(materialTextureDescriptorSets[materialIndex]) = ImGui_ImplVulkan_AddTexture(
+                        textures.descriptorInfos[textureInfo->textureIndex].sampler,
+                        *imageViews.emplace_back(gpu.device, image.getViewCreateInfo()
+                            .setFormat(colorSpaceCompatibleFormat)
+                            .setComponents({ vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eOne })),
+                        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                }
+
+                if (const auto &textureInfo = material.emissiveTexture) {
+                    const vku::Image &image = getImage(textureInfo->textureIndex);
+
+                    // Emissive texture is sRGB by default, therefore image view format must be mutated if color space is not sRGB.
+                    vk::Format colorSpaceCompatibleFormat = image.format;
+                    if (!srgbColorAttachment) {
+                        colorSpaceCompatibleFormat = convertSrgb(image.format);
+                    }
+
+                    const vk::ComponentMapping components = [&]() -> vk::ComponentMapping {
+                        switch (componentCount(image.format)) {
+                            case 1:
+                            case 2:
+                                // Grayscale: red channel have to be propagated to green/blue channels. Alpha channel is ignored.
+                                return { vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eOne };
+                            case 4:
+                                // RGB or RGBA.
+                                return {};
+                            default:
+                                std::unreachable();
+                        }
+                    }();
+
+                    get<4>(materialTextureDescriptorSets[materialIndex]) = ImGui_ImplVulkan_AddTexture(
+                        textures.descriptorInfos[textureInfo->textureIndex].sampler,
+                        *imageViews.emplace_back(gpu.device, image.getViewCreateInfo().setFormat(colorSpaceCompatibleFormat).setComponents(components)),
+                        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+                }
+            }
+        }
+
+        ~ImGuiColorSpaceAndUsageCorrectedTextures() override {
+            for (vk::DescriptorSet descriptorSet : materialTextureDescriptorSets | std::views::join) {
+                if (descriptorSet) {
+                    ImGui_ImplVulkan_RemoveTexture(descriptorSet);
+                }
+            }
+            for (vk::DescriptorSet descriptorSet : textureDescriptorSets) {
+                ImGui_ImplVulkan_RemoveTexture(descriptorSet);
+            }
+        }
+
+        [[nodiscard]] ImTextureID getTextureID(std::size_t textureIndex) const override {
+            return vku::toUint64(textureDescriptorSets[textureIndex]);
+        }
+
+        [[nodiscard]] ImTextureID getMetallicTextureID(std::size_t materialIndex) const override {
+            return vku::toUint64(get<0>(materialTextureDescriptorSets[materialIndex]));
+        }
+
+        [[nodiscard]] ImTextureID getRoughnessTextureID(std::size_t materialIndex) const override {
+            return vku::toUint64(get<1>(materialTextureDescriptorSets[materialIndex]));
+        }
+
+        [[nodiscard]] ImTextureID getNormalTextureID(std::size_t materialIndex) const override {
+            return vku::toUint64(get<2>(materialTextureDescriptorSets[materialIndex]));
+        }
+
+        [[nodiscard]] ImTextureID getOcclusionTextureID(std::size_t materialIndex) const override {
+            return vku::toUint64(get<3>(materialTextureDescriptorSets[materialIndex]));
+        }
+
+        [[nodiscard]] ImTextureID getEmissiveTextureID(std::size_t materialIndex) const override {
+            return vku::toUint64(get<4>(materialTextureDescriptorSets[materialIndex]));
+        }
+    };
+}

--- a/interface/vulkan/texture/Textures.cppm
+++ b/interface/vulkan/texture/Textures.cppm
@@ -28,7 +28,7 @@ namespace vk_gltf_viewer::vulkan::texture {
                     to_optional(texture.samplerIndex)
                         .transform([&](std::size_t samplerIndex) { return *samplers[samplerIndex]; })
                         .value_or(*fallbackTexture.sampler),
-                    *images.imageViews.at(getPreferredImageIndex(texture)),
+                    *get<1>(images.at(getPreferredImageIndex(texture))),
                     vk::ImageLayout::eShaderReadOnlyOptimal,
                 };
             }) } { }


### PR DESCRIPTION
<table>
<thead>
<td><code>VK_KHR_swapchain_mutable_format</code></td>
<td>Before</td>
<td>After</td>
</thead>
<tbody>
<tr>
<td>
Yes
</td>
<td>
<img width="1392" alt="Screenshot 2025-04-15 at 9 59 35 PM" src="https://github.com/user-attachments/assets/7e69a607-428c-4aef-bc37-b43469475435" />

</td>
<td>
<img width="1392" alt="Screenshot 2025-04-15 at 9 56 46 PM" src="https://github.com/user-attachments/assets/8aecfe50-3039-416c-8302-f3450c6a4363" />

</td>
</tr>
<tr>
<td>
No
</td>
<td>
<img width="1392" alt="Screenshot 2025-04-15 at 10 04 40 PM" src="https://github.com/user-attachments/assets/9f84faea-d8e3-491c-b778-dbcba3503bd4" />

</td>
<td>
<img width="1392" alt="Screenshot 2025-04-15 at 10 03 39 PM" src="https://github.com/user-attachments/assets/84051f0c-b9fe-4a30-bc01-4d7cc546a8e2" />

</td>
</tr>
</tbody>
</table>

- If `VK_KHR_swapchain_mutable_format` device extension is available, ImGui rendered in swapchain image will treat the image format as `VK_FORMAT_B8G8R8A8_UNORM`, therefore glTF asset's base color and emissive textures (whose color space is encoded by sRGB) should have image views with `XXX_UNORM` mutated format.
- If `VK_KHR_swapchain_mutable_format` device extension is not available, ImGui rendered in swapchain image will treat the image format as `VK_FORMAT_B8G8R8A8_SRGB`, therefore glTF asset's normal/ORM textures (whose color space is encoded by non-sRGB) should have image views with `XXX_SRGB` mutated format.
- When showing metallic/roughness/occlusion texture, their relevant components (b, g and r, respectivel) must be propagated to the whole RGB components and alpha must be 1.

Please note that after the change, the texture is rendered identically in the screenshot regardless of the swapchain color space.