### PR TITLE
Support attaching transform gizmo to the multiple selected nodes.

### DIFF
--- a/extlibs/module-ports/ImGuizmo.cppm
+++ b/extlibs/module-ports/ImGuizmo.cppm
@@ -9,6 +9,7 @@ export import imgui;
 
 namespace ImGuizmo {
     export using ImGuizmo::BeginFrame;
+    export using ImGuizmo::IsUsing;
     export using ImGuizmo::Enable;
     export using ImGuizmo::OPERATION;
     export using ImGuizmo::Manipulate;

--- a/interface/control/ImGuiTaskCollector.cppm
+++ b/interface/control/ImGuiTaskCollector.cppm
@@ -36,7 +36,7 @@ namespace vk_gltf_viewer::control {
         void imageBasedLighting(const AppState::ImageBasedLighting &info, ImTextureID eqmapTextureImGuiDescriptorSet);
         void inputControl(Camera &camera, bool& automaticNearFarPlaneAdjustment, bool &useFrustumCulling, full_optional<AppState::Outline> &hoveringNodeOutline, full_optional<AppState::Outline> &selectedNodeOutline);
         void imguizmo(Camera &camera);
-        void imguizmo(Camera &camera, fastgltf::Asset &asset, std::size_t selectedNodeIndex, const fastgltf::math::fmat4x4 &selectedNodeWorldTransform, ImGuizmo::OPERATION operation, std::span<const gltf::Animation> animations, const std::vector<bool> &animationEnabled);
+        void imguizmo(Camera &camera, fastgltf::Asset &asset, const std::unordered_set<std::size_t> &selectedNodes, std::span<fastgltf::math::fmat4x4> nodeWorldTransforms, ImGuizmo::OPERATION operation, std::span<const gltf::Animation> animations, const std::vector<bool> &animationEnabled);
 
     private:
         std::queue<Task> &tasks;

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -25,6 +25,14 @@ namespace vk_gltf_viewer::control {
         struct NodeSelectionChanged { };
         struct HoverNodeFromGui { std::size_t nodeIndex; };
         struct NodeLocalTransformChanged { std::size_t nodeIndex; };
+
+        /**
+         * @brief Unlike <tt>NodeLocalTransformChanged</tt> struct, the transformation of the node indexed by
+         * <tt>nodeIndex</tt> is not affected to its descendants' world transforms; only the immediate descendants local
+         * transforms will be changed to match their original world transform.
+         */
+        struct NodeWorldTransformChanged { std::size_t nodeIndex; };
+
         struct MaterialPropertyChanged {
             enum Property {
                 AlphaCutoff,
@@ -77,6 +85,7 @@ namespace vk_gltf_viewer::control {
         task::NodeSelectionChanged,
         task::HoverNodeFromGui,
         task::NodeLocalTransformChanged,
+        task::NodeWorldTransformChanged,
         task::MaterialPropertyChanged,
         task::SelectMaterialVariants,
         task::MorphTargetWeightChanged>;

--- a/interface/gltf/NodeWorldTransforms.cppm
+++ b/interface/gltf/NodeWorldTransforms.cppm
@@ -13,24 +13,9 @@ namespace vk_gltf_viewer::gltf {
         std::reference_wrapper<const fastgltf::Asset> asset;
 
     public:
-        NodeWorldTransforms(const fastgltf::Asset &asset LIFETIMEBOUND, const fastgltf::Scene &scene)
-            : vector { vector(asset.nodes.size()) }
-            , asset { asset } {
+        NodeWorldTransforms(const fastgltf::Asset &asset LIFETIMEBOUND, const fastgltf::Scene &scene) : asset { asset } {
+            resize(asset.nodes.size());
             update(scene);
-        }
-
-        /**
-         * @brief Update the world transform matrices of the current (specified by \p nodeIndex) and its descendant nodes.
-         *
-         * You can call this function when <tt>asset.nodes[nodeIndex]</tt> (local transform of the node) is changed, to update the world transform matrices of the current and its descendant nodes.
-         *
-         * @param nodeIndex Node index to be started.
-         * @param worldTransform Start node world transform matrix.
-         */
-        void update(std::size_t nodeIndex, const fastgltf::math::fmat4x4 &worldTransform) {
-            algorithm::traverseNode(asset, nodeIndex, [this](std::size_t nodeIndex, const fastgltf::math::fmat4x4 &nodeWorldTransform) {
-                this->operator[](nodeIndex) = nodeWorldTransform;
-            }, worldTransform);
         }
 
         /**
@@ -39,7 +24,7 @@ namespace vk_gltf_viewer::gltf {
          */
         void update(const fastgltf::Scene &scene) {
             algorithm::traverseScene(asset, scene, [this](std::size_t nodeIndex, const fastgltf::math::fmat4x4 &nodeWorldTransform) {
-                this->operator[](nodeIndex) = nodeWorldTransform;
+                operator[](nodeIndex) = nodeWorldTransform;
             });
         }
     };

--- a/interface/gltf/algorithm/miniball.cppm
+++ b/interface/gltf/algorithm/miniball.cppm
@@ -13,7 +13,6 @@ export import fastgltf;
 import :helpers.fastgltf;
 import :gltf.algorithm.bounding_box;
 import :gltf.algorithm.traversal;
-export import :gltf.NodeWorldTransforms;
 
 namespace vk_gltf_viewer::gltf::algorithm {
     /**
@@ -22,14 +21,14 @@ namespace vk_gltf_viewer::gltf::algorithm {
      * @tparam BufferDataAdapter A functor type that acquires the binary buffer data from a glTF buffer view.
      * @param asset fastgltf Asset.
      * @param scene Scene to be considered. It must be from the same asset.
-     * @param nodeWorldTransforms Pre-calculated world transforms for each node in the scene.
+     * @param nodeWorldTransforms Node world transform matrices ordered by node indices in the asset.
      * @return The pair of the miniball's center and radius.
      */
     export template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
     [[nodiscard]] std::pair<fastgltf::math::fvec3, float> getMiniball(
         const fastgltf::Asset &asset,
         const fastgltf::Scene &scene,
-        const NodeWorldTransforms &nodeWorldTransforms,
+        std::span<const fastgltf::math::fmat4x4> nodeWorldTransforms,
         const BufferDataAdapter &adapter = {}
     ) {
 #ifdef EXACT_BOUNDING_VOLUME_USING_CGAL

--- a/interface/vulkan/Frame.cppm
+++ b/interface/vulkan/Frame.cppm
@@ -10,7 +10,6 @@ module;
 export module vk_gltf_viewer:vulkan.Frame;
 
 import std;
-export import :gltf.NodeWorldTransforms;
 export import :gltf.OrderedPrimitives;
 import :helpers.optional;
 import :math.extended_arithmetic;
@@ -84,7 +83,7 @@ namespace vk_gltf_viewer::vulkan {
             template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
             GltfAsset(
                 const fastgltf::Asset &asset LIFETIMEBOUND,
-                const gltf::NodeWorldTransforms &nodeWorldTransforms,
+                std::span<const fastgltf::math::fmat4x4> nodeWorldTransforms,
                 const SharedData &sharedData LIFETIMEBOUND,
                 const BufferDataAdapter &adapter = {}
             ) : instancedNodeWorldTransformBuffer { value_if(sharedData.gltfAsset->nodeInstanceCountExclusiveScanWithCount.back() != 0, [&]() {
@@ -140,7 +139,7 @@ namespace vk_gltf_viewer::vulkan {
 
                 const fastgltf::Asset &asset;
                 const gltf::OrderedPrimitives &orderedPrimitives;
-                const gltf::NodeWorldTransforms &nodeWorldTransforms;
+                std::span<const fastgltf::math::fmat4x4> nodeWorldTransforms;
 
                 bool regenerateDrawCommands;
                 const std::vector<bool> &nodeVisibilities;
@@ -208,7 +207,7 @@ namespace vk_gltf_viewer::vulkan {
         template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
         void changeAsset(
             const fastgltf::Asset &asset,
-            const gltf::NodeWorldTransforms &nodeWorldTransforms,
+            std::span<const fastgltf::math::fmat4x4> nodeWorldTransforms,
             const BufferDataAdapter &adapter = {}
         ) {
             const auto &inner = gltfAsset.emplace(asset, nodeWorldTransforms, sharedData, adapter);

--- a/interface/vulkan/buffer/InstancedNodeWorldTransforms.cppm
+++ b/interface/vulkan/buffer/InstancedNodeWorldTransforms.cppm
@@ -12,7 +12,6 @@ export import vk_mem_alloc_hpp;
 export import vulkan_hpp;
 import :gltf.algorithm.traversal;
 export import :gltf.data_structure.NodeInstanceCountExclusiveScanWithCount;
-export import :gltf.NodeWorldTransforms;
 import :helpers.algorithm;
 import :helpers.fastgltf;
 import :helpers.ranges;
@@ -38,7 +37,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
          * @param asset glTF asset.
          * @param scene Scene represents the node hierarchy.
          * @param nodeInstanceCountExclusiveScanWithCount pre-calculated scanned instance counts, with additional total count at the end.
-         * @param nodeWorldTransforms pre-calculated node world transforms.
+         * @param nodeWorldTransforms Node world transform matrices ordered by node indices in the asset.
          * @param adapter Buffer data adapter.
          * @note This will fill the buffer data with each node's local transform (and post-multiplied instance transforms if presented), as the scene structure is not provided. You have to call <tt>update</tt> to update the world transforms.
          */
@@ -49,7 +48,7 @@ namespace vk_gltf_viewer::vulkan::buffer {
             const fastgltf::Asset &asset LIFETIMEBOUND,
             const fastgltf::Scene &scene,
             const gltf::ds::NodeInstanceCountExclusiveScanWithCount &nodeInstanceCountExclusiveScanWithCount LIFETIMEBOUND,
-            const gltf::NodeWorldTransforms &nodeWorldTransforms,
+            std::span<const fastgltf::math::fmat4x4> nodeWorldTransforms,
             const BufferDataAdapter &adapter = {}
         ) : asset { asset },
             nodeInstanceCountExclusiveScanWithCount { nodeInstanceCountExclusiveScanWithCount },
@@ -67,16 +66,41 @@ namespace vk_gltf_viewer::vulkan::buffer {
         }
 
         /**
-         * @brief Update the node world transforms from given \p nodeIndex, to its descendants.
+         * @brief Update the node world transform at \p nodeIndex.
          * @tparam BufferDataAdapter A functor type that acquires the binary buffer data from a glTF buffer view.
-         * @param nodeIndex Node index to be started.
-         * @param nodeWorldTransforms pre-calculated node world transforms.
+         * @param nodeIndex Node index.
+         * @param nodeWorldTransform World transform matrix of the node.
          * @param adapter Buffer data adapter.
          */
         template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
         void update(
             std::size_t nodeIndex,
-            const gltf::NodeWorldTransforms &nodeWorldTransforms,
+            const fastgltf::math::fmat4x4 &nodeWorldTransform,
+            const BufferDataAdapter &adapter = {}
+        ) {
+            const fastgltf::Node &node = asset.get().nodes[nodeIndex];
+            if (!node.instancingAttributes.empty()) {
+                const std::span bufferData = buffer.asRange<fastgltf::math::fmat4x4>();
+                std::ranges::transform(
+                    getInstanceTransforms(asset, nodeIndex, adapter),
+                    &bufferData[nodeInstanceCountExclusiveScanWithCount.get()[nodeIndex]],
+                    [&](const fastgltf::math::fmat4x4 &instanceTransform) {
+                        return nodeWorldTransform * instanceTransform;
+                    });
+            }
+        }
+
+        /**
+         * @brief Update the node world transforms from given \p nodeIndex, to its descendants.
+         * @tparam BufferDataAdapter A functor type that acquires the binary buffer data from a glTF buffer view.
+         * @param nodeIndex Node index to be started.
+         * @param nodeWorldTransforms Node world transform matrices ordered by node indices in the asset.
+         * @param adapter Buffer data adapter.
+         */
+        template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
+        void updateHierarchical(
+            std::size_t nodeIndex,
+            std::span<const fastgltf::math::fmat4x4> nodeWorldTransforms,
             const BufferDataAdapter &adapter = {}
         ) {
             const std::span bufferData = buffer.asRange<fastgltf::math::fmat4x4>();
@@ -97,17 +121,17 @@ namespace vk_gltf_viewer::vulkan::buffer {
          * @brief Update the node world transforms for all nodes in a scene.
          * @tparam BufferDataAdapter A functor type that acquires the binary buffer data from a glTF buffer view.
          * @param scene Scene to be updated.
-         * @param nodeWorldTransforms pre-calculated node world transforms.
+         * @param nodeWorldTransforms Node world transform matrices ordered by node indices in the asset.
          * @param adapter Buffer data adapter.
          */
         template <typename BufferDataAdapter = fastgltf::DefaultBufferDataAdapter>
         void update(
             const fastgltf::Scene &scene,
-            const gltf::NodeWorldTransforms &nodeWorldTransforms,
+            std::span<const fastgltf::math::fmat4x4> nodeWorldTransforms,
             const BufferDataAdapter &adapter = {}
         ) {
             for (std::size_t nodeIndex : scene.nodeIndices) {
-                update(nodeIndex, nodeWorldTransforms, adapter);
+                updateHierarchical(nodeIndex, nodeWorldTransforms, adapter);
             }
         }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/bd5ac4c7-262a-4162-93bf-92ce7e1f4a71

This PR adds support for attaching the transform gizmo to multiple selected nodes. The gizmo is positioned at the average of the selected nodes’ translation components (the third column of their 4×4 transform matrices). When the gizmo is moved, the world transforms of the attached nodes are updated directly, meaning their rotation and scale axes are not preserved after releasing the mouse.

Since only the world transforms of the attached nodes are modified—not their descendants’—only the local transforms of the direct children of these nodes need to be recalculated. To handle this case, a new `NodeWorldTransformChanged` struct has been introduced in the `control::task` namespace, separate from the existing `NodeLocalTransformChanged` struct.