### PR TITLE
Handling 1- or 2-channel sRGB texture compatibility.

### DIFF
--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -225,6 +225,15 @@ vk::raii::Device vk_gltf_viewer::vulkan::Gpu::createDevice() {
     supportVariableDescriptorCount = availableFeatures.template get<vk::PhysicalDeviceVulkan12Features>().descriptorBindingVariableDescriptorCount;
 #endif
 
+    constexpr vk::FormatFeatureFlags requiredFormatFeatureFlags
+        = vk::FormatFeatureFlagBits::eTransferDst
+        | vk::FormatFeatureFlagBits::eTransferSrc
+        | vk::FormatFeatureFlagBits::eBlitSrc
+        | vk::FormatFeatureFlagBits::eBlitDst
+        | vk::FormatFeatureFlagBits::eSampledImage;
+    supportR8SrgbImageFormat = vku::contains(physicalDevice.getFormatProperties(vk::Format::eR8Srgb).optimalTilingFeatures, requiredFormatFeatureFlags);
+    supportR8G8SrgbImageFormat = vku::contains(physicalDevice.getFormatProperties(vk::Format::eR8G8Srgb).optimalTilingFeatures, requiredFormatFeatureFlags);
+
 	const vku::RefHolder queueCreateInfos = Queues::getCreateInfos(physicalDevice, queueFamilies);
     vk::StructureChain createInfo {
         vk::DeviceCreateInfo {

--- a/interface/vulkan/Gpu.cppm
+++ b/interface/vulkan/Gpu.cppm
@@ -44,6 +44,8 @@ namespace vk_gltf_viewer::vulkan {
         std::uint32_t maxPerStageDescriptorUpdateAfterBindSamplers;
         bool supportShaderImageLoadStoreLod;
         bool supportVariableDescriptorCount;
+        bool supportR8SrgbImageFormat;
+        bool supportR8G8SrgbImageFormat;
 
         Gpu(const vk::raii::Instance &instance LIFETIMEBOUND, vk::SurfaceKHR surface);
         ~Gpu();

--- a/interface/vulkan/image/Images.cppm
+++ b/interface/vulkan/image/Images.cppm
@@ -181,8 +181,10 @@ namespace vk_gltf_viewer::vulkan::image {
                             throw std::runtime_error { std::format("Failed to get the image info: {}", stbi_failure_reason()) };
                         }
 
-                        // Vulkan is not friendly with 3-channel image.
-                        if (channels == 3) {
+                        if ((channels == 1 && srgbImageIndices.contains(imageIndex) && !gpu.supportR8SrgbImageFormat) ||
+                            (channels == 2 && srgbImageIndices.contains(imageIndex) && !gpu.supportR8G8SrgbImageFormat) ||
+                            channels == 3) {
+                            // Use 4-channel image for best compatibility.
                             info.alphaChannelPadded = true;
                             channels = 4;
                         }
@@ -201,8 +203,10 @@ namespace vk_gltf_viewer::vulkan::image {
                             throw std::runtime_error { std::format("Failed to get the image info: {}", stbi_failure_reason()) };
                         }
 
-                        // Vulkan is not friendly with 3-channel image.
-                        if (channels == 3) {
+                        if ((channels == 1 && srgbImageIndices.contains(imageIndex) && !gpu.supportR8SrgbImageFormat) ||
+                            (channels == 2 && srgbImageIndices.contains(imageIndex) && !gpu.supportR8G8SrgbImageFormat) ||
+                            channels == 3) {
+                            // Use 4-channel image for best compatibility.
                             channels = 4;
                         }
 

--- a/interface/vulkan/image/Images.cppm
+++ b/interface/vulkan/image/Images.cppm
@@ -207,6 +207,7 @@ namespace vk_gltf_viewer::vulkan::image {
                             (channels == 2 && srgbImageIndices.contains(imageIndex) && !gpu.supportR8G8SrgbImageFormat) ||
                             channels == 3) {
                             // Use 4-channel image for best compatibility.
+                            info.alphaChannelPadded = true;
                             channels = 4;
                         }
 


### PR DESCRIPTION
Some GPUs are not capable to manipulate the 1- or 2-channel sRGB texture (`VK_FORMAT_{R8,R8G8}_SRGB`), especially for NVIDIA. This PR adds format availability querying from the physical device and pads the image data when loading.
It also fixes the missing `Info::alphaChannelPadded` toggling from https://github.com/stripe2933/vk-gltf-viewer/pull/73.