### PR TITLE
Reduce pipeline state change for different primitive topologies when VK_EXT_extended_dynamic_state3 is supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The extensions and feature used in this application are quite common in the mode
   - (optional) `VK_EXT_index_type_uint8` (if not presented, unsigned byte primitive indices will re-generated with `uint16_t`s)
   - (optional) `VK_EXT_shader_stencil_export` (more plausible bloom effect)
   - (optional) `VK_AMD_shader_image_load_store_lod` (can replace the descriptor indexing based cubemap mipmapping and prefilteredmap generation[^2])
+  - (optional) `VK_EXT_extended_dynamic_state3` (if supported and `VkPhysicalDeviceExtendedDynamicState3PropertiesEXT::dynamicPrimitiveTopologyUnrestricted` is `true`, can reduce the pipeline switch for different primitive topologies)
 - Device Features
   - `VkPhysicalDeviceFeatures`
     - `drawIndirectFirstInstance`

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -177,7 +177,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
 
             if (material.unlit || isPrimitivePointsOrLineWithoutNormal) {
                 result.pipeline = sharedData.getUnlitPrimitiveRenderer({
-                    .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return accessors.texcoordAccessors.at(textureInfo.texCoordIndex).componentType;
@@ -196,7 +196,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             }
             else {
                 result.pipeline = sharedData.getPrimitiveRenderer({
-                    .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .normalComponentType = accessors.normalAccessor.transform([](const shader_type::Accessor &accessor) {
                         return accessor.componentType;
@@ -240,7 +240,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
         }
         else if (isPrimitivePointsOrLineWithoutNormal) {
             result.pipeline = sharedData.getUnlitPrimitiveRenderer({
-                .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                 .positionComponentType = accessors.positionAccessor.componentType,
                 .colorComponentCountAndType = accessors.colorAccessor.transform([](const auto &info) {
                     return std::pair { info.componentCount, info.componentType };
@@ -254,7 +254,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
         }
         else {
             result.pipeline = sharedData.getPrimitiveRenderer({
-                .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                 // TANGENT, TEXCOORD_<i> and their corresponding morph targets are unnecessary as there is no texture.
                 .positionComponentType = accessors.positionAccessor.componentType,
                 .normalComponentType = accessors.normalAccessor.transform([](const shader_type::Accessor &accessor) {
@@ -290,7 +290,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             const fastgltf::Material& material = task.gltf->asset.materials[*primitive.materialIndex];
             if (material.alphaMode == fastgltf::AlphaMode::Mask) {
                 result.pipeline = sharedData.getMaskNodeIndexRenderer({
-                    .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return accessors.texcoordAccessors.at(textureInfo.texCoordIndex).componentType;
@@ -306,7 +306,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             }
             else {
                 result.pipeline = sharedData.getNodeIndexRenderer({
-                    .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                     .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
@@ -316,7 +316,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
         }
         else {
             result.pipeline = sharedData.getNodeIndexRenderer({
-                .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                 .positionComponentType = accessors.positionAccessor.componentType,
                 .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                 .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
@@ -339,7 +339,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             const fastgltf::Material& material = task.gltf->asset.materials[*primitive.materialIndex];
             if (material.alphaMode == fastgltf::AlphaMode::Mask) {
                 result.pipeline = sharedData.getMaskMultiNodeMousePickingRenderer({
-                    .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return accessors.texcoordAccessors.at(textureInfo.texCoordIndex).componentType;
@@ -355,7 +355,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             }
             else {
                 result.pipeline = sharedData.getMultiNodeMousePickingRenderer({
-                    .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                     .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
@@ -364,7 +364,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
         }
         else {
             result.pipeline = sharedData.getMultiNodeMousePickingRenderer({
-                .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                 .positionComponentType = accessors.positionAccessor.componentType,
                 .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                 .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
@@ -387,7 +387,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             const fastgltf::Material &material = task.gltf->asset.materials[*primitive.materialIndex];
             if (material.alphaMode == fastgltf::AlphaMode::Mask) {
                 result.pipeline = sharedData.getMaskJumpFloodSeedRenderer({
-                    .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
                         return accessors.texcoordAccessors.at(textureInfo.texCoordIndex).componentType;
@@ -403,7 +403,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             }
             else {
                 result.pipeline = sharedData.getJumpFloodSeedRenderer({
-                    .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                     .positionComponentType = accessors.positionAccessor.componentType,
                     .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                     .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),
@@ -413,7 +413,7 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
         }
         else {
             result.pipeline = sharedData.getJumpFloodSeedRenderer({
-                .topologyClass = getTopologyClass(getPrimitiveTopology(primitive.type)),
+                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
                 .positionComponentType = accessors.positionAccessor.componentType,
                 .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.positionMorphTargetAccessors.size()),
                 .skinAttributeCount = static_cast<std::uint32_t>(accessors.jointsAccessors.size()),

--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -25,6 +25,7 @@ constexpr std::array optionalExtensions {
     vk::AMDShaderImageLoadStoreLodExtensionName,
     vk::EXTAttachmentFeedbackLoopLayoutExtensionName,
     vk::EXTShaderStencilExportExtensionName,
+    vk::EXTExtendedDynamicState3ExtensionName,
 };
 
 constexpr vk::PhysicalDeviceFeatures requiredFeatures = vk::PhysicalDeviceFeatures{}
@@ -247,6 +248,13 @@ vk::raii::Device vk_gltf_viewer::vulkan::Gpu::createDevice() {
     supportUint8Index = indexTypeUint8Features.indexTypeUint8;
     supportVariableDescriptorCount = vulkan12Features.descriptorBindingVariableDescriptorCount;
 #endif
+
+    if (availableExtensionNames.contains(vk::EXTExtendedDynamicStateExtensionName)) {
+        const auto [_, extendedDynamicState3Props] = physicalDevice.getProperties2<
+            vk::PhysicalDeviceProperties2,
+            vk::PhysicalDeviceExtendedDynamicState3PropertiesEXT>();
+        supportDynamicPrimitiveTopologyUnrestricted = extendedDynamicState3Props.dynamicPrimitiveTopologyUnrestricted;
+    }
 
     constexpr vk::FormatFeatureFlags requiredFormatFeatureFlags
         = vk::FormatFeatureFlagBits::eTransferDst

--- a/interface/vulkan/Gpu.cppm
+++ b/interface/vulkan/Gpu.cppm
@@ -71,6 +71,7 @@ namespace vk_gltf_viewer::vulkan {
         bool supportR8SrgbImageFormat;
         bool supportR8G8SrgbImageFormat;
         bool supportS8UintDepthStencilAttachment;
+        bool supportDynamicPrimitiveTopologyUnrestricted;
 
         Workaround workaround;
 

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -16,7 +16,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class JumpFloodSeedRendererSpecialization {
     public:
-        TopologyClass topologyClass;
+        std::optional<TopologyClass> topologyClass;
         std::uint8_t positionComponentType = 0;
         std::uint32_t positionMorphTargetWeightCount = 0;
         std::uint32_t skinAttributeCount = 0;
@@ -43,15 +43,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     *pipelineLayout, 1, true)
                     .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                         {},
-                        [this]() {
-                            switch (topologyClass) {
-                                case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
-                                case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
-                                case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
-                                case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
-                            }
-                            std::unreachable();
-                        }(),
+                        topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
                     }))
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},
@@ -88,7 +80,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     export class MaskJumpFloodSeedRendererSpecialization {
     public:
-        TopologyClass topologyClass;
+        std::optional<TopologyClass> topologyClass;
         std::uint8_t positionComponentType;
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
@@ -125,15 +117,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     *pipelineLayout, 1, true)
                     .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                         {},
-                        [this]() {
-                            switch (topologyClass) {
-                                case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
-                                case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
-                                case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
-                                case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
-                            }
-                            std::unreachable();
-                        }(),
+                        topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
                     }))
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},

--- a/interface/vulkan/pipeline/MultiNodeMousePickingRenderer.cppm
+++ b/interface/vulkan/pipeline/MultiNodeMousePickingRenderer.cppm
@@ -17,7 +17,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class MultiNodeMousePickingRendererSpecialization {
     public:
-        TopologyClass topologyClass;
+        std::optional<TopologyClass> topologyClass;
         std::uint8_t positionComponentType = 0;
         std::uint32_t positionMorphTargetWeightCount = 0;
         std::uint32_t skinAttributeCount = 0;
@@ -45,15 +45,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     *pipelineLayout, 0, gpu.workaround.attachmentLessRenderPass)
                     .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                         {},
-                        [this]() {
-                            switch (topologyClass) {
-                                case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
-                                case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
-                                case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
-                                case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
-                            }
-                            std::unreachable();
-                        }(),
+                        topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
                     }))
                     .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                         {},
@@ -93,7 +85,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     export class MaskMultiNodeMousePickingRendererSpecialization {
     public:
-        TopologyClass topologyClass;
+        std::optional<TopologyClass> topologyClass;
         std::uint8_t positionComponentType;
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
@@ -131,15 +123,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     *pipelineLayout, 0, gpu.workaround.attachmentLessRenderPass)
                     .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                         {},
-                        [this]() {
-                            switch (topologyClass) {
-                                case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
-                                case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
-                                case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
-                                case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
-                            }
-                            std::unreachable();
-                        }(),
+                        topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
                     }))
                     .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                         {},

--- a/interface/vulkan/pipeline/NodeIndexRenderer.cppm
+++ b/interface/vulkan/pipeline/NodeIndexRenderer.cppm
@@ -17,7 +17,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class NodeIndexRendererSpecialization {
     public:
-        TopologyClass topologyClass;
+        std::optional<TopologyClass> topologyClass;
         std::uint8_t positionComponentType = 0;
         std::uint32_t positionMorphTargetWeightCount = 0;
         std::uint32_t skinAttributeCount = 0;
@@ -44,15 +44,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 *pipelineLayout, 1, true)
                 .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                     {},
-                    [this]() {
-                        switch (topologyClass) {
-                            case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
-                            case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
-                            case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
-                            case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
-                        }
-                        std::unreachable();
-                    }(),
+                    topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
                 }))
                 .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                     {},
@@ -86,7 +78,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
     export class MaskNodeIndexRendererSpecialization {
     public:
-        TopologyClass topologyClass;
+        std::optional<TopologyClass> topologyClass;
         std::uint8_t positionComponentType;
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::uint8_t> colorAlphaComponentType;
@@ -123,15 +115,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 *pipelineLayout, 1, true)
                 .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                     {},
-                    [this]() {
-                        switch (topologyClass) {
-                            case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
-                            case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
-                            case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
-                            case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
-                        }
-                        std::unreachable();
-                    }(),
+                    topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
                 }))
                 .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                     {},

--- a/interface/vulkan/pipeline/PrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/PrimitiveRenderer.cppm
@@ -24,7 +24,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class PrimitiveRendererSpecialization {
     public:
-        TopologyClass topologyClass;
+        std::optional<TopologyClass> topologyClass;
         std::uint8_t positionComponentType;
         std::optional<std::uint8_t> normalComponentType;
         std::optional<std::uint8_t> tangentComponentType;
@@ -78,15 +78,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
             const vk::PipelineInputAssemblyStateCreateInfo inputAssemblyStateCreateInfo {
                 {},
-                [this]() {
-                    switch (topologyClass) {
-                        case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
-                        case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
-                        case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
-                        case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
-                    }
-                    std::unreachable();
-                }(),
+                topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
             };
 
             switch (alphaMode) {

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -21,7 +21,7 @@ import :vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class UnlitPrimitiveRendererSpecialization {
     public:
-        TopologyClass topologyClass;
+        std::optional<TopologyClass> topologyClass;
         std::uint8_t positionComponentType;
         std::optional<std::uint8_t> baseColorTexcoordComponentType;
         std::optional<std::pair<std::uint8_t, std::uint8_t>> colorComponentCountAndType;
@@ -64,15 +64,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
             const vk::PipelineInputAssemblyStateCreateInfo inputAssemblyStateCreateInfo {
                 {},
-                [this]() {
-                    switch (topologyClass) {
-                        case TopologyClass::Point: return vk::PrimitiveTopology::ePointList;
-                        case TopologyClass::Line: return vk::PrimitiveTopology::eLineList;
-                        case TopologyClass::Triangle: return vk::PrimitiveTopology::eTriangleList;
-                        case TopologyClass::Patch: return vk::PrimitiveTopology::ePatchList;
-                    }
-                    std::unreachable();
-                }(),
+                topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
             };
 
             switch (alphaMode) {


### PR DESCRIPTION
This PR reduces pipeline state changes for different primitive topologies on Vulkan physical devices that support `VkPhysicalDeviceExtendedDynamicState3PropertiesEXT::dynamicPrimitiveTopologyUnrestricted` from the `VK_EXT_extended_dynamic_state3` extension.

With this change,`(Unlit)PrimitiveRenderers` using different [primitive topology classes](https://vkdoc.net/chapters/drawing#drawing-primitive-topology-class) can share a single pipeline, as long as there are no other differences in pipeline state. This avoids creating separate pipelines for each topology class.

This optimization can benefit GPUs from vendors like NVIDIA and Intel.