### PR TITLE
CI simplification.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,18 +44,6 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: sudo apt-get install libc++-dev libc++abi-dev xorg-dev libtool libltdl-dev
 
-      - name: Setup vcpkg (macOS)
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          git clone https://github.com/microsoft/vcpkg.git --depth 1
-          cd vcpkg && ./bootstrap-vcpkg.sh
-          echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> $GITHUB_ENV
-          echo "${{ github.workspace }}/vcpkg" >> $GITHUB_PATH
-
-      - name: Setup vcpkg (Linux)
-        if: ${{ runner.os == 'Linux' }}
-        run: echo ${VCPKG_INSTALLATION_ROOT} >> GITHUB_PATH
-
       - name: Enable Developer Command Prompt (Windows)
         if: ${{ runner.os == 'Windows' }}
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: sudo apt-get install libc++-dev libc++abi-dev xorg-dev libtool libltdl-dev
 
-      - name: Enable Developer Command Prompt (Windows)
-        if: ${{ runner.os == 'Windows' }}
+      - name: Enable Developer Command Prompt (Windows + MSVC)
+        if: ${{ runner.os == 'Windows' && matrix.compiler == 'msvc' }}
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Workaround for CMake bug that cannot find __CMAKE::CXX23 target when using homebrew libc++ (macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,16 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Vulkan SDK (without GLSL -> SPIR-V compiler)
-        if: ${{ runner.os != 'Windows' }}
-        uses: stripe2933/setup-vulkan-sdk@30a1c4f5464781f4559063b11e19b080a53b4411
-        with:
-          vulkan-query-version: latest
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
-
-      - name: Install Vulkan SDK (with GLSL -> SPIR-V compiler)
-        if: ${{ runner.os == 'Windows' }}
+      - name: Install Vulkan SDK
         uses: stripe2933/setup-vulkan-sdk@30a1c4f5464781f4559063b11e19b080a53b4411
         with:
           vulkan-query-version: latest
@@ -47,11 +38,11 @@ jobs:
 
       - name: Install build dependencies (macOS)
         if: ${{ runner.os == 'macOS' }}
-        run: brew install llvm autoconf automake libtool nasm shaderc molten-vk
+        run: brew install llvm autoconf automake libtool nasm molten-vk
 
       - name: Install build dependencies (Linux)
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get install libc++-dev libc++abi-dev xorg-dev libtool libltdl-dev glslc
+        run: sudo apt-get install libc++-dev libc++abi-dev xorg-dev libtool libltdl-dev
 
       - name: Setup vcpkg (macOS)
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,11 +47,11 @@ jobs:
 
       - name: Install build dependencies (macOS)
         if: ${{ runner.os == 'macOS' }}
-        run: brew install llvm ninja autoconf automake libtool nasm shaderc molten-vk
+        run: brew install llvm autoconf automake libtool nasm shaderc molten-vk
 
       - name: Install build dependencies (Linux)
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get install ninja-build libc++-dev libc++abi-dev xorg-dev libtool libltdl-dev glslc
+        run: sudo apt-get install libc++-dev libc++abi-dev xorg-dev libtool libltdl-dev glslc
 
       - name: Setup vcpkg (macOS)
         if: ${{ runner.os == 'macOS' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: Build
 
-env:
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-
 on:
   push:
     paths:
@@ -67,13 +64,6 @@ jobs:
       - name: Setup vcpkg (Linux)
         if: ${{ runner.os == 'Linux' }}
         run: echo ${VCPKG_INSTALLATION_ROOT} >> GITHUB_PATH
-
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Enable Developer Command Prompt (Windows)
         if: ${{ runner.os == 'Windows' }}

--- a/.github/workflows/scripts/CMakeUserPresets.json
+++ b/.github/workflows/scripts/CMakeUserPresets.json
@@ -7,6 +7,9 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "ON"
+      },
+      "environment": {
+        "VCPKG_ROOT": "$env{VCPKG_INSTALLATION_ROOT}"
       }
     },
     {
@@ -46,9 +49,6 @@
         "CMAKE_CXX_FLAGS": "-stdlib=libc++ -Wno-deprecated-declarations",
         "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++ -lc++abi",
         "VCPKG_TARGET_TRIPLET": "x64-linux-clang-release"
-      },
-      "environment": {
-        "VCPKG_ROOT": "$env{VCPKG_INSTALLATION_ROOT}"
       }
     },
     {

--- a/.github/workflows/scripts/CMakeUserPresets.json
+++ b/.github/workflows/scripts/CMakeUserPresets.json
@@ -16,7 +16,6 @@
       "name": "windows-latest-msvc",
       "inherits": "ci",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/EHsc /wd5050",
         "VCPKG_TARGET_TRIPLET": "x64-windows-release"
       }
     },
@@ -46,7 +45,7 @@
       "cacheVariables": {
         "CMAKE_C_COMPILER": "/usr/bin/clang",
         "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
-        "CMAKE_CXX_FLAGS": "-stdlib=libc++ -Wno-deprecated-declarations",
+        "CMAKE_CXX_FLAGS": "-stdlib=libc++",
         "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++ -lc++abi",
         "VCPKG_TARGET_TRIPLET": "x64-linux-clang-release"
       }


### PR DESCRIPTION
- Removed vcpkg binary caching related environment variables.
- Do not install ninja, as it is already installed for all runners.
- Use Vulkan SDK provided shader compiler.
- Do not enable MSVC Developer Prompt when using MinGW Clang compiler in Windows runner.
- Removed some non-default compiler flags.
