### PR TITLE
Update vcpkg baseline.

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,13 +1,13 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "460551b0ec06be1ba6b918448bf3b0f44add813d",
+    "baseline": "38d9cf0bd45404cd25aeb03f79bcb0af256de343",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [
     {
       "kind": "git",
-      "baseline": "fc7f511164e1e0eb4ad9b99268147a84a89cec63",
+      "baseline": "8764d1f97ea52e2895ef30cd8ffea310159b43e6",
       "reference": "main",
       "repository": "https://github.com/stripe2933/vcpkg-registry",
       "packages": [


### PR DESCRIPTION
As CI uses the newest Vulkan SDK (1.4.313), binary cache of vku also has to be invalidated. The bumped vcpkg baseline contains the updated vku dependency. 