### PR TITLE
Use reversible tone mapping operator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,6 @@ target_link_shaders(vk-gltf-viewer PRIVATE
         shaders/screen_quad.vert
         shaders/skybox.frag
         shaders/skybox.vert
-        shaders/weighted_blended_composition.frag
 )
 
 target_link_shader_variants(vk-gltf-viewer PRIVATE
@@ -385,4 +384,10 @@ target_link_shader_variants(vk-gltf-viewer PRIVATE
     MACRO_VALUES
         "0 0 0" "0 0 1" "0 0 2" "0 1 0" "0 1 1" "0 1 2"
         "1 0 0" "1 0 1" "1 0 2" "1 1 0" "1 1 1" "1 1 2"
+)
+target_link_shader_variants(vk-gltf-viewer PRIVATE
+    TARGET_ENV vulkan1.2
+    FILES shaders/weighted_blended_composition.frag
+    MACRO_NAMES "AMD_SHADER_TRINARY_MINMAX"
+    MACRO_VALUES 0 1
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,6 @@ endif()
 target_link_shaders(vk-gltf-viewer PRIVATE
     TARGET_ENV vulkan1.2
     FILES
-        shaders/cubemap_tone_mapping.frag
         shaders/jump_flood_seed.frag
         shaders/jump_flood_seed.vert
         shaders/jump_flood.comp
@@ -387,7 +386,9 @@ target_link_shader_variants(vk-gltf-viewer PRIVATE
 )
 target_link_shader_variants(vk-gltf-viewer PRIVATE
     TARGET_ENV vulkan1.2
-    FILES shaders/weighted_blended_composition.frag
+    FILES
+        shaders/cubemap_tone_mapping.frag
+        shaders/weighted_blended_composition.frag
     MACRO_NAMES "AMD_SHADER_TRINARY_MINMAX"
     MACRO_VALUES 0 1
 )

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -1183,7 +1183,7 @@ void vk_gltf_viewer::MainApp::loadEqmap(const std::filesystem::path &eqmapPath) 
 
     // Generate Tone-mapped cubemap.
     const vulkan::rp::CubemapToneMapping cubemapToneMappingRenderPass { gpu.device };
-    const vulkan::CubemapToneMappingRenderer cubemapToneMappingRenderer { gpu.device, cubemapToneMappingRenderPass };
+    const vulkan::CubemapToneMappingRenderer cubemapToneMappingRenderer { gpu, cubemapToneMappingRenderPass };
 
     vku::AllocatedImage toneMappedCubemapImage { gpu.allocator, vk::ImageCreateInfo {
         vk::ImageCreateFlagBits::eCubeCompatible,

--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -213,6 +213,7 @@ vk::raii::Device vk_gltf_viewer::vulkan::Gpu::createDevice() {
 
     supportSwapchainMutableFormat = availableExtensionNames.contains(vk::KHRSwapchainMutableFormatExtensionName);
     supportShaderImageLoadStoreLod = availableExtensionNames.contains(vk::AMDShaderImageLoadStoreLodExtensionName);
+    supportShaderTrinaryMinMax = availableExtensionNames.contains(vk::AMDShaderTrinaryMinmaxExtensionName);
 
     // Set optional features if available.
     const auto [_, vulkan12Features, indexTypeUint8Features] = physicalDevice.getFeatures2<

--- a/interface/vulkan/Gpu.cppm
+++ b/interface/vulkan/Gpu.cppm
@@ -52,6 +52,7 @@ namespace vk_gltf_viewer::vulkan {
         std::uint32_t subgroupSize;
         std::uint32_t maxPerStageDescriptorUpdateAfterBindSamplers;
         bool supportShaderImageLoadStoreLod;
+        bool supportShaderTrinaryMinMax;
         bool supportVariableDescriptorCount;
         bool supportR8SrgbImageFormat;
         bool supportR8G8SrgbImageFormat;

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -196,7 +196,7 @@ namespace vk_gltf_viewer::vulkan {
             , jumpFloodComputer { gpu.device }
             , mousePickingRenderer { gpu.device, mousePickingRenderPass }
             , outlineRenderer { gpu.device }
-            , skyboxRenderer { gpu.device, skyboxDescriptorSetLayout, true, sceneRenderPass, cubeIndices }
+            , skyboxRenderer { gpu.device, skyboxDescriptorSetLayout, sceneRenderPass, cubeIndices }
             , weightedBlendedCompositionRenderer { gpu, sceneRenderPass }
             , imGuiAttachmentGroup { gpu, swapchainExtent, swapchainImages }
             , descriptorPool { gpu.device, getPoolSizes(imageBasedLightingDescriptorSetLayout, skyboxDescriptorSetLayout).getDescriptorPoolCreateInfo() }

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -197,7 +197,7 @@ namespace vk_gltf_viewer::vulkan {
             , mousePickingRenderer { gpu.device, mousePickingRenderPass }
             , outlineRenderer { gpu.device }
             , skyboxRenderer { gpu.device, skyboxDescriptorSetLayout, true, sceneRenderPass, cubeIndices }
-            , weightedBlendedCompositionRenderer { gpu.device, sceneRenderPass }
+            , weightedBlendedCompositionRenderer { gpu, sceneRenderPass }
             , imGuiAttachmentGroup { gpu, swapchainExtent, swapchainImages }
             , descriptorPool { gpu.device, getPoolSizes(imageBasedLightingDescriptorSetLayout, skyboxDescriptorSetLayout).getDescriptorPoolCreateInfo() }
             , fallbackTexture { gpu }{

--- a/interface/vulkan/pipeline/SkyboxRenderer.cppm
+++ b/interface/vulkan/pipeline/SkyboxRenderer.cppm
@@ -27,7 +27,6 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
         SkyboxRenderer(
             const vk::raii::Device &device LIFETIMEBOUND,
             const dsl::Skybox &descriptorSetLayout LIFETIMEBOUND,
-            bool isCubemapImageToneMapped,
             const rp::Scene &sceneRenderPass LIFETIMEBOUND,
             const buffer::CubeIndices &cubeIndices LIFETIMEBOUND
         ) : pipelineLayout { device, vk::PipelineLayoutCreateInfo {
@@ -42,14 +41,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 createPipelineStages(
                     device,
                     vku::Shader { shader::skybox_vert, vk::ShaderStageFlagBits::eVertex },
-                    vku::Shader {
-                        shader::skybox_frag,
-                        vk::ShaderStageFlagBits::eFragment,
-                        vku::unsafeAddress(vk::SpecializationInfo {
-                            vku::unsafeProxy(vk::SpecializationMapEntry { 0, 0, sizeof(vk::Bool32) }),
-                            vku::unsafeProxy<vk::Bool32>(isCubemapImageToneMapped),
-                        }),
-                    }).get(),
+                    vku::Shader { shader::skybox_frag, vk::ShaderStageFlagBits::eFragment }).get(),
                 *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
                 .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                     {},

--- a/shaders/cubemap_tone_mapping.frag
+++ b/shaders/cubemap_tone_mapping.frag
@@ -1,15 +1,23 @@
 #version 450
 #extension GL_EXT_multiview : require
 #extension GL_EXT_samplerless_texture_functions : require
-
-const vec3 REC_709_LUMA = vec3(0.2126, 0.7152, 0.0722);
+#if AMD_SHADER_TRINARY_MINMAX == 1
+#extension GL_AMD_shader_trinary_minmax : enable
+#endif
 
 layout (location = 0) out vec4 outColor;
 
 layout (set = 0, binding = 0) uniform texture2DArray highPrecisionCubemapImageArray;
 
+float trinaryMax(vec3 v) {
+#if AMD_SHADER_TRINARY_MINMAX == 1
+    return max3(v.x, v.y, v.z);
+#else
+    return max(max(v.x, v.y), v.z);
+#endif
+}
+
 void main() {
     vec3 color = texelFetch(highPrecisionCubemapImageArray, ivec3(gl_FragCoord.xy, gl_ViewIndex), 0).rgb;
-    float luminance = dot(color, REC_709_LUMA);
-    outColor = vec4(color / (1.0 + luminance), 1.0);
+    outColor = vec4(color / (1.0 + trinaryMax(color)), 1.0);
 }

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -14,8 +14,6 @@
 
 #define HAS_VARIADIC_IN !FRAGMENT_SHADER_GENERATED_TBN || TEXCOORD_COUNT >= 1 || HAS_COLOR_ATTRIBUTE
 
-const vec3 REC_709_LUMA = vec3(0.2126, 0.7152, 0.0722);
-
 layout (constant_id = 0) const uint PACKED_TEXTURE_TRANSFORMS = 0; // [FALSE, FALSE, FALSE, FALSE, FALSE]
 
 layout (location = 0) in vec3 inPosition;
@@ -225,9 +223,8 @@ void main(){
 
     vec3 color = (kD * diffuse + specular) * occlusion + emissive;
 
-    // Tone mapping using REC.709 luma.
-    float colorLuminance = dot(color, REC_709_LUMA);
-    vec3 correctedColor = color / (1.0 + colorLuminance);
+    // Tone mapping.
+    vec3 correctedColor = color / (1.0 + max(max(color.r, color.g), color.b));
 
     writeOutput(vec4(correctedColor, baseColor.a));
 }

--- a/shaders/skybox.frag
+++ b/shaders/skybox.frag
@@ -1,9 +1,5 @@
 #version 460
 
-const vec3 REC_709_LUMA = vec3(0.2126, 0.7152, 0.0722);
-
-layout (constant_id = 0) const bool isCubemapImageToneMapped = false;
-
 layout (location = 0) in vec3 inPosition;
 
 layout (location = 0) out vec4 outColor;
@@ -14,9 +10,5 @@ layout (early_fragment_tests) in;
 
 void main() {
     vec3 color = textureLod(cubemapSampler, inPosition, 0.0).rgb;
-    if (!isCubemapImageToneMapped) {
-        float luminance = dot(color, REC_709_LUMA);
-        color = color / (1.0 + luminance);
-    }
     outColor = vec4(color, 1.0);
 }

--- a/shaders/weighted_blended_composition.frag
+++ b/shaders/weighted_blended_composition.frag
@@ -1,4 +1,7 @@
 #version 450
+#if AMD_SHADER_TRINARY_MINMAX == 1
+#extension GL_AMD_shader_trinary_minmax : enable
+#endif
 
 const float EPSILON = 1e-5f;
 
@@ -15,8 +18,12 @@ bool isApproximatelyEqual(float a, float b) {
     return abs(a - b) <= (abs(a) < abs(b) ? abs(b) : abs(a)) * EPSILON;
 }
 
-float max3(vec3 v) {
+float trinaryMax(vec3 v) {
+#if AMD_SHADER_TRINARY_MINMAX == 1
+    return max3(v.x, v.y, v.z);
+#else
     return max(max(v.x, v.y), v.z);
+#endif
 }
 
 void main(){
@@ -26,7 +33,7 @@ void main(){
     }
 
     vec4 accumulation = subpassLoad(inputAccumulation);
-    if (isinf(max3(abs(accumulation.rgb)))) {
+    if (isinf(trinaryMax(abs(accumulation.rgb)))) {
         accumulation.rgb = accumulation.aaa;
     }
 


### PR DESCRIPTION
This PR replaces the previous REC.709-based tone mapping with AMD’s reversible tone mapping operator. Colors written to the attachment image can be restored to their original HDR values using the formula `color / (1 - max3(color))`.

GPUs from AMD or those derived from AMD architecture (such as Apple GPUs) can accelerate the 3-variable maximum operation via the `VK_AMD_shader_trinary_minmax` Vulkan extension. This change selects a different SPIR-V binary depending on the availability of that extension.