### PR TITLE
Support KHR_materials_ior glTF 2.0 extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Blazingly fast[^1] Vulkan glTF viewer.
   - Multiple scenes.
   - Binary format (`.glb`).
 - Support glTF 2.0 extensions:
+  - [`KHR_materials_ior`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_ior)
   - [`KHR_materials_unlit`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_unlit) for lighting independent material shading
   - [`KHR_materials_variants`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_variants)
   - [`KHR_mesh_quantization`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_mesh_quantization)

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -551,6 +551,12 @@ void vk_gltf_viewer::MainApp::run() {
                                 changedMaterial.pbrData.roughnessFactor,
                                 sharedDataUpdateCommandBuffer);
                             break;
+                        case Property::Ior:
+                            hasUpdateData |= sharedData.gltfAsset->materialBuffer.update<&vulkan::shader_type::Material::ior>(
+                                task.materialIndex,
+                                changedMaterial.ior,
+                                sharedDataUpdateCommandBuffer);
+                            break;
                     }
                 },
                 [&](const control::task::SelectMaterialVariants &task) {

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -1033,6 +1033,14 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(
                     }, material.unlit);
                 }
             });
+
+            if (ImGui::CollapsingHeader("KHR_materials_ior")) {
+                ImGui::WithDisabled([&]() {
+                    if (ImGui::DragFloat("Index of Refraction", &material.ior, 1e-2f, 1.f, std::numeric_limits<float>::max())) {
+                        notifyPropertyChanged(task::MaterialPropertyChanged::Ior);
+                    }
+                }, material.unlit);
+            }
         }
     }
     ImGui::End();

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -27,7 +27,8 @@ namespace vk_gltf_viewer {
 
     private:
         static constexpr fastgltf::Extensions SUPPORTED_EXTENSIONS
-            = fastgltf::Extensions::KHR_materials_unlit
+            = fastgltf::Extensions::KHR_materials_ior
+            | fastgltf::Extensions::KHR_materials_unlit
             | fastgltf::Extensions::KHR_materials_variants
             | fastgltf::Extensions::KHR_mesh_quantization
 #ifdef SUPPORT_KHR_TEXTURE_BASISU

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -47,6 +47,7 @@ namespace vk_gltf_viewer::control {
                 OcclusionTextureTransform,
                 OcclusionTextureTransformEnabled,
                 Unlit,
+                Ior,
             };
 
             std::size_t materialIndex;

--- a/interface/vulkan/buffer/Materials.cppm
+++ b/interface/vulkan/buffer/Materials.cppm
@@ -95,6 +95,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
                     .roughnessFactor = material.pbrData.roughnessFactor,
                     .emissiveFactor = glm::gtc::make_vec3(material.emissiveFactor.data()),
                     .alphaCutOff = material.alphaCutoff,
+                    .ior = material.ior,
                 };
 
                 if (const auto& baseColorTexture = material.pbrData.baseColorTexture) {

--- a/interface/vulkan/shader_type/Material.cppm
+++ b/interface/vulkan/shader_type/Material.cppm
@@ -32,7 +32,8 @@ namespace vk_gltf_viewer::vulkan::shader_type {
         glm::mat3x2 normalTextureTransform;
         glm::mat3x2 occlusionTextureTransform;
         glm::mat3x2 emissiveTextureTransform;
-        char padding1[8];
+        float ior = 1.5;
+        char padding1[4];
     };
 
     static_assert(sizeof(Material) == 192);

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -205,7 +205,10 @@ void main(){
     }
     vec3 R = reflect(-V, N);
 
-    vec3 F0 = mix(vec3(0.04), baseColor.rgb, metallic);
+    float dielectric_f0 = (MATERIAL.ior - 1.0) / (MATERIAL.ior + 1.0);
+    dielectric_f0 = dielectric_f0 * dielectric_f0;
+
+    vec3 F0 = mix(vec3(dielectric_f0), baseColor.rgb, metallic);
     float maxNdotV = max(NdotV, 0.0);
     vec3 F = fresnelSchlickRoughness(maxNdotV, F0, roughness);
 

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -25,7 +25,8 @@ struct Material {
     mat3x2 normalTextureTransform;
     mat3x2 occlusionTextureTransform;
     mat3x2 emissiveTextureTransform;
-    vec2 padding1;
+    float ior;
+    float padding1;
 }; // 192 bytes.
 
 // --------------------


### PR DESCRIPTION
<table>
    <thead>
        <tr>
            <td><a href="https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/CompareIor">CompareIOR</a></td>
            <td><a href="https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/IORTestGrid">IORTestGrid</a></td>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td><img width="1392" alt="CompareIOR" src="https://github.com/user-attachments/assets/ad810f36-6ab6-464b-a840-6ba7440ee5bd" /></td>
            <td><img width="1392" alt="IORTestGrid" src="https://github.com/user-attachments/assets/e61774de-48eb-4440-8f85-c408305a418d" /></td>
        </tr>
    </tbody>
</table>

This PR adds support for [`KHR_materials_ior`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_ior). Currently the difference of rendering is insignificant as it only affects the Fresnel component of the PBR, however it has to be implemented in advance to implement the other material extensions like [`KHR_materials_transmission`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_transmission), [`KHR_materials_volume`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_volume), etc.