### PR TITLE
Composite background (solid color/skybox image) after the WBOIT composition and support background transparency with premultiplied alpha.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/vulkan/pipeline/OutlineRenderer.cppm
         interface/vulkan/pipeline/PrimitiveRenderer.cppm
         interface/vulkan/pipeline/SkyboxRenderer.cppm
+        interface/vulkan/pipeline/SolidRenderer.cppm
         interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
         interface/vulkan/pipeline/WeightedBlendedCompositionRenderer.cppm
         interface/vulkan/pipeline_layout/MultiNodeMousePicking.cppm
@@ -326,6 +327,7 @@ target_link_shaders(vk-gltf-viewer PRIVATE
         shaders/screen_quad.vert
         shaders/skybox.frag
         shaders/skybox.vert
+        shaders/solid.frag
 )
 
 target_link_shader_variants(vk-gltf-viewer PRIVATE

--- a/extlibs/module-ports/imgui/imgui.cppm
+++ b/extlibs/module-ports/imgui/imgui.cppm
@@ -84,6 +84,7 @@ namespace ImGui {
     export using ImGui::CollapsingHeader;
     export using ImGui::ColorEdit4;
     export using ImGui::ColorPicker3;
+    export using ImGui::ColorPicker4;
     export using ImGui::Combo;
     export using ImGui::CreateContext;
     export using ImGui::DestroyContext;

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -1586,7 +1586,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::nodeInspector(
 
 void vk_gltf_viewer::control::ImGuiTaskCollector::background(
     bool canSelectSkyboxBackground,
-    full_optional<glm::vec3> &solidBackground
+    full_optional<glm::vec4> &solidBackground
 ) {
     if (ImGui::Begin("Background")) {
         const bool useSolidBackground = solidBackground.has_value();
@@ -1601,7 +1601,7 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::background(
             solidBackground.set_active(true);
         }
         ImGui::WithDisabled([&]() {
-            ImGui::ColorPicker3("Color", value_ptr(*solidBackground));
+            ImGui::ColorPicker4("Color", value_ptr(*solidBackground));
         }, !useSolidBackground);
     }
     ImGui::End();

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -539,7 +539,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
     }
 
     if (task.solidBackground) {
-        background.emplace<glm::vec3>(*task.solidBackground);
+        background.emplace<glm::vec4>(*task.solidBackground);
     }
     else {
         background.emplace<vku::DescriptorSet<dsl::Skybox>>(sharedData.skyboxDescriptorSet);
@@ -678,9 +678,9 @@ void vk_gltf_viewer::vulkan::Frame::recordCommandsAndSubmit(
             [this](vku::DescriptorSet<dsl::Skybox> skyboxDescriptorSet) {
                 sharedData.skyboxRenderer.draw(sceneRenderingCommandBuffer, skyboxDescriptorSet, { translationlessProjectionViewMatrix });
             },
-            [this](const glm::vec3 &color) {
+            [this](const glm::vec4 &color) {
                 sceneRenderingCommandBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, *sharedData.solidRenderer.pipeline);
-                sceneRenderingCommandBuffer.pushConstants<glm::vec4>(*sharedData.solidRenderer.pipelineLayout, vk::ShaderStageFlagBits::eFragment, 0, glm::vec4 { color, 1.f });
+                sceneRenderingCommandBuffer.pushConstants<glm::vec4>(*sharedData.solidRenderer.pipelineLayout, vk::ShaderStageFlagBits::eFragment, 0, color);
                 sceneRenderingCommandBuffer.draw(3, 1, 0, 0);
             },
         }, background);

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -648,9 +648,6 @@ void vk_gltf_viewer::vulkan::Frame::recordCommandsAndSubmit(
         if (renderingNodes) {
             recordSceneOpaqueMeshDrawCommands(sceneRenderingCommandBuffer);
         }
-        if (holds_alternative<vku::DescriptorSet<dsl::Skybox>>(background)) {
-            recordSkyboxDrawCommands(sceneRenderingCommandBuffer);
-        }
 
         // Render meshes whose AlphaMode=Blend.
         sceneRenderingCommandBuffer.nextSubpass(vk::SubpassContents::eInline);
@@ -671,6 +668,18 @@ void vk_gltf_viewer::vulkan::Frame::recordCommandsAndSubmit(
                 sharedData.weightedBlendedCompositionRenderer.pipelineLayout,
                 0, weightedBlendedCompositionSet, {});
             sceneRenderingCommandBuffer.draw(3, 1, 0, 0);
+
+            sceneRenderingCommandBuffer.pipelineBarrier(
+                vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eColorAttachmentOutput,
+                vk::DependencyFlagBits::eByRegion,
+                vk::MemoryBarrier {
+                    vk::AccessFlagBits::eColorAttachmentWrite, vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite,
+                },
+                {}, {});
+        }
+
+        if (holds_alternative<vku::DescriptorSet<dsl::Skybox>>(background)) {
+            recordSkyboxDrawCommands(sceneRenderingCommandBuffer);
         }
 
         sceneRenderingCommandBuffer.endRenderPass();

--- a/interface/AppState.cppm
+++ b/interface/AppState.cppm
@@ -41,7 +41,7 @@ namespace vk_gltf_viewer {
         full_optional<Outline> hoveringNodeOutline { std::in_place, 2.f, glm::vec4 { 1.f, 0.5f, 0.2f, 1.f } };
         full_optional<Outline> selectedNodeOutline { std::in_place, 2.f, glm::vec4 { 0.f, 1.f, 0.2f, 1.f } };
         bool canSelectSkyboxBackground = false; // TODO: bad design... this and background should be handled in a single field.
-        full_optional<glm::vec3> background { std::in_place, 0.f, 0.f, 0.f }; // nullopt -> use cubemap from the given equirectangular map image.
+        full_optional<glm::vec4> background { std::in_place, 0.f, 0.f, 0.f, 1.f }; // nullopt -> use cubemap from the given equirectangular map image.
         std::optional<ImageBasedLighting> imageBasedLightingProperties;
         ImGuizmo::OPERATION imGuizmoOperation = ImGuizmo::OPERATION::TRANSLATE;
 

--- a/interface/control/ImGuiTaskCollector.cppm
+++ b/interface/control/ImGuiTaskCollector.cppm
@@ -32,7 +32,7 @@ namespace vk_gltf_viewer::control {
         void materialVariants(const fastgltf::Asset &asset);
         void sceneHierarchy(fastgltf::Asset &asset, std::size_t sceneIndex, gltf::StateCachedNodeVisibilityStructure &nodeVisibilities, const std::optional<std::size_t> &hoveringNodeIndex, std::unordered_set<std::size_t> &selectedNodeIndices);
         void nodeInspector(fastgltf::Asset &asset, const std::vector<bool> &animationEnabled, const gltf::NodeAnimationUsages &nodeAnimationUsages, std::unordered_set<std::size_t> &selectedNodeIndices);
-        void background(bool canSelectSkyboxBackground, full_optional<glm::vec3> &solidBackground);
+        void background(bool canSelectSkyboxBackground, full_optional<glm::vec4> &solidBackground);
         void imageBasedLighting(const AppState::ImageBasedLighting &info, ImTextureID eqmapTextureImGuiDescriptorSet);
         void inputControl(Camera &camera, bool& automaticNearFarPlaneAdjustment, bool &useFrustumCulling, full_optional<AppState::Outline> &hoveringNodeOutline, full_optional<AppState::Outline> &selectedNodeOutline);
         void imguizmo(Camera &camera);

--- a/interface/vulkan/Frame.cppm
+++ b/interface/vulkan/Frame.cppm
@@ -352,7 +352,6 @@ namespace vk_gltf_viewer::vulkan {
         [[nodiscard]] bool recordJumpFloodComputeCommands(vk::CommandBuffer cb, const vku::Image &image, vku::DescriptorSet<JumpFloodComputer::DescriptorSetLayout> descriptorSet, std::uint32_t initialSampleOffset) const;
         void recordSceneOpaqueMeshDrawCommands(vk::CommandBuffer cb) const;
         bool recordSceneBlendMeshDrawCommands(vk::CommandBuffer cb) const;
-        void recordSkyboxDrawCommands(vk::CommandBuffer cb) const;
         void recordNodeOutlineCompositionCommands(vk::CommandBuffer cb, std::optional<bool> hoveringNodeJumpFloodForward, std::optional<bool> selectedNodeJumpFloodForward) const;
         void recordImGuiCompositionCommands(vk::CommandBuffer cb, std::uint32_t swapchainImageIndex) const;
     };

--- a/interface/vulkan/Frame.cppm
+++ b/interface/vulkan/Frame.cppm
@@ -174,7 +174,7 @@ namespace vk_gltf_viewer::vulkan {
              * @brief Information of glTF to be rendered. <tt>std::nullopt</tt> if no glTF scene to be rendered.
              */
             std::optional<Gltf> gltf;
-            std::optional<glm::vec3> solidBackground; // If this is nullopt, use SharedData::SkyboxDescriptorSet instead.
+            std::optional<glm::vec4> solidBackground; // If this is nullopt, use SharedData::SkyboxDescriptorSet instead.
         };
 
         struct UpdateResult {
@@ -343,7 +343,7 @@ namespace vk_gltf_viewer::vulkan {
         std::optional<RenderingNodes> renderingNodes;
         std::optional<SelectedNodes> selectedNodes;
         std::optional<HoveringNode> hoveringNode;
-        std::variant<vku::DescriptorSet<dsl::Skybox>, glm::vec3> background;
+        std::variant<vku::DescriptorSet<dsl::Skybox>, glm::vec4> background;
 
         [[nodiscard]] vk::raii::DescriptorPool createDescriptorPool() const;
 

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -35,6 +35,7 @@ export import :vulkan.pipeline.NodeIndexRenderer;
 export import :vulkan.pipeline.OutlineRenderer;
 export import :vulkan.pipeline.PrimitiveRenderer;
 export import :vulkan.pipeline.SkyboxRenderer;
+export import :vulkan.pipeline.SolidRenderer;
 export import :vulkan.pipeline.UnlitPrimitiveRenderer;
 export import :vulkan.pipeline.WeightedBlendedCompositionRenderer;
 export import :vulkan.rp.MousePicking;
@@ -148,6 +149,7 @@ namespace vk_gltf_viewer::vulkan {
         MousePickingRenderer mousePickingRenderer;
         OutlineRenderer outlineRenderer;
         SkyboxRenderer skyboxRenderer;
+        SolidRenderer solidRenderer;
         WeightedBlendedCompositionRenderer weightedBlendedCompositionRenderer;
 
         // --------------------
@@ -197,6 +199,7 @@ namespace vk_gltf_viewer::vulkan {
             , mousePickingRenderer { gpu.device, mousePickingRenderPass }
             , outlineRenderer { gpu.device }
             , skyboxRenderer { gpu.device, skyboxDescriptorSetLayout, sceneRenderPass, cubeIndices }
+            , solidRenderer { gpu.device, sceneRenderPass }
             , weightedBlendedCompositionRenderer { gpu, sceneRenderPass }
             , imGuiAttachmentGroup { gpu, swapchainExtent, swapchainImages }
             , descriptorPool { gpu.device, getPoolSizes(imageBasedLightingDescriptorSetLayout, skyboxDescriptorSetLayout).getDescriptorPoolCreateInfo() }

--- a/interface/vulkan/pipeline/SkyboxRenderer.cppm
+++ b/interface/vulkan/pipeline/SkyboxRenderer.cppm
@@ -42,7 +42,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     device,
                     vku::Shader { shader::skybox_vert, vk::ShaderStageFlagBits::eVertex },
                     vku::Shader { shader::skybox_frag, vk::ShaderStageFlagBits::eFragment }).get(),
-                *pipelineLayout, 1, true, vk::SampleCountFlagBits::e4)
+                *pipelineLayout, 1)
                 .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                     {},
                     false, false,
@@ -51,12 +51,19 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     {}, {}, {}, {},
                     1.f,
                 }))
-                .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
+                .setPColorBlendState(vku::unsafeAddress(vk::PipelineColorBlendStateCreateInfo {
                     {},
-                    true, false, vk::CompareOp::eEqual,
+                    false, {},
+                    vku::unsafeProxy(vk::PipelineColorBlendAttachmentState {
+                        true,
+                        // Inverse alpha blending (src and dst are swapped) with premultiplied alpha
+                        vk::BlendFactor::eOneMinusDstAlpha, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
+                        vk::BlendFactor::eOneMinusDstAlpha, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
+                        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA,
+                    }),
                 }))
                 .setRenderPass(*sceneRenderPass)
-                .setSubpass(0),
+                .setSubpass(2),
             },
             cubeIndices { cubeIndices } { }
 

--- a/interface/vulkan/pipeline/SolidRenderer.cppm
+++ b/interface/vulkan/pipeline/SolidRenderer.cppm
@@ -1,0 +1,63 @@
+module;
+
+#include <lifetimebound.hpp>
+
+export module vk_gltf_viewer:vulkan.pipeline.SolidRenderer;
+
+import std;
+export import glm;
+import vku;
+import :shader.screen_quad_vert;
+import :shader.solid_frag;
+export import :vulkan.rp.Scene;
+
+namespace vk_gltf_viewer::vulkan::inline pipeline {
+    export struct SolidRenderer {
+        struct PushConstant {
+            glm::vec4 color;
+        };
+
+        vk::raii::PipelineLayout pipelineLayout;
+        vk::raii::Pipeline pipeline;
+
+        SolidRenderer(
+            const vk::raii::Device &device LIFETIMEBOUND,
+            const rp::Scene &sceneRenderPass LIFETIMEBOUND
+        ) : pipelineLayout { device, vk::PipelineLayoutCreateInfo {
+                {},
+                {},
+                vku::unsafeProxy(vk::PushConstantRange {
+                    vk::ShaderStageFlagBits::eFragment,
+                    0, sizeof(PushConstant),
+                }),
+            } },
+            pipeline { device, nullptr, vku::getDefaultGraphicsPipelineCreateInfo(
+                createPipelineStages(
+                    device,
+                    vku::Shader { shader::screen_quad_vert, vk::ShaderStageFlagBits::eVertex },
+                    vku::Shader { shader::solid_frag, vk::ShaderStageFlagBits::eFragment }).get(),
+                *pipelineLayout, 1)
+                .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
+                    {},
+                    false, false,
+                    vk::PolygonMode::eFill,
+                    vk::CullModeFlagBits::eNone, {},
+                    {}, {}, {}, {},
+                    1.f,
+                }))
+                .setPColorBlendState(vku::unsafeAddress(vk::PipelineColorBlendStateCreateInfo {
+                    {},
+                    false, {},
+                    vku::unsafeProxy(vk::PipelineColorBlendAttachmentState {
+                        true,
+                        // Inverse alpha blending (src and dst are swapped) with premultiplied alpha
+                        vk::BlendFactor::eOneMinusDstAlpha, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
+                        vk::BlendFactor::eOneMinusDstAlpha, vk::BlendFactor::eOne, vk::BlendOp::eAdd,
+                        vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA,
+                    }),
+                }))
+                .setRenderPass(*sceneRenderPass)
+                .setSubpass(2),
+            } { }
+    };
+}

