### PR TITLE
Optimize scene world transforms/miniball calculation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/gltf/NodeWorldTransforms.cppm
         interface/gltf/OrderedPrimitives.cppm
         interface/gltf/TextureUsages.cppm
+        interface/helpers/mod.cppm
         interface/helpers/AggregateHasher.cppm
         interface/helpers/algorithm.cppm
         interface/helpers/concepts.cppm
@@ -163,6 +164,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/helpers/imgui/mod.cppm
         interface/helpers/imgui/table.cppm
         interface/helpers/io.cppm
+        interface/helpers/Lazy.cppm
         interface/helpers/optional.cppm
         interface/helpers/PairHasher.cppm
         interface/helpers/ranges/mod.cppm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/gltf/data_structure/SceneInverseHierarchy.cppm
         interface/gltf/data_structure/TargetWeightCountExclusiveScanWithCount.cppm
         interface/gltf/NodeAnimationUsages.cppm
+        interface/gltf/SceneNodeLevels.cppm
         interface/gltf/StateCachedNodeVisibilityStructure.cppm
         interface/gltf/NodeWorldTransforms.cppm
         interface/gltf/OrderedPrimitives.cppm

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -159,17 +159,16 @@ void vk_gltf_viewer::MainApp::run() {
 
         std::queue<control::Task> tasks;
 
+        std::vector<std::size_t> transformedNodes;
+
         // Collect task from animation system.
         if (gltf) {
-            std::vector<std::size_t> transformedNodes, morphedNodes;
+            std::vector<std::size_t> morphedNodes;
             for (const auto &[animation, enabled] : std::views::zip(gltf->animations, *gltf->animationEnabled)) {
                 if (!enabled) continue;
                 animation.update(glfwGetTime(), back_inserter(transformedNodes), back_inserter(morphedNodes), gltf->assetExternalBuffers);
             }
 
-            for (std::size_t nodeIndex : transformedNodes) {
-                tasks.emplace(std::in_place_type<control::task::NodeLocalTransformChanged>, nodeIndex);
-            }
             for (std::size_t nodeIndex : morphedNodes) {
                 const std::size_t targetWeightCount = getTargetWeightCount(gltf->asset.nodes[nodeIndex], gltf->asset);
                 tasks.emplace(std::in_place_type<control::task::MorphTargetWeightChanged>, nodeIndex, 0, targetWeightCount);
@@ -244,6 +243,8 @@ void vk_gltf_viewer::MainApp::run() {
             task(frame);
         }
         deferredFrameUpdateTasks.clear();
+
+        bool recalculateSceneMiniball = false;
 
         graphicsCommandPool.reset();
         sharedDataUpdateCommandBuffer.begin({ vk::CommandBufferUsageFlagBits::eOneTimeSubmit });
@@ -426,31 +427,7 @@ void vk_gltf_viewer::MainApp::run() {
                     gltf->hoveringNode.emplace(task.nodeIndex);
                 },
                 [&](const control::task::NodeLocalTransformChanged &task) {
-                    fastgltf::math::fmat4x4 baseMatrix { 1.f };
-                    if (const auto &parentNodeIndex = gltf->sceneInverseHierarchy->parentNodeIndices[task.nodeIndex]) {
-                        baseMatrix = gltf->nodeWorldTransforms[*parentNodeIndex];
-                    }
-                    const fastgltf::math::fmat4x4 nodeWorldTransform = fastgltf::getTransformMatrix(gltf->asset.nodes[task.nodeIndex], baseMatrix);
-
-                    // Update the current and its descendant nodes' world transforms for both host and GPU side data.
-                    gltf->nodeWorldTransforms.update(task.nodeIndex, nodeWorldTransform);
-                    auto updateNodeTransformTask = [this, nodeIndex = task.nodeIndex](vulkan::Frame &frame) {
-                        if (frame.gltfAsset->instancedNodeWorldTransformBuffer) {
-                            frame.gltfAsset->instancedNodeWorldTransformBuffer->update(
-                                nodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
-                        }
-                        frame.gltfAsset->nodeBuffer.update(nodeIndex, gltf->nodeWorldTransforms);
-                    };
-                    updateNodeTransformTask(frame);
-                    deferredFrameUpdateTasks.push_back(std::move(updateNodeTransformTask));
-
-                    // Scene enclosing sphere would be changed. Adjust the camera's near/far plane if necessary.
-                    if (appState.automaticNearFarPlaneAdjustment) {
-                        const auto &[center, radius]
-                            = gltf->sceneMiniball
-                            = gltf::algorithm::getMiniball(gltf->asset, gltf->asset.scenes[gltf->sceneIndex], gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
-                        appState.camera.tightenNearFar(glm::make_vec3(center.data()), radius);
-                    }
+                    transformedNodes.push_back(task.nodeIndex);
                 },
                 [this](control::task::TightenNearFarPlane) {
                     if (gltf) {
@@ -580,15 +557,69 @@ void vk_gltf_viewer::MainApp::run() {
                     updateTargetWeightTask(frame);
                     deferredFrameUpdateTasks.push_back(std::move(updateTargetWeightTask));
 
-                    // Scene enclosing sphere would be changed. Adjust the camera's near/far plane if necessary.
-                    if (appState.automaticNearFarPlaneAdjustment) {
-                        const auto &[center, radius]
-                            = gltf->sceneMiniball
-                            = gltf::algorithm::getMiniball(gltf->asset, gltf->asset.scenes[gltf->sceneIndex], gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
-                        appState.camera.tightenNearFar(glm::make_vec3(center.data()), radius);
-                    }
+                    recalculateSceneMiniball = true;
                 },
             }, tasks.front());
+        }
+
+        if (!transformedNodes.empty()) {
+            std::vector visited(gltf->asset.nodes.size(), false);
+
+            // Remove duplicates in transformedNodes.
+            std::ranges::sort(transformedNodes);
+            const auto [begin, end] = std::ranges::unique(transformedNodes);
+            transformedNodes.erase(begin, end);
+
+            // Sort transformedNodes by their node level in the scene.
+            std::ranges::sort(transformedNodes, {}, LIFT(gltf->sceneNodeLevels.operator[]));
+
+            for (std::size_t nodeIndex : transformedNodes) {
+                // If node is marked as visited, its world transform is already updated by its ancestor node. Skipping it.
+                if (visited[nodeIndex]) continue;
+
+                // TODO.CXX26: std::optional<const fastgltf::math::fmat4x4&> can ditch the unnecessary copying.
+                fastgltf::math::fmat4x4 baseMatrix { 1.f };
+                if (const auto &parentNodeIndex = gltf->sceneInverseHierarchy->parentNodeIndices[nodeIndex]) {
+                    baseMatrix = gltf->nodeWorldTransforms[*parentNodeIndex];
+                }
+                const fastgltf::math::fmat4x4 nodeWorldTransform = fastgltf::getTransformMatrix(gltf->asset.nodes[nodeIndex], baseMatrix);
+
+                // Update the current and its descendant nodes' world transforms for both host and GPU side data.
+                gltf->nodeWorldTransforms.update(nodeIndex, nodeWorldTransform);
+                auto updateNodeTransformTask = [this, nodeIndex](vulkan::Frame &frame) {
+                    if (frame.gltfAsset->instancedNodeWorldTransformBuffer) {
+                        frame.gltfAsset->instancedNodeWorldTransformBuffer->update(
+                            nodeIndex, gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+                    }
+                    frame.gltfAsset->nodeBuffer.update(nodeIndex, gltf->nodeWorldTransforms);
+                };
+                updateNodeTransformTask(frame);
+                deferredFrameUpdateTasks.push_back(std::move(updateNodeTransformTask));
+
+                // Mark current and its descendant nodes as visited.
+                gltf::algorithm::traverseNode(gltf->asset, nodeIndex, [&](std::size_t nodeIndex) noexcept {
+                    if (visited[nodeIndex]) {
+                        // If node is already visited, its descendants must be visited too. Therefore, continuing traversal
+                        // is unnecessary.
+                        return false;
+                    }
+                    else {
+                        visited[nodeIndex] = true;
+                        return true;
+                    }
+                });
+            }
+
+            recalculateSceneMiniball = true;
+        }
+
+        if (recalculateSceneMiniball) {
+            gltf->sceneMiniball = gltf::algorithm::getMiniball(
+                gltf->asset, gltf->asset.scenes[gltf->sceneIndex], gltf->nodeWorldTransforms, gltf->assetExternalBuffers);
+        }
+        if (gltf && appState.automaticNearFarPlaneAdjustment) {
+            const auto &[center, radius] = gltf->sceneMiniball;
+            appState.camera.tightenNearFar(glm::make_vec3(center.data()), radius);
         }
 
         if (hasUpdateData) {
@@ -832,6 +863,7 @@ vk_gltf_viewer::MainApp::Gltf::Gltf(fastgltf::Parser &parser, const std::filesys
     , sceneIndex { asset.defaultScene.value_or(0) }
     , nodeWorldTransforms { asset, asset.scenes[sceneIndex] }
     , sceneInverseHierarchy { std::make_shared<gltf::ds::SceneInverseHierarchy>(asset, asset.scenes[sceneIndex]) }
+    , sceneNodeLevels { asset, asset.scenes[sceneIndex] }
     , nodeVisibilities { asset, asset.scenes[sceneIndex], sceneInverseHierarchy } {
     sceneMiniball = gltf::algorithm::getMiniball(asset, asset.scenes[sceneIndex], nodeWorldTransforms, assetExternalBuffers);
 }
@@ -840,6 +872,7 @@ void vk_gltf_viewer::MainApp::Gltf::setScene(std::size_t sceneIndex) {
     this->sceneIndex = sceneIndex;
     nodeWorldTransforms.update(asset.scenes[sceneIndex]);
     sceneInverseHierarchy = std::make_shared<gltf::ds::SceneInverseHierarchy>(asset, asset.scenes[sceneIndex]);
+    sceneNodeLevels = { asset, asset.scenes[sceneIndex] };
     nodeVisibilities.setScene(asset.scenes[sceneIndex], sceneInverseHierarchy);
     selectedNodes.clear();
     hoveringNode.reset();

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -398,7 +398,7 @@ void vk_gltf_viewer::MainApp::run() {
                     // Adjust the camera based on the scene enclosing sphere.
                     const auto &[center, radius] = gltf->sceneMiniball.get();
                     const float distance = radius / std::sin(appState.camera.fov / 2.f);
-                    appState.camera.position = glm::make_vec3(center.data()) - glm::dvec3 { distance * normalize(appState.camera.direction) };
+                    appState.camera.position = glm::make_vec3(center.data()) - distance * normalize(appState.camera.direction);
                     appState.camera.zMin = distance - radius;
                     appState.camera.zMax = distance + radius;
                     appState.camera.targetDistance = distance;
@@ -1018,7 +1018,7 @@ void vk_gltf_viewer::MainApp::loadGltf(const std::filesystem::path &path) {
     // Adjust the camera based on the scene enclosing sphere.
     const auto &[center, radius] = gltf->sceneMiniball.get();
     const float distance = radius / std::sin(appState.camera.fov / 2.f);
-    appState.camera.position = glm::make_vec3(center.data()) - glm::dvec3 { distance * normalize(appState.camera.direction) };
+    appState.camera.position = glm::make_vec3(center.data()) - distance * normalize(appState.camera.direction);
     appState.camera.zMin = distance - radius;
     appState.camera.zMax = distance + radius;
     appState.camera.targetDistance = distance;

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -1660,28 +1660,19 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::inputControl(
 ) {
     if (ImGui::Begin("Input control")){
         if (ImGui::CollapsingHeader("Camera")) {
-            bool cameraViewChanged = false;
-            cameraViewChanged |= ImGui::DragFloat3("Position", value_ptr(camera.position), 0.1f);
+            ImGui::DragFloat3("Position", value_ptr(camera.position), 0.1f);
             if (ImGui::DragFloat3("Direction", value_ptr(camera.direction), 0.1f, -1.f, 1.f)) {
                 camera.direction = normalize(camera.direction);
-                cameraViewChanged = true;
             }
             if (ImGui::DragFloat3("Up", value_ptr(camera.up), 0.1f, -1.f, 1.f)) {
                 camera.up = normalize(camera.up);
-                cameraViewChanged = true;
-            }
-
-            if (cameraViewChanged) {
-                tasks.emplace(std::in_place_type<task::CameraViewChanged>);
             }
 
             if (float fovInDegree = glm::degrees(camera.fov); ImGui::DragFloat("FOV", &fovInDegree, 0.1f, 15.f, 120.f, "%.2f deg")) {
                 camera.fov = glm::radians(fovInDegree);
             }
 
-            if (ImGui::Checkbox("Automatic Near/Far Adjustment", &automaticNearFarPlaneAdjustment) && automaticNearFarPlaneAdjustment) {
-                tasks.emplace(std::in_place_type<task::TightenNearFarPlane>);
-            }
+            ImGui::Checkbox("Automatic Near/Far Adjustment", &automaticNearFarPlaneAdjustment);
             ImGui::SameLine();
             ImGui::HelperMarker("(?)", "Near/Far plane will be automatically tightened to fit the scene bounding box.");
 
@@ -1731,8 +1722,6 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::imguizmo(Camera &camera) {
         const glm::mat4 inverseView = inverse(newView);
         camera.position = inverseView[3];
         camera.direction = -inverseView[2];
-
-        tasks.emplace(std::in_place_type<task::CameraViewChanged>);
     }
 }
 
@@ -1784,7 +1773,5 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::imguizmo(
         const glm::mat4 inverseView = inverse(newView);
         camera.position = inverseView[3];
         camera.direction = -inverseView[2];
-
-        tasks.emplace(std::in_place_type<task::CameraViewChanged>);
     }
 }

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -102,7 +102,7 @@ namespace vk_gltf_viewer {
              * 
 			 * The first of the pair is the center, and the second is the radius of the miniball.
 			 */
-            Lazy<std::pair<fastgltf::math::dvec3, double>> sceneMiniball;
+            Lazy<std::pair<fastgltf::math::fvec3, float>> sceneMiniball;
 
             Gltf(fastgltf::Parser &parser, const std::filesystem::path &path);
 

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -7,9 +7,10 @@ import :gltf.Animation;
 import :gltf.AssetExternalBuffers;
 import :gltf.data_structure.MaterialVariantsMapping;
 import :gltf.data_structure.SceneInverseHierarchy;
-import :gltf.StateCachedNodeVisibilityStructure;
 import :gltf.NodeAnimationUsages;
 import :gltf.NodeWorldTransforms;
+import :gltf.SceneNodeLevels;
+import :gltf.StateCachedNodeVisibilityStructure;
 import :gltf.TextureUsages;
 import :helpers.fastgltf;
 import :imgui.UserData;
@@ -89,6 +90,7 @@ namespace vk_gltf_viewer {
 
             gltf::NodeWorldTransforms nodeWorldTransforms;
             std::shared_ptr<gltf::ds::SceneInverseHierarchy> sceneInverseHierarchy;
+            gltf::SceneNodeLevels sceneNodeLevels;
 
             gltf::StateCachedNodeVisibilityStructure nodeVisibilities;
             std::unordered_set<std::size_t> selectedNodes;

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -1,6 +1,7 @@
 export module vk_gltf_viewer:MainApp;
 
 import std;
+import vk_gltf_viewer.helpers;
 import :AppState;
 import :control.AppWindow;
 import :gltf.Animation;
@@ -101,7 +102,7 @@ namespace vk_gltf_viewer {
              * 
 			 * The first of the pair is the center, and the second is the radius of the miniball.
 			 */
-            std::pair<fastgltf::math::dvec3, double> sceneMiniball;
+            Lazy<std::pair<fastgltf::math::dvec3, double>> sceneMiniball;
 
             Gltf(fastgltf::Parser &parser, const std::filesystem::path &path);
 

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -23,8 +23,6 @@ namespace vk_gltf_viewer::control {
         struct NodeSelectionChanged { };
         struct HoverNodeFromGui { std::size_t nodeIndex; };
         struct NodeLocalTransformChanged { std::size_t nodeIndex; };
-        struct TightenNearFarPlane { };
-        struct CameraViewChanged { };
         struct MaterialPropertyChanged {
             enum Property {
                 AlphaCutoff,
@@ -74,8 +72,6 @@ namespace vk_gltf_viewer::control {
         task::NodeSelectionChanged,
         task::HoverNodeFromGui,
         task::NodeLocalTransformChanged,
-        task::TightenNearFarPlane,
-        task::CameraViewChanged,
         task::MaterialPropertyChanged,
         task::SelectMaterialVariants,
         task::MorphTargetWeightChanged>;

--- a/interface/gltf/SceneNodeLevels.cppm
+++ b/interface/gltf/SceneNodeLevels.cppm
@@ -1,0 +1,28 @@
+export module vk_gltf_viewer:gltf.SceneNodeLevels;
+
+import std;
+export import fastgltf;
+
+namespace vk_gltf_viewer::gltf {
+    /**
+     * @brief Data structure that caches the level of a node in the glTF asset scene.
+     *
+     * You can access the level of <tt>i</tt>-th node as <tt>sceneNodeLevels[i]</tt>.
+     *
+     * @note Accessing a node that is not in the scene will return undefined value.
+     */
+    export struct SceneNodeLevels : std::vector<std::size_t> {
+        SceneNodeLevels(const fastgltf::Asset &asset, const fastgltf::Scene &scene) {
+            resize(asset.nodes.size());
+            for (std::size_t nodeIndex : scene.nodeIndices) {
+                [&](this const auto &self, std::size_t nodeIndex, std::size_t level) -> void {
+                    operator[](nodeIndex) = level;
+
+                    for (std::size_t childNodeIndex : asset.nodes[nodeIndex].children) {
+                        self(childNodeIndex, level + 1);
+                    }
+                }(nodeIndex, 0);
+            }
+        }
+    };
+}

--- a/interface/gltf/algorithm/bounding_box.cppm
+++ b/interface/gltf/algorithm/bounding_box.cppm
@@ -13,13 +13,13 @@ namespace vk_gltf_viewer::gltf::algorithm {
     /**
      * @brief Get min/max points of \p primitive's bounding box.
      *
-     * @tparam T Floating point type for calculate position, default: <tt>double</tt>.
+     * @tparam T Floating point type for calculate position.
      * @param primtiive primitive to get the bounding box corner points.
      * @param node Node that owns \p primitive.
      * @param asset Asset that owns \p node.
      * @return Array of (min, max) of the bounding box.
      */
-    export template <std::floating_point T = double>
+    export template <std::floating_point T>
     [[nodiscard]] std::array<fastgltf::math::vec<T, 3>, 2> getBoundingBoxMinMax(
         const fastgltf::Primitive &primitive,
         const fastgltf::Node &node,
@@ -105,21 +105,21 @@ namespace vk_gltf_viewer::gltf::algorithm {
      * @param asset Asset that owns \p node.
      * @return Array of 8 corner points of the bounding box.
      */
-    export
-    [[nodiscard]] std::array<fastgltf::math::dvec3, 8> getBoundingBoxCornerPoints(
+    export template <std::floating_point T>
+    [[nodiscard]] std::array<fastgltf::math::vec<T, 3>, 8> getBoundingBoxCornerPoints(
         const fastgltf::Primitive &primitive,
         const fastgltf::Node &node,
         const fastgltf::Asset &asset
     ) {
-        const auto [min, max] = getBoundingBoxMinMax(primitive, node, asset);
+        const auto [min, max] = getBoundingBoxMinMax<T>(primitive, node, asset);
         return {
             min,
-            fastgltf::math::dvec3 { min[0], min[1], max[2] },
-            fastgltf::math::dvec3 { min[0], max[1], min[2] },
-            fastgltf::math::dvec3 { min[0], max[1], max[2] },
-            fastgltf::math::dvec3 { max[0], min[1], min[2] },
-            fastgltf::math::dvec3 { max[0], min[1], max[2] },
-            fastgltf::math::dvec3 { max[0], max[1], min[2] },
+            { min[0], min[1], max[2] },
+            { min[0], max[1], min[2] },
+            { min[0], max[1], max[2] },
+            { max[0], min[1], min[2] },
+            { max[0], min[1], max[2] },
+            { max[0], max[1], min[2] },
             max,
         };
     }

--- a/interface/helpers/Lazy.cppm
+++ b/interface/helpers/Lazy.cppm
@@ -1,0 +1,35 @@
+export module vk_gltf_viewer.helpers.Lazy;
+
+import std;
+
+#define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+
+/**
+ * @brief A container that wraps the value and lazily calculates it when needed.
+ *
+ * @tparam T Value type that be stored and lazily calculated.
+ * @tparam F Function type that calculates the value when the value is invalidated.
+ */
+export template <typename T, std::invocable F = std::function<T()>>
+class Lazy {
+    std::optional<T> value;
+    F calculator;
+
+public:
+    explicit Lazy(F &&f) noexcept(std::is_nothrow_constructible_v<F, F&&>)
+        : calculator { FWD(f) } { }
+
+    void invalidate() noexcept {
+        value.reset();
+    }
+
+    [[nodiscard]] const T &get() noexcept {
+        if (!value) {
+            value.emplace(std::invoke(calculator));
+        }
+        return *value;
+    }
+};
+
+export template <std::invocable F>
+explicit Lazy(F&&) -> Lazy<std::invoke_result_t<F>, F>;

--- a/interface/helpers/fastgltf.cppm
+++ b/interface/helpers/fastgltf.cppm
@@ -409,22 +409,6 @@ namespace fastgltf {
 
 namespace math {
     /**
-     * @brief Convert matrix of type \tp U to matrix of type \tp T.
-     * @tparam T The destination matrix type.
-     * @tparam U The source matrix type.
-     * @tparam N The number of columns.
-     * @tparam M The number of rows.
-     * @param m The source matrix.
-     * @return The converted matrix of type \tp T.
-     */
-    export template <typename T, typename U, std::size_t N, std::size_t M>
-    [[nodiscard]] mat<T, N, M> cast(const mat<U, N, M> &m) noexcept {
-        return INDEX_SEQ(Is, M, {
-            return mat<T, N, M> { vec<T, N> { m[Is] }... };
-        });
-    }
-
-    /**
      * @brief Get component-wise minimum of two vectors.
      * @tparam T Vector component type.
      * @tparam N Number of vector components.

--- a/interface/helpers/mod.cppm
+++ b/interface/helpers/mod.cppm
@@ -1,0 +1,2 @@
+export module vk_gltf_viewer.helpers;
+export import vk_gltf_viewer.helpers.Lazy;


### PR DESCRIPTION
This PR improves the current method for computing world transform matrices and miniball in a glTF scene when local transforms or morph target weights of nodes change. These updates occur frequently during animation playback and involve a large number of 4x4 matrix multiplications, making them computationally intensive. As a result, this optimization can significantly reduce total CPU frame time.

Previously, whenever a node’s local transform or morph target weights changed, a `task::NodeLocalTransformChanged` or `task::MorphTargetWeightChanged` struct was enqueued. When dequeued, each task would trigger a full update of the scene’s world transform hierarchy and corresponding miniball.

The new approach separates the process of updating world transforms and miniball. For world transform updates, nodes with modified local transforms are first sorted by their level in the scene hierarchy. The traversal then proceeds in order from lower to higher levels. During traversal:

1. The world transforms of the node and its descendants are updated.
2. Nodes whose world transforms are updated are marked as *visited*.

If a node is already marked as *visited*, the traversal skips it, since its world transform has already been updated via an ancestor. This guarantees that each node’s world transform is recalculated at most once per frame.

Miniball updates are performed on-demand. If any world transforms or morph target weights have changed during the frame, the miniballs are recalculated accordingly.