### PR TITLE
Embed the world transform matrix in the node buffer, and conditionally bind the node instance world transform buffer to the pipeline.

### DIFF
--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -251,9 +251,11 @@ void vk_gltf_viewer::MainApp::run() {
                     gltf->setScene(task.newSceneIndex);
 
                     auto nodeWorldTransformUpdateTask = [this, sceneIndex = task.newSceneIndex](vulkan::Frame &frame) {
+                        if (frame.gltfAsset->instancedNodeWorldTransformBuffer) {
+                            frame.gltfAsset->instancedNodeWorldTransformBuffer->update(
+                                gltf->asset.scenes[sceneIndex], gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                        }
                         frame.gltfAsset->nodeBuffer.update(gltf->asset.scenes[sceneIndex], gltf->nodeWorldTransforms);
-                        frame.gltfAsset->instancedNodeWorldTransformBuffer.update(
-                            gltf->asset.scenes[sceneIndex], gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
                     };
                     nodeWorldTransformUpdateTask(frame);
                     deferredFrameUpdateTasks.push_back(std::move(nodeWorldTransformUpdateTask));
@@ -310,9 +312,11 @@ void vk_gltf_viewer::MainApp::run() {
                     // Update the current and its descendant nodes' world transforms for both host and GPU side data.
                     gltf->nodeWorldTransforms.update(task.nodeIndex, nodeWorldTransform);
                     auto updateNodeTransformTask = [this, nodeIndex = task.nodeIndex](vulkan::Frame &frame) {
+                        if (frame.gltfAsset->instancedNodeWorldTransformBuffer) {
+                            frame.gltfAsset->instancedNodeWorldTransformBuffer->update(
+                                nodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                        }
                         frame.gltfAsset->nodeBuffer.update(nodeIndex, gltf->nodeWorldTransforms);
-                        frame.gltfAsset->instancedNodeWorldTransformBuffer.update(
-                            nodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
                     };
                     updateNodeTransformTask(frame);
                     deferredFrameUpdateTasks.push_back(std::move(updateNodeTransformTask));
@@ -373,9 +377,11 @@ void vk_gltf_viewer::MainApp::run() {
                     // Update the current and its descendant nodes' world transforms for both host and GPU side data.
                     gltf->nodeWorldTransforms.update(selectedNodeIndex, selectedNodeWorldTransform);
                     auto updateNodeTransformTask = [this, selectedNodeIndex](vulkan::Frame &frame) {
+                        if (frame.gltfAsset->instancedNodeWorldTransformBuffer) {
+                            frame.gltfAsset->instancedNodeWorldTransformBuffer->update(
+                                selectedNodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                        }
                         frame.gltfAsset->nodeBuffer.update(selectedNodeIndex, gltf->nodeWorldTransforms);
-                        frame.gltfAsset->instancedNodeWorldTransformBuffer.update(
-                            selectedNodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
                     };
                     updateNodeTransformTask(frame);
                     deferredFrameUpdateTasks.push_back(std::move(updateNodeTransformTask));

--- a/interface/gltf/data_structure/NodeInstanceCountExclusiveScanWithCount.cppm
+++ b/interface/gltf/data_structure/NodeInstanceCountExclusiveScanWithCount.cppm
@@ -6,13 +6,13 @@ export import fastgltf;
 
 namespace vk_gltf_viewer::gltf::ds {
     /**
-     * @brief Exclusive scan of the instance counts (or 1 if the node doesn't have any instance), and additional total instance count at the end.
+     * @brief Exclusive scan of the instance counts, and additional total instance count at the end.
      */
     export struct NodeInstanceCountExclusiveScanWithCount final : std::vector<std::uint32_t> {
         explicit NodeInstanceCountExclusiveScanWithCount(const fastgltf::Asset &asset)
             : vector { exclusive_scan_with_count(asset.nodes | std::views::transform([&](const fastgltf::Node &node) -> std::uint32_t {
                 if (node.instancingAttributes.empty()) {
-                    return 1;
+                    return 0;
                 }
                 else {
                     // According to the EXT_mesh_gpu_instancing specification, all attribute accessors in a given node

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -265,7 +265,7 @@ namespace vk_gltf_viewer::vulkan {
             }
 
             gltfAsset.emplace(asset, directory, orderedPrimitives, gpu, fallbackTexture, adapter);
-            if (!gpu.supportVariableDescriptorCount && assetDescriptorSetLayout.descriptorCounts[7] != textureCount) {
+            if (!gpu.supportVariableDescriptorCount && assetDescriptorSetLayout.descriptorCounts[6] != textureCount) {
                 // If texture count is different, descriptor set layouts, pipeline layouts and pipelines have to be recreated.
                 depthPipelines.clear();
                 maskDepthPipelines.clear();

--- a/interface/vulkan/descriptor_set_layout/Asset.cppm
+++ b/interface/vulkan/descriptor_set_layout/Asset.cppm
@@ -8,7 +8,7 @@ import std;
 export import :vulkan.Gpu;
 
 namespace vk_gltf_viewer::vulkan::dsl {
-    export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
+    export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
         explicit Asset(const Gpu &gpu LIFETIMEBOUND)
             : DescriptorSetLayout { gpu.device, vk::StructureChain {
                 vk::DescriptorSetLayoutCreateInfo {
@@ -19,13 +19,11 @@ namespace vk_gltf_viewer::vulkan::dsl {
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
-                        { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment },
                         { maxTextureCount(gpu), vk::ShaderStageFlagBits::eFragment })),
                 },
                 vk::DescriptorSetLayoutBindingFlagsCreateInfo {
                     vku::unsafeProxy<vk::DescriptorBindingFlags>({
-                        {},
                         {},
                         {},
                         vk::DescriptorBindingFlagBits::ePartiallyBound,
@@ -47,13 +45,11 @@ namespace vk_gltf_viewer::vulkan::dsl {
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex },
-                        { 1, vk::ShaderStageFlagBits::eVertex },
                         { 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment },
                         { textureCount, vk::ShaderStageFlagBits::eFragment })),
                 },
                 vk::DescriptorSetLayoutBindingFlagsCreateInfo {
                     vku::unsafeProxy<vk::DescriptorBindingFlags>({
-                        {},
                         {},
                         {},
                         vk::DescriptorBindingFlagBits::ePartiallyBound,

--- a/interface/vulkan/shader_type/Node.cppm
+++ b/interface/vulkan/shader_type/Node.cppm
@@ -6,18 +6,18 @@ export module vk_gltf_viewer:vulkan.shader_type.Node;
 
 import std;
 export import glm;
+export import vulkan_hpp;
 
 namespace vk_gltf_viewer::vulkan::shader_type {
     export struct Node {
         glm::mat4 worldTransform;
-        std::uint32_t instancedTransformStartIndex;
+        vk::DeviceAddress pInstancedWorldTransforms;
         std::uint32_t morphTargetWeightStartIndex;
         std::uint32_t skinJointIndexStartIndex;
-        std::uint32_t _padding_;
     };
 
     static_assert(sizeof(Node) == 80);
-    static_assert(offsetof(Node, instancedTransformStartIndex) == 64);
-    static_assert(offsetof(Node, morphTargetWeightStartIndex) == 68);
-    static_assert(offsetof(Node, skinJointIndexStartIndex) == 72);
+    static_assert(offsetof(Node, pInstancedWorldTransforms) == 64);
+    static_assert(offsetof(Node, morphTargetWeightStartIndex) == 72);
+    static_assert(offsetof(Node, skinJointIndexStartIndex) == 76);
 }

--- a/shaders/depth.vert
+++ b/shaders/depth.vert
@@ -22,16 +22,13 @@ layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
-    mat4 instancedTransforms[];
-};
-layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
+layout (set = 0, binding = 2) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 0, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+layout (set = 0, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
     uint skinJointIndices[];
 };
-layout (set = 0, binding = 5) readonly buffer InverseBindMatrixBuffer {
+layout (set = 0, binding = 4) readonly buffer InverseBindMatrixBuffer {
     mat4 inverseBindMatrices[];
 };
 

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -20,16 +20,13 @@ layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
-    mat4 instancedTransforms[];
-};
-layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
+layout (set = 0, binding = 2) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 0, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+layout (set = 0, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
     uint skinJointIndices[];
 };
-layout (set = 0, binding = 5) readonly buffer InverseBindMatrixBuffer {
+layout (set = 0, binding = 4) readonly buffer InverseBindMatrixBuffer {
     mat4 inverseBindMatrices[];
 };
 

--- a/shaders/mask_depth.frag
+++ b/shaders/mask_depth.frag
@@ -27,10 +27,10 @@ layout (location = 2) in FRAG_VARIADIC_IN {
 
 layout (location = 0) out uint outNodeIndex;
 
-layout (set = 0, binding = 6, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 5, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 0, binding = 7) uniform sampler2D textures[];
+layout (set = 0, binding = 6) uniform sampler2D textures[];
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;

--- a/shaders/mask_depth.vert
+++ b/shaders/mask_depth.vert
@@ -37,19 +37,16 @@ layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
-    mat4 instancedTransforms[];
-};
-layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
+layout (set = 0, binding = 2) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 0, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+layout (set = 0, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
     uint skinJointIndices[];
 };
-layout (set = 0, binding = 5) readonly buffer InverseBindMatrixBuffer {
+layout (set = 0, binding = 4) readonly buffer InverseBindMatrixBuffer {
     mat4 inverseBindMatrices[];
 };
-layout (set = 0, binding = 6, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 5, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -26,10 +26,10 @@ layout (location = 1) in FRAG_VARIDIC_IN {
 
 layout (location = 0) out uvec2 outCoordinate;
 
-layout (set = 0, binding = 6, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 5, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 0, binding = 7) uniform sampler2D textures[];
+layout (set = 0, binding = 6) uniform sampler2D textures[];
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -36,19 +36,16 @@ layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 0, binding = 2) readonly buffer InstancedTransformBuffer {
-    mat4 instancedTransforms[];
-};
-layout (set = 0, binding = 3) readonly buffer MorphTargetWeightBuffer {
+layout (set = 0, binding = 2) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 0, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+layout (set = 0, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
     uint skinJointIndices[];
 };
-layout (set = 0, binding = 5) readonly buffer InverseBindMatrixBuffer {
+layout (set = 0, binding = 4) readonly buffer InverseBindMatrixBuffer {
     mat4 inverseBindMatrices[];
 };
-layout (set = 0, binding = 6, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 5, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -55,10 +55,10 @@ layout (set = 0, binding = 0, scalar) uniform SphericalHarmonicsBuffer {
 layout (set = 0, binding = 1) uniform samplerCube prefilteredmap;
 layout (set = 0, binding = 2) uniform sampler2D brdfmap;
 
-layout (set = 1, binding = 6, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 5, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 1, binding = 7) uniform sampler2D textures[];
+layout (set = 1, binding = 6) uniform sampler2D textures[];
 
 layout (push_constant, std430) uniform PushConstant {
     mat4 projectionView;

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -50,19 +50,16 @@ layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
 layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 1, binding = 2) readonly buffer InstancedTransformBuffer {
-    mat4 instancedTransforms[];
-};
-layout (set = 1, binding = 3) readonly buffer MorphTargetWeightBuffer {
+layout (set = 1, binding = 2) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 1, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+layout (set = 1, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
     uint skinJointIndices[];
 };
-layout (set = 1, binding = 5) readonly buffer InverseBindMatrixBuffer {
+layout (set = 1, binding = 4) readonly buffer InverseBindMatrixBuffer {
     mat4 inverseBindMatrices[];
 };
-layout (set = 1, binding = 6, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 5, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/transform.glsl
+++ b/shaders/transform.glsl
@@ -7,7 +7,7 @@
 
 mat4 getTransform(uint skinAttributeCount) {
     if (skinAttributeCount == 0U) {
-        return instancedTransforms[NODE.instancedTransformStartIndex + gl_InstanceIndex - gl_BaseInstance];
+        return NODE.instancedWorldTransforms.data[gl_InstanceIndex - gl_BaseInstance];
     }
     else {
         mat4 skinMatrix = mat4(0.0);

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -34,12 +34,13 @@ struct Material {
 
 #ifdef VERTEX_SHADER
 
+layout (buffer_reference) readonly buffer TransformMatrices { mat4 data[]; };
+
 struct Node {
     mat4 worldTransform;
-    uint instancedTransformStartIndex;
+    TransformMatrices instancedWorldTransforms;
     uint morphTargetWeightStartIndex;
     uint skinJointStartIndex;
-    uint _padding_;
 }; // 80 bytes.
 
 struct Accessor {

--- a/shaders/unlit_primitive.frag
+++ b/shaders/unlit_primitive.frag
@@ -30,10 +30,10 @@ layout (location = 0) out vec4 outColor;
 layout (location = 1) out float outRevealage;
 #endif
 
-layout (set = 1, binding = 6, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 5, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 1, binding = 7) uniform sampler2D textures[];
+layout (set = 1, binding = 6) uniform sampler2D textures[];
 
 #if ALPHA_MODE == 0 || ALPHA_MODE == 2
 layout (early_fragment_tests) in;

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -38,19 +38,16 @@ layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
 layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 1, binding = 2) readonly buffer InstancedTransformBuffer {
-    mat4 instancedTransforms[];
-};
-layout (set = 1, binding = 3) readonly buffer MorphTargetWeightBuffer {
+layout (set = 1, binding = 2) readonly buffer MorphTargetWeightBuffer {
     float morphTargetWeights[];
 };
-layout (set = 1, binding = 4, std430) readonly buffer SkinJointIndexBuffer {
+layout (set = 1, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
     uint skinJointIndices[];
 };
-layout (set = 1, binding = 5) readonly buffer InverseBindMatrixBuffer {
+layout (set = 1, binding = 4) readonly buffer InverseBindMatrixBuffer {
     mat4 inverseBindMatrices[];
 };
-layout (set = 1, binding = 6, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 5, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 


### PR DESCRIPTION
This PR addresses a niche but potentially critical issue related to how node world transforms are accessed in shaders.

Currently, world transforms are accessed via a `mat4 instancedTransforms[]` storage buffer in the shader. This buffer contains flattened world transform matrices for either each instance of a node or the node’s own world transform if it is not instanced (i.e., `fastgltf::Node::instancingAttributes` is empty). However, the shader cannot distinguish between these two cases, making it impossible to access the actual node’s world transform when the node is instanced.

While this scenario is rare—since vertex skinning is the only current feature requiring the node’s actual world transform and it’s unlikely to occur on instanced nodes—it can lead to unexpected rendering issues. Moreover, the current design may hinder the future implementation of features like `KHR_lights_punctual`, which requires access to the true node world transform for lights.

# Changes

This PR modifies the node structure so that each node directly stores its own world transform matrix. This allows the shader to differentiate between the actual node world transform and instance transforms. The new shader-side layout of the node structure is:

```glsl
layout (buffer_reference) readonly buffer TransformMatrices { mat4 data[]; };

struct Node {
    mat4 worldTransform;
    TransformMatrices instancedWorldTransforms;
    uint morphTargetWeightStartIndex;
    uint skinJointStartIndex;
};
```

- The worldTransform field provides the node’s actual world transform.
- The instancedWorldTransforms field points to the per-instance transform buffer if the node is instanced, or to the worldTransform itself if it is not. In the vertex shader, it can be accessed as:

```glsl
node.instancedWorldTransforms.data[gl_InstanceIndex - gl_BaseInstance];
```

# Implications

- The node buffer now contains per-frame data (due to frequent updates from animation or gizmo interaction) and is no longer shared across frames.
- The previously used flattened instance world transform buffer, now accessed via buffer device address, is removed from the descriptor set layout.