### PR TITLE
Implemented LDR skybox loading.

### DIFF
--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -921,25 +921,18 @@ void vk_gltf_viewer::MainApp::closeGltf() {
 
 void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) {
     vk::Extent2D eqmapImageExtent;
+    vk::Format eqmapImageFormat;
     const vku::MappedBuffer eqmapStagingBuffer = [&]() -> vku::MappedBuffer {
         std::unique_ptr<std::byte[]> data; // It should be freed after copying to the staging buffer, therefore declared as unique_ptr.
-        if (auto extension = eqmapPath.extension(); extension == ".hdr") {
-            int width, height;
-            data.reset(reinterpret_cast<std::byte*>(stbi_loadf(PATH_C_STR(eqmapPath), &width, &height, nullptr, 4)));
-            if (!data) {
-                throw std::runtime_error { std::format("Failed to load image: {}", stbi_failure_reason()) };
-            }
-
-            eqmapImageExtent.width = static_cast<std::uint32_t>(width);
-            eqmapImageExtent.height = static_cast<std::uint32_t>(height);
-        }
+        const std::filesystem::path extension = eqmapPath.extension();
 #ifdef SUPPORT_EXR_SKYBOX
-        else if (extension == ".exr") {
+        if (extension == ".exr") {
             Imf::InputFile file{ PATH_C_STR(eqmapPath), static_cast<int>(std::thread::hardware_concurrency()) };
 
             const Imath::Box2i dw = file.header().dataWindow();
             eqmapImageExtent.width = static_cast<std::uint32_t>(dw.max.x - dw.min.x + 1);
             eqmapImageExtent.height = static_cast<std::uint32_t>(dw.max.y - dw.min.y + 1);
+            eqmapImageFormat = vk::Format::eR32G32B32A32Sfloat;
 
             data = std::make_unique_for_overwrite<std::byte[]>(4 * eqmapImageExtent.width * eqmapImageExtent.height * sizeof(float));
 
@@ -954,18 +947,29 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
 
             file.readPixels(frameBuffer, dw.min.y, dw.max.y);
         }
+        else
 #endif
-        else {
-#ifdef SUPPORT_EXR_SKYBOX
-            throw std::runtime_error { "Unknown file format: only HDR and EXR are supported." };
-#else
-            throw std::runtime_error { "Unknown file format: only HDR is supported." };
-#endif
+        {
+            int width, height;
+            if (extension == ".hdr") {
+                data.reset(reinterpret_cast<std::byte*>(stbi_loadf(PATH_C_STR(eqmapPath), &width, &height, nullptr, 4)));
+                eqmapImageFormat = vk::Format::eR32G32B32A32Sfloat;
+            }
+            else {
+                data.reset(reinterpret_cast<std::byte*>(stbi_load(PATH_C_STR(eqmapPath), &width, &height, nullptr, 4)));
+                eqmapImageFormat = vk::Format::eR8G8B8A8Srgb;
+            }
+            if (!data) {
+                throw std::runtime_error { std::format("Failed to load image: {}", stbi_failure_reason()) };
+            }
+
+            eqmapImageExtent.width = static_cast<std::uint32_t>(width);
+            eqmapImageExtent.height = static_cast<std::uint32_t>(height);
         }
 
         return {
             gpu.allocator,
-            std::from_range, std::span { data.get(), sizeof(float[4]) * eqmapImageExtent.width * eqmapImageExtent.height },
+            std::from_range, std::span { data.get(), blockSize(eqmapImageFormat) * eqmapImageExtent.width * eqmapImageExtent.height },
             vk::BufferUsageFlagBits::eTransferSrc,
         };
         // After this scope, data will be automatically freed.
@@ -977,7 +981,7 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
     const vku::AllocatedImage eqmapImage { gpu.allocator, vk::ImageCreateInfo {
         {},
         vk::ImageType::e2D,
-        vk::Format::eR32G32B32A32Sfloat,
+        eqmapImageFormat,
         vk::Extent3D { eqmapImageExtent, 1 },
         eqmapImageMipLevels, 1,
         vk::SampleCountFlagBits::e1,
@@ -1000,7 +1004,8 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
     vku::AllocatedImage cubemapImage { gpu.allocator, vk::ImageCreateInfo {
         vk::ImageCreateFlagBits::eCubeCompatible,
         vk::ImageType::e2D,
-        vk::Format::eR32G32B32A32Sfloat,
+        // Use non-sRGB format as sRGB format is usually not compatible with storage image.
+        eqmapImageFormat == vk::Format::eR8G8B8A8Srgb ? vk::Format::eR8G8B8A8Unorm : eqmapImageFormat,
         vk::Extent3D { 1024, 1024, 1 },
         vku::Image::maxMipLevels(1024), 6,
         vk::SampleCountFlagBits::e1,
@@ -1023,7 +1028,7 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
     vku::AllocatedImage prefilteredmapImage { gpu.allocator, vk::ImageCreateInfo {
         vk::ImageCreateFlagBits::eCubeCompatible,
         vk::ImageType::e2D,
-        vk::Format::eR32G32B32A32Sfloat,
+        cubemapImage.format,
         vk::Extent3D { prefilteredmapSize, prefilteredmapSize, 1 },
         vku::Image::maxMipLevels(prefilteredmapSize), 6,
         vk::SampleCountFlagBits::e1,

--- a/impl/control/AppWindow.cpp
+++ b/impl/control/AppWindow.cpp
@@ -173,6 +173,9 @@ void vk_gltf_viewer::control::AppWindow::onDropCallback(std::span<const char * c
     if (paths.empty()) return;
 
     static constexpr auto supportedSkyboxExtensions = {
+        ".jpg",
+        ".jpeg",
+        ".png",
         ".hdr",
 #ifdef SUPPORT_EXR_SKYBOX
         ".exr",

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -576,12 +576,13 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::menuBar(
                 constexpr std::array filterItems {
                     nfdfilteritem_t { 
                         "All Supported Images", 
-                        "hdr"
+                        "hdr,jpg,jpeg,png"
 #ifdef SUPPORT_EXR_SKYBOX
                         ",exr",
 #endif
                     },
                     nfdfilteritem_t { "HDR Image", "hdr" },
+                    nfdfilteritem_t { "LDR Image", "jpg,jpeg,png" },
 #ifdef SUPPORT_EXR_SKYBOX
                     nfdfilteritem_t { "EXR Image", "exr" },
 #endif


### PR DESCRIPTION
This PR adds support for loading skyboxes from JPG and PNG files. The resulting equirectangular image uses `VK_FORMAT_R8G8B8A8_SRGB`, while the cubemap and prefiltered environment maps use `VK_FORMAT_R8G8B8A8_UNORM`. Compared to the previously used formats (e.g., HDR/EXR), this change can reduce bandwidth usage by approximately 4x.

Implementation Details

To simplify the implementation and avoid performance issues with uncached GPU memory, the image data is no longer written directly into the staging buffer. Instead, the process now:

1. Allocates an uninitialized temporary storage.
2. Writes the decoded image data into this temporary buffer.
3. Copies the result to the staging buffer.

This approach ensures more efficient memory access and better overall performance during texture uploads.