### PR TITLE
Minor fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The extensions and feature used in this application are quite common in the mode
   - (optional) `VK_AMD_shader_image_load_store_lod` (can replace the descriptor indexing based cubemap mipmapping and prefilteredmap generation[^2])
 - Device Features
   - `VkPhysicalDeviceFeatures`
+    - `drawIndirectFirstInstance`
     - `samplerAnistropy`
     - `shaderInt16`
     - `multiDrawIndirect`

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -338,7 +338,7 @@ void vk_gltf_viewer::MainApp::run() {
                         #endif
                     };
 
-                    const std::filesystem::path path = task.paths[0];
+                    const std::filesystem::path &path = task.paths[0];
                     if (std::filesystem::is_directory(path)) {
                         // If directory contains glTF file, load it.
                         for (const std::filesystem::path &childPath : std::filesystem::directory_iterator { path }) {

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -1574,12 +1574,6 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
         sphericalHarmonicCoefficients,
         appState.imageBasedLightingProperties->diffuseIrradiance.sphericalHarmonicCoefficients.begin());
 
-    if (skyboxResources){
-        // Since a descriptor set allocated using ImGui_ImplVulkan_AddTexture cannot be updated, it has to be freed
-        // and re-allocated (which done in below).
-        ImGui_ImplVulkan_RemoveTexture(skyboxResources->imGuiEqmapTextureDescriptorSet);
-    }
-
     // Emplace the results into skyboxResources and imageBasedLightingResources.
     vk::raii::ImageView reducedEqmapImageView { gpu.device, reducedEqmapImage.getViewCreateInfo() };
     const vk::DescriptorSet imGuiEqmapImageDescriptorSet = ImGui_ImplVulkan_AddTexture(

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -1139,8 +1139,8 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
         // After this scope, data will be automatically freed.
     }();
 
-    std::uint32_t eqmapImageMipLevels = 0;
-    for (std::uint32_t mipWidth = eqmapImageExtent.width; mipWidth > 512; mipWidth >>= 1, ++eqmapImageMipLevels);
+    std::uint32_t eqmapImageMipLevels = 1;
+    for (std::uint32_t mipWidth = eqmapImageExtent.width >> 1; mipWidth > 512; mipWidth >>= 1, ++eqmapImageMipLevels);
 
     const vku::AllocatedImage eqmapImage { gpu.allocator, vk::ImageCreateInfo {
         {},
@@ -1165,13 +1165,14 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
         vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eSampled,
     } };
 
+    const std::uint32_t cubemapSize = std::bit_floor(eqmapImageExtent.height / 2);
     vku::AllocatedImage cubemapImage { gpu.allocator, vk::ImageCreateInfo {
         vk::ImageCreateFlagBits::eCubeCompatible,
         vk::ImageType::e2D,
         // Use non-sRGB format as sRGB format is usually not compatible with storage image.
         eqmapImageFormat == vk::Format::eR8G8B8A8Srgb ? vk::Format::eR8G8B8A8Unorm : eqmapImageFormat,
-        vk::Extent3D { 1024, 1024, 1 },
-        vku::Image::maxMipLevels(1024), 6,
+        vk::Extent3D { cubemapSize, cubemapSize, 1 },
+        vku::Image::maxMipLevels(cubemapSize), 6,
         vk::SampleCountFlagBits::e1,
         vk::ImageTiling::eOptimal,
         cubemap::CubemapComputer::requiredCubemapImageUsageFlags
@@ -1188,7 +1189,7 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
         .useShaderImageLoadStoreLod = gpu.supportShaderImageLoadStoreLod,
     } };
 
-    constexpr std::uint32_t prefilteredmapSize = 256;
+    const std::uint32_t prefilteredmapSize = std::min(cubemapSize, 256U);
     vku::AllocatedImage prefilteredmapImage { gpu.allocator, vk::ImageCreateInfo {
         vk::ImageCreateFlagBits::eCubeCompatible,
         vk::ImageType::e2D,
@@ -1547,7 +1548,7 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
     }, ~0ULL);
 
     const std::span<glm::vec3> sphericalHarmonicCoefficients = sphericalHarmonicsBuffer.asRange<glm::vec3>();
-    for (float multiplier = 4.f * std::numbers::pi_v<float> / (cubemapImage.extent.width * cubemapImage.extent.width * 6.f);
+    for (float multiplier = 4.f * std::numbers::pi_v<float> / (cubemapSize * cubemapSize * 6.f);
         glm::vec3 &v : sphericalHarmonicCoefficients) {
         v *= multiplier;
     }
@@ -1561,10 +1562,10 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
             .dimension = { eqmapImage.extent.width, eqmapImage.extent.height },
         },
         .cubemap = {
-            .size = cubemapImage.extent.width,
+            .size = cubemapSize,
         },
         .prefilteredmap = {
-            .size = prefilteredmapImage.extent.width,
+            .size = prefilteredmapSize,
             .roughnessLevels = prefilteredmapImage.mipLevels,
             .sampleCount = 1024,
         }

--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -26,6 +26,7 @@ constexpr std::array optionalExtensions {
 };
 
 constexpr vk::PhysicalDeviceFeatures requiredFeatures = vk::PhysicalDeviceFeatures{}
+    .setDrawIndirectFirstInstance(true)
     .setSamplerAnisotropy(true)
     .setShaderInt16(true)
     .setMultiDrawIndirect(true)
@@ -130,7 +131,7 @@ vk::raii::PhysicalDevice vk_gltf_viewer::vulkan::Gpu::selectPhysicalDevice(const
         }
 
         // Check physical device feature availability.
-        const vk::StructureChain availableFeatures
+        const auto [features2, vulkan11Features, vulkan12Features, dynamicRenderingFeatures, synchronization2Features, extendedDynamicStateFeatures]
             = physicalDevice.getFeatures2<
                 vk::PhysicalDeviceFeatures2,
                 vk::PhysicalDeviceVulkan11Features,
@@ -138,15 +139,13 @@ vk::raii::PhysicalDevice vk_gltf_viewer::vulkan::Gpu::selectPhysicalDevice(const
                 vk::PhysicalDeviceDynamicRenderingFeatures,
                 vk::PhysicalDeviceSynchronization2Features,
                 vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-        const vk::PhysicalDeviceFeatures &features = availableFeatures.get<vk::PhysicalDeviceFeatures2>().features;
-        const vk::PhysicalDeviceVulkan11Features &vulkan11Features = availableFeatures.get<vk::PhysicalDeviceVulkan11Features>();
-        const vk::PhysicalDeviceVulkan12Features &vulkan12Features = availableFeatures.get<vk::PhysicalDeviceVulkan12Features>();
-        if (!features.samplerAnisotropy ||
-            !features.shaderInt16 ||
-            !features.multiDrawIndirect ||
-            !features.shaderStorageImageWriteWithoutFormat ||
-            !features.independentBlend ||
-            !features.fragmentStoresAndAtomics ||
+        if (!features2.features.drawIndirectFirstInstance ||
+            !features2.features.samplerAnisotropy ||
+            !features2.features.shaderInt16 ||
+            !features2.features.multiDrawIndirect ||
+            !features2.features.shaderStorageImageWriteWithoutFormat ||
+            !features2.features.independentBlend ||
+            !features2.features.fragmentStoresAndAtomics ||
             !vulkan11Features.shaderDrawParameters ||
             !vulkan11Features.storageBuffer16BitAccess ||
             !vulkan11Features.uniformAndStorageBuffer16BitAccess ||
@@ -161,9 +160,9 @@ vk::raii::PhysicalDevice vk_gltf_viewer::vulkan::Gpu::selectPhysicalDevice(const
             !vulkan12Features.scalarBlockLayout ||
             !vulkan12Features.timelineSemaphore ||
             !vulkan12Features.shaderInt8 ||
-            !availableFeatures.get<vk::PhysicalDeviceDynamicRenderingFeatures>().dynamicRendering ||
-            !availableFeatures.get<vk::PhysicalDeviceSynchronization2Features>().synchronization2 ||
-            !availableFeatures.get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState) {
+            !dynamicRenderingFeatures.dynamicRendering ||
+            !synchronization2Features.synchronization2 ||
+            !extendedDynamicStateFeatures.extendedDynamicState) {
             return 0U;
         }
 

--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -21,7 +21,7 @@ constexpr std::array requiredExtensions {
 
 constexpr std::array optionalExtensions {
     vk::KHRSwapchainMutableFormatExtensionName,
-    vk::EXTIndexTypeUint8ExtensionName,
+    vk::KHRIndexTypeUint8ExtensionName,
     vk::AMDShaderImageLoadStoreLodExtensionName,
 };
 

--- a/interface/control/AppWindow.cppm
+++ b/interface/control/AppWindow.cppm
@@ -45,7 +45,7 @@ namespace vk_gltf_viewer::control {
             });
             glfwSetDropCallback(window, [](GLFWwindow *window, int count, const char **paths) {
                 static_cast<AppWindow*>(glfwGetWindowUserPointer(window))
-                    ->pTasks->emplace(std::in_place_type<task::WindowDrop>, std::span { paths, static_cast<std::size_t>(count) });
+                    ->pTasks->emplace(std::in_place_type<task::WindowDrop>, std::vector<std::filesystem::path> { std::from_range, std::span { paths, static_cast<std::size_t>(count) } });
             });
         }
 

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -12,7 +12,7 @@ namespace vk_gltf_viewer::control {
         struct WindowScroll { glm::dvec2 offset; };
         struct WindowTrackpadZoom { double scale; };
         struct WindowTrackpadRotate { double angle; };
-        struct WindowDrop { std::span<const char* const> paths; };
+        struct WindowDrop { std::vector<std::filesystem::path> paths; };
 
         struct ChangePassthruRect { ImRect newRect; };
         struct LoadGltf { std::filesystem::path path; };


### PR DESCRIPTION
- Disable the unsigned byte index type support for MoltenVK.
  - `VK_KHR_index_type_uint8` extension is supported from MoltenVK v1.3.0, but it uses compute command encoder to copy the `uint8_t`s to `uint16_t`s, which breaks the render pass and have performance penalty. As the application already has loading time fallback path for it, the feature should be disabled.
- Add missing `VkPhysicalDeviceFeatures::drawIndirectFirstInstance` requirement.
- Fix `control::task::WindowDrop` stores dangling `const char*`, by make it to have ownership for `std::filesystem::path`s.
- Fix `vk::InitializationError` for input equirectangular map image width ≤ 512 by setting the minimum mip level as 1. Also dynamically adjust the cubemap and prefiltered map image resolution.
  - By default, cubemap size is bit floor of (equirectangular map height) / 2.
- Fix duplicated `MainApp::SkyboxResources::imGuiEqmapTextureDescriptorSet` destroying.
- Fix inconsistent extension usage: replaced `VK_EXT_index_type_uint8` -> `VK_KHR_index_type_uint8`.