--- a/interface/vulkan/pipeline/WeightedBlendedCompositionRenderer.cppm
+++ b/interface/vulkan/pipeline/WeightedBlendedCompositionRenderer.cppm
@@ -63,7 +63,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     vku::unsafeProxy(vk::PipelineColorBlendAttachmentState {
                         true,
                         vk::BlendFactor::eSrcAlpha, vk::BlendFactor::eOneMinusSrcAlpha, vk::BlendOp::eAdd,
-                        vk::BlendFactor::eSrcAlpha, vk::BlendFactor::eOneMinusSrcAlpha, vk::BlendOp::eAdd,
+                        vk::BlendFactor::eOne, vk::BlendFactor::eOneMinusSrcAlpha, vk::BlendOp::eAdd,
                         vk::ColorComponentFlagBits::eR | vk::ColorComponentFlagBits::eG | vk::ColorComponentFlagBits::eB | vk::ColorComponentFlagBits::eA,
                     }),
                     { 1.f, 1.f, 1.f, 1.f },

--- a/interface/vulkan/render_pass/Scene.cppm
+++ b/interface/vulkan/render_pass/Scene.cppm
@@ -117,19 +117,25 @@ namespace vk_gltf_viewer::vulkan::rp {
                         vk::PipelineStageFlagBits::eLateFragmentTests, vk::PipelineStageFlagBits::eEarlyFragmentTests,
                         vk::AccessFlagBits::eDepthStencilAttachmentWrite, vk::AccessFlagBits::eDepthStencilAttachmentRead,
                     },
-                    // Dependency between opaque pass and swapchain full-quad pass:
+                    // Dependency between opaque pass and WBOIT composition pass:
                     // Color attachments must be written before full-quad pass writes them.
                     vk::SubpassDependency {
                         0, 2,
                         vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eColorAttachmentOutput,
                         vk::AccessFlagBits::eColorAttachmentWrite, vk::AccessFlagBits::eColorAttachmentRead,
                     },
-                    // Dependency between weighted blend pass and swapchain full-quad pass:
-                    // Color attachments must be written before full-quad pass reads them.
+                    // Dependency between blend pass and WBOIT composition pass:
+                    // Color attachments must be written before they are read as input attachments
                     vk::SubpassDependency {
                         1, 2,
                         vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eFragmentShader,
                         vk::AccessFlagBits::eColorAttachmentWrite, vk::AccessFlagBits::eInputAttachmentRead,
+                    },
+                    vk::SubpassDependency {
+                        2, 2,
+                        vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::PipelineStageFlagBits::eColorAttachmentOutput,
+                        vk::AccessFlagBits::eColorAttachmentWrite, vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eColorAttachmentWrite,
+                        vk::DependencyFlagBits::eByRegion,
                     },
                 }),
             } } { }

--- a/shaders/skybox.frag
+++ b/shaders/skybox.frag
@@ -7,6 +7,9 @@ layout (location = 0) out vec4 outColor;
 layout (set = 0, binding = 0) uniform samplerCube cubemapSampler;
 
 void main() {
-    vec3 color = textureLod(cubemapSampler, inPosition, 0.0).rgb;
-    outColor = vec4(color, 1.0);
+    vec4 color = textureLod(cubemapSampler, inPosition, 0.0);
+
+    // As inverse alpha blending (src and dst color is swapped) does not support the pre-multiplying alpha via
+    // VkPipelineColorBlendAttachmentState, it has to be done manually.
+    outColor = vec4(color.rgb * color.a, color.a);
 }

--- a/shaders/skybox.frag
+++ b/shaders/skybox.frag
@@ -6,8 +6,6 @@ layout (location = 0) out vec4 outColor;
 
 layout (set = 0, binding = 0) uniform samplerCube cubemapSampler;
 
-layout (early_fragment_tests) in;
-
 void main() {
     vec3 color = textureLod(cubemapSampler, inPosition, 0.0).rgb;
     outColor = vec4(color, 1.0);

--- a/shaders/solid.frag
+++ b/shaders/solid.frag
@@ -7,5 +7,7 @@ layout (push_constant) uniform PushConstant {
 } pc;
 
 void main() {
-    outColor = pc.color;
+    // As inverse alpha blending (src and dst color is swapped) does not support the pre-multiplying alpha via
+    // VkPipelineColorBlendAttachmentState, it has to be done manually.
+    outColor = vec4(pc.color.rgb * pc.color.a, pc.color.a);
 }

--- a/shaders/solid.frag
+++ b/shaders/solid.frag
@@ -1,0 +1,11 @@
+#version 450
+
+layout (location = 0) out vec4 outColor;
+
+layout (push_constant) uniform PushConstant {
+    vec4 color;
+} pc;
+
+void main() {
+    outColor = pc.color;
+}


### PR DESCRIPTION
This PR moves background composition from the `OPAQUE` stage to the `WBOIT` stage within the existing 3-stage render pass (`OPAQUE`–`BLEND`–`WBOIT`). The background is composed using either a solid color (`SolidRenderer`) or a loaded skybox (`SkyboxRenderer`), depending on the user’s selection.

By deferring background composition until the `WBOIT` pass, the intermediate output at this stage—containing the glTF scene with preserved transparency—can be more effectively used in subsequent post-processing steps where background interference is undesirable.

Since the background must be composited behind the scene rendering results, the corresponding pipeline uses alpha blending with swapped source and destination roles. This cannot be fully expressed through the `vk::PipelineColorBlendAttachmentState` configuration alone. Instead, the issue is addressed by using premultiplied alpha, where the RGB values are multiplied by alpha in the fragment shader.

As a side effect, users can now utilize skyboxes or solid backgrounds that include transparency. While the scene rendering image is currently only copied to the swapchain with opaque composition, this change lays the groundwork for preserving transparency when exporting the scene directly to an image file in the future.
