### PR TITLE
Use checkerboard background when showing transparent texture.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/helpers/type_variant.cppm
         interface/helpers/vulkan.cppm
         interface/imgui/ColorSpaceAndUsageCorrectedTextures.cppm
+        interface/imgui/UserData.cppm
         interface/MainApp.cppm
         interface/math/extended_arithmetic.cppm
         interface/math/Frustum.cppm
@@ -208,6 +209,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/Frame.cppm
         interface/vulkan/Gpu.cppm
         interface/vulkan/image/Images.cppm
+        interface/vulkan/imgui/UserData.cppm
         interface/vulkan/mipmap.cppm
         interface/vulkan/pipeline/CubemapToneMappingRenderer.cppm
         interface/vulkan/pipeline/DepthRenderer.cppm
@@ -231,6 +233,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/shader_type/Primitive.cppm
         interface/vulkan/SharedData.cppm
         interface/vulkan/specialization_constants/SpecializationMap.cppm
+        interface/vulkan/texture/Checkerboard.cppm
         interface/vulkan/texture/Fallback.cppm
         interface/vulkan/texture/ImGuiColorSpaceAndUsageCorrectedTextures.cppm
         interface/vulkan/texture/Textures.cppm

--- a/extlibs/module-ports/imgui/imgui.cppm
+++ b/extlibs/module-ports/imgui/imgui.cppm
@@ -136,7 +136,9 @@ namespace ImGui {
     export using ImGui::Separator;
     export using ImGui::SeparatorText;
     export using ImGui::SetCursorPosX;
+    export using ImGui::SetCursorScreenPos;
     export using ImGui::SetItemDefaultFocus;
+    export using ImGui::SetNextItemAllowOverlap;
     export using ImGui::SetNextItemWidth;
     export using ImGui::TableHeadersRow;
     export using ImGui::TableNextRow;

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -46,6 +46,7 @@ import :helpers.ranges;
 import :helpers.tristate;
 import :imgui.TaskCollector;
 import :vulkan.Frame;
+import :vulkan.imgui.UserData;
 import :vulkan.mipmap;
 import :vulkan.pipeline.CubemapToneMappingRenderer;
 
@@ -692,9 +693,15 @@ vk_gltf_viewer::MainApp::ImGuiContext::ImGuiContext(const control::AppWindow &wi
         },
     };
     ImGui_ImplVulkan_Init(&initInfo);
+
+    userData = std::make_unique<vulkan::imgui::UserData>(gpu);
+    io.UserData = userData.get();
 }
 
 vk_gltf_viewer::MainApp::ImGuiContext::~ImGuiContext() {
+    // Since userData is instantiated under ImGui_ImplVulkan context, it must be destroyed before shutdown ImGui_ImplVulkan.
+    userData.reset();
+
     ImGui_ImplVulkan_Shutdown();
     ImGui_ImplGlfw_Shutdown();
     ImGui::DestroyContext();

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -103,6 +103,26 @@ void hoverableImage(ImTextureID texture, const ImVec2 &size) {
     }
 }
 
+void hoverableImageCheckerboardBackground(ImTextureID texture, const ImVec2 &size) {
+    const ImVec2 texturePosition = ImGui::GetCursorScreenPos();
+    ImGui::ImageCheckerboardBackground(texture, size);
+
+    if (ImGui::BeginItemTooltip()) {
+        const ImGuiIO &io = ImGui::GetIO();
+
+        const ImVec2 zoomedPortionSize = size / 4.f;
+        ImVec2 region = io.MousePos - texturePosition - zoomedPortionSize * 0.5f;
+        region.x = std::clamp(region.x, 0.f, size.x - zoomedPortionSize.x);
+        region.y = std::clamp(region.y, 0.f, size.y - zoomedPortionSize.y);
+
+        constexpr float zoomScale = 4.0f;
+        ImGui::ImageCheckerboardBackground(texture, zoomedPortionSize * zoomScale, region / size, (region + zoomedPortionSize) / size);
+        ImGui::TextUnformatted(tempStringBuffer.write("Showing: [{:.0f}, {:.0f}]x[{:.0f}, {:.0f}]", region.x, region.y, region.x + zoomedPortionSize.y, region.y + zoomedPortionSize.y));
+
+        ImGui::EndTooltip();
+    }
+}
+
 void attributeTable(std::ranges::viewable_range auto const &attributes) {
     ImGui::Table<false>(
         "attributes-table",
@@ -351,7 +371,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::assetTextures(
                 return;
             }
 
-            hoverableImage(imGuiTextures.getTextureID(*textureIndex), { 256, 256 });
+            hoverableImageCheckerboardBackground(imGuiTextures.getTextureID(*textureIndex), { 256, 256 });
 
             ImGui::SameLine();
 
@@ -755,7 +775,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                 ImGui::WithID("basecolor", [&]() {
                     auto &baseColorTextureInfo = material.pbrData.baseColorTexture;
                     if (baseColorTextureInfo) {
-                        hoverableImage(imGuiTextures.getTextureID(baseColorTextureInfo->textureIndex), { 128.f, 128.f });
+                        hoverableImageCheckerboardBackground(imGuiTextures.getTextureID(baseColorTextureInfo->textureIndex), { 128.f, 128.f });
                         ImGui::SameLine();
                     }
                     ImGui::WithItemWidth(ImGui::CalcItemWidth() - ImGui::GetCursorPosX() + 2.f * ImGui::GetStyle().ItemInnerSpacing.x, [&]() {

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -9,6 +9,7 @@ import :gltf.data_structure.SceneInverseHierarchy;
 import :gltf.NodeWorldTransforms;
 import :gltf.TextureUsage;
 import :helpers.fastgltf;
+import :imgui.UserData;
 import :vulkan.dsl.Asset;
 import :vulkan.dsl.ImageBasedLighting;
 import :vulkan.dsl.Skybox;
@@ -34,6 +35,8 @@ namespace vk_gltf_viewer {
         static constexpr std::uint32_t FRAMES_IN_FLIGHT = 2;
 
         struct ImGuiContext {
+            std::unique_ptr<imgui::UserData> userData;
+
             ImGuiContext(const control::AppWindow &window, vk::Instance instance, const vulkan::Gpu &gpu);
             ~ImGuiContext();
         };

--- a/interface/helpers/imgui/mod.cppm
+++ b/interface/helpers/imgui/mod.cppm
@@ -7,7 +7,9 @@ export module vk_gltf_viewer:helpers.imgui;
 import std;
 export import imgui;
 import imgui.internal;
+import imgui.math;
 export import :helpers.imgui.table;
+import :imgui.UserData;
 
 #define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 
@@ -113,12 +115,21 @@ namespace ImGui {
         const ImVec2 p_max { bb.Max.x - padding.x, bb.Max.y - padding.y - GetTextLineHeight() };
         if (bg_col.w > 0.0f)
             window->DrawList->AddRectFilled(p_min, p_max, GetColorU32(bg_col));
+        window->DrawList->AddImage(static_cast<const vk_gltf_viewer::imgui::UserData*>(GetIO().UserData)->checkerboardTextureID, p_min, p_max, image_size * uv0 / 16.f, image_size * uv1 / 16.f, GetColorU32(tint_col));
         window->DrawList->AddImage(user_texture_id, p_min, p_max, uv0, uv1, GetColorU32(tint_col));
         window->DrawList->PushClipRect({ p_min.x, p_max.y }, { p_max.x, p_max.y + GetTextLineHeight() }, true);
         window->DrawList->AddText({ p_min.x, p_max.y }, GetColorU32(ImGuiCol_Text), text.data(), text.data() + text.size());
         window->DrawList->PopClipRect();
 
         return pressed;
+    }
+
+    export void ImageCheckerboardBackground(ImTextureID textureId, const ImVec2 &size, const ImVec2 &uv0 = {}, const ImVec2 &uv1 = { 1, 1 }) {
+        const ImVec2 texturePosition = GetCursorScreenPos();
+        SetNextItemAllowOverlap();
+        Image(static_cast<const vk_gltf_viewer::imgui::UserData*>(GetIO().UserData)->checkerboardTextureID, size, size * uv0 / 16.f, size * uv1 / 16.f);
+        SetCursorScreenPos(texturePosition);
+        Image(textureId, size, uv0, uv1);
     }
 
     export template <std::invocable F>

--- a/interface/imgui/UserData.cppm
+++ b/interface/imgui/UserData.cppm
@@ -1,0 +1,11 @@
+export module vk_gltf_viewer:imgui.UserData;
+
+import imgui;
+
+namespace vk_gltf_viewer::imgui {
+    export struct UserData {
+        ImTextureID checkerboardTextureID;
+
+        virtual ~UserData() = default;
+    };
+}

--- a/interface/vulkan/imgui/UserData.cppm
+++ b/interface/vulkan/imgui/UserData.cppm
@@ -1,0 +1,29 @@
+module;
+
+#include <vulkan/vulkan_hpp_macros.hpp>
+
+#include <lifetimebound.hpp>
+
+export module vk_gltf_viewer:vulkan.imgui.UserData;
+
+import imgui.vulkan;
+export import :imgui.UserData;
+export import :vulkan.Gpu;
+import :vulkan.texture.Checkerboard;
+
+namespace vk_gltf_viewer::vulkan::imgui {
+    export class UserData final : public vk_gltf_viewer::imgui::UserData {
+        texture::Checkerboard checkerboardTexture;
+
+    public:
+        explicit UserData(const Gpu &gpu LIFETIMEBOUND)
+            : checkerboardTexture { gpu } {
+            checkerboardTextureID = vku::toUint64<vk::DescriptorSet>(ImGui_ImplVulkan_AddTexture(
+                *checkerboardTexture.sampler, *checkerboardTexture.imageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL));
+        }
+
+        ~UserData() override {
+            ImGui_ImplVulkan_RemoveTexture(reinterpret_cast<vk::DescriptorSet::CType>(checkerboardTextureID));
+        }
+    };
+}

--- a/interface/vulkan/texture/Checkerboard.cppm
+++ b/interface/vulkan/texture/Checkerboard.cppm
@@ -1,0 +1,83 @@
+module;
+
+#include <vulkan/vulkan_hpp_macros.hpp>
+
+#include <lifetimebound.hpp>
+
+export module vk_gltf_viewer:vulkan.texture.Checkerboard;
+
+import std;
+export import :vulkan.Gpu;
+
+constexpr unsigned char data[] = {
+    0x52, 0x52, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x52, 0x52, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xb4, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xb4, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x52, 0x52, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x52, 0x52, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xb4, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xb4, 0xb4, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xb4, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xb4, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x52, 0x52, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x52, 0x52, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xb4, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xb4, 0xb4, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x52, 0x52, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x52, 0x52, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+namespace vk_gltf_viewer::vulkan::texture {
+    export struct Checkerboard {
+        vku::AllocatedImage image;
+        vk::raii::ImageView imageView;
+        vk::raii::Sampler sampler;
+
+        explicit Checkerboard(const Gpu &gpu LIFETIMEBOUND)
+            : image { gpu.allocator, vk::ImageCreateInfo {
+                {},
+                vk::ImageType::e2D,
+                vk::Format::eBc4UnormBlock,
+                { 16, 16, 1 },
+                1, 1,
+                vk::SampleCountFlagBits::e1,
+                vk::ImageTiling::eOptimal,
+                vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eSampled,
+            } }
+            , imageView { gpu.device, image.getViewCreateInfo().setComponents({ vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eR, vk::ComponentSwizzle::eOne }) }
+            , sampler { gpu.device, vk::SamplerCreateInfo{}.setMaxLod(vk::LodClampNone) } {
+            const vku::MappedBuffer stagingBuffer {
+                gpu.allocator,
+                std::from_range, std::span { data },
+                vk::BufferUsageFlagBits::eTransferSrc,
+            };
+
+            vk::raii::CommandPool graphicsCommandPool { gpu.device, vk::CommandPoolCreateInfo { {}, gpu.queueFamilies.graphicsPresent } };
+            vk::raii::Fence fence { gpu.device, vk::FenceCreateInfo{} };
+            vku::executeSingleCommand(*gpu.device, *graphicsCommandPool, gpu.queues.graphicsPresent, [&](vk::CommandBuffer cb) {
+                cb.pipelineBarrier(
+                    vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eTransfer,
+                    {}, {}, {},
+                    vk::ImageMemoryBarrier {
+                        {}, vk::AccessFlagBits::eTransferWrite,
+                        {}, vk::ImageLayout::eTransferDstOptimal,
+                        vk::QueueFamilyIgnored, vk::QueueFamilyIgnored,
+                        image, vku::fullSubresourceRange(),
+                    });
+
+                cb.copyBufferToImage(stagingBuffer, image, vk::ImageLayout::eTransferDstOptimal, vk::BufferImageCopy {
+                    0, 0, 0,
+                    { vk::ImageAspectFlagBits::eColor, 0, 0, 1 },
+                    {}, image.extent,
+                });
+
+                cb.pipelineBarrier(
+                    vk::PipelineStageFlagBits::eTransfer, vk::PipelineStageFlagBits::eBottomOfPipe,
+                    {}, {}, {},
+                    vk::ImageMemoryBarrier {
+                        vk::AccessFlagBits::eTransferWrite, {},
+                        vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal,
+                        vk::QueueFamilyIgnored, vk::QueueFamilyIgnored,
+                        image, vku::fullSubresourceRange(),
+                    });
+            }, *fence);
+            std::ignore = gpu.device.waitForFences(*fence, true, ~0ULL);
+        }
+    };
+}


### PR DESCRIPTION
16x16 checkerboard image data is embedded in the application with BC4 format (occupies 128 bytes).

|Before|After|
|:---:|:---:|
|![Before](https://github.com/user-attachments/assets/9de2ea3a-8ed7-4abf-a733-f6a3f73bef4e)|![After](https://github.com/user-attachments/assets/5cfb4cf0-5b5c-4ad8-8049-ef1c9d7a357a)|