### PR TITLE
Implemented EXT_meshopt_compression support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(fastgltf CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
 find_package(imguizmo CONFIG REQUIRED)
+find_package(meshoptimizer CONFIG REQUIRED)
 find_package(mikktspace CONFIG REQUIRED)
 find_package(nfd CONFIG REQUIRED)
 find_package(Stb REQUIRED)
@@ -265,6 +266,7 @@ target_link_libraries(vk-gltf-viewer PRIVATE
     ibl
     imgui::imgui
     imguizmo::imguizmo
+    meshoptimizer::meshoptimizer
     mikktspace::mikktspace
     nfd::nfd
     vku::vku

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Blazingly fast[^1] Vulkan glTF viewer.
   - [`KHR_texture_basisu`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_basisu) for BC7 GPU compression texture decoding
   - [`KHR_texture_transform`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform)
   - [`EXT_mesh_gpu_instancing`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing) for instancing multiple meshes with the same geometry
+  - [`EXT_meshopt_compression`](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_meshopt_compression)
 - Use 4x MSAA by default.
 - Support HDR and EXR skybox.
 - File loading using platform-native file dialog.

--- a/interface/MainApp.cppm
+++ b/interface/MainApp.cppm
@@ -38,6 +38,7 @@ namespace vk_gltf_viewer {
             | fastgltf::Extensions::KHR_texture_basisu
 #endif
             | fastgltf::Extensions::KHR_texture_transform
+            | fastgltf::Extensions::EXT_meshopt_compression
             | fastgltf::Extensions::EXT_mesh_gpu_instancing;
         static constexpr std::uint32_t FRAMES_IN_FLIGHT = 2;
 

--- a/interface/gltf/AssetExternalBuffers.cppm
+++ b/interface/gltf/AssetExternalBuffers.cppm
@@ -3,6 +3,8 @@ module;
 #include <cerrno>
 #include <cstring>
 
+#include <meshoptimizer.h>
+
 export module vk_gltf_viewer:gltf.AssetExternalBuffers;
 
 import std;
@@ -19,12 +21,84 @@ namespace vk_gltf_viewer::gltf {
      * Also, this class implements <tt>const std::byte* operator(const fastgltf::Asset&, std::size_t) const</tt> for compatibility with <tt>fastgltf::DefaultBufferDataAdapter</tt>. You can directly pass the class instance as the fastgltf's buffer data adapter, such like <tt>fastgltf::iterateAccessor</tt>.
      */
     export class AssetExternalBuffers {
-        std::vector<std::vector<std::byte>> cache;
-        std::vector<std::span<const std::byte>> bytes;
+        std::unordered_map<std::size_t, std::vector<std::byte>> externalBufferBytes;
+        std::vector<std::unique_ptr<std::byte[]>> meshoptDecompressedBytes;
+        std::vector<std::span<const std::byte>> bufferViewBytes;
 
     public:
-        AssetExternalBuffers(const fastgltf::Asset &asset, const std::filesystem::path &directory)
-            : bytes { createBufferBytes(asset, directory) } { }
+        AssetExternalBuffers(const fastgltf::Asset &asset, const std::filesystem::path &directory) {
+            const auto getBufferBytes = [&](std::size_t bufferIndex) -> std::span<const std::byte> {
+                return visit(fastgltf::visitor {
+                    [](const fastgltf::sources::Array &array) -> std::span<const std::byte> {
+                        return as_bytes(std::span { array.bytes });
+                    },
+                    [](const fastgltf::sources::ByteView &byteView) -> std::span<const std::byte> {
+                        return byteView.bytes;
+                    },
+                    [&](const fastgltf::sources::URI &uri) -> std::span<const std::byte> {
+                        auto it = externalBufferBytes.find(bufferIndex);
+                        if (it == externalBufferBytes.end()) {
+                            if (!uri.uri.isLocalPath()) throw AssetProcessError::UnsupportedSourceDataType;
+                            it = externalBufferBytes.emplace_hint(it, bufferIndex, loadFileAsBinary(directory / uri.uri.fspath()));
+                        }
+
+                        return it->second;
+                    },
+                    // Note: fastgltf::source::{BufferView,Vector} should not be handled since they are not used
+                    // for fastgltf::Buffer::data.
+                    [](const auto&) -> std::span<const std::byte> {
+                        throw AssetProcessError::UnsupportedSourceDataType;
+                    },
+                }, asset.buffers[bufferIndex].data);
+            };
+
+            bufferViewBytes.reserve(asset.bufferViews.size());
+            for (const fastgltf::BufferView &bufferView : asset.bufferViews) {
+                if (const auto &mc = bufferView.meshoptCompression) {
+                    const auto compressed = reinterpret_cast<const unsigned char*>(getBufferBytes(mc->bufferIndex).data()) + mc->byteOffset;
+
+                    const std::size_t decompressedBufferSize = mc->count * mc->byteStride;
+                    std::byte* const decompressed = meshoptDecompressedBytes.emplace_back(std::make_unique_for_overwrite<std::byte[]>(decompressedBufferSize)).get();
+
+                    int rc = -1;
+                    switch (mc->mode) {
+                        case fastgltf::MeshoptCompressionMode::Attributes:
+                            rc = meshopt_decodeVertexBuffer(decompressed, mc->count, mc->byteStride, compressed, mc->byteLength);
+                            break;
+                        case fastgltf::MeshoptCompressionMode::Triangles:
+                            rc = meshopt_decodeIndexBuffer(decompressed, mc->count, mc->byteStride, compressed, mc->byteLength);
+                            break;
+                        case fastgltf::MeshoptCompressionMode::Indices:
+                            rc = meshopt_decodeIndexSequence(decompressed, mc->count, mc->byteStride, compressed, mc->byteLength);
+                            break;
+                    }
+
+                    if (rc != 0) {
+                        throw std::runtime_error { "Failed to decompress EXT_meshopt_compression compressed buffer view." };
+                    }
+
+                    switch (mc->filter) {
+                        case fastgltf::MeshoptCompressionFilter::None:
+                            break;
+                        case fastgltf::MeshoptCompressionFilter::Octahedral:
+                            meshopt_decodeFilterOct(decompressed, mc->count, mc->byteStride);
+                            break;
+                        case fastgltf::MeshoptCompressionFilter::Quaternion:
+                            meshopt_decodeFilterQuat(decompressed, mc->count, mc->byteStride);
+                            break;
+                        case fastgltf::MeshoptCompressionFilter::Exponential:
+                            meshopt_decodeFilterExp(decompressed, mc->count, mc->byteStride);
+                            break;
+                    }
+
+                    bufferViewBytes.emplace_back(decompressed, decompressedBufferSize);
+                }
+                else {
+                    const std::span<const std::byte> bufferBytes = getBufferBytes(bufferView.bufferIndex);
+                    bufferViewBytes.push_back( bufferBytes.subspan(bufferView.byteOffset, bufferView.byteLength));
+                }
+            }
+        }
 
         /**
          * Interface for <tt>fastgltf::BufferDataAdapter</tt>.
@@ -33,36 +107,7 @@ namespace vk_gltf_viewer::gltf {
          * @return First byte address of the buffer.
          */
         [[nodiscard]] std::span<const std::byte> operator()(const fastgltf::Asset &asset, std::size_t bufferViewIndex) const {
-            const fastgltf::BufferView &bufferView = asset.bufferViews[bufferViewIndex];
-            return bytes[bufferView.bufferIndex].subspan(bufferView.byteOffset, bufferView.byteLength);
-        }
-
-    private:
-        [[nodiscard]] std::vector<std::span<const std::byte>> createBufferBytes(
-            const fastgltf::Asset &asset,
-            const std::filesystem::path &directory
-        ) {
-            return asset.buffers
-                | std::views::transform([&](const fastgltf::Buffer &buffer) {
-                    return visit(fastgltf::visitor {
-                        [](const fastgltf::sources::Array &array) -> std::span<const std::byte> {
-                            return as_bytes(std::span { array.bytes });
-                        },
-                        [](const fastgltf::sources::ByteView &byteView) -> std::span<const std::byte> {
-                            return byteView.bytes;
-                        },
-                        [&](const fastgltf::sources::URI &uri) -> std::span<const std::byte> {
-                            if (!uri.uri.isLocalPath()) throw AssetProcessError::UnsupportedSourceDataType;
-                            return cache.emplace_back(loadFileAsBinary(directory / uri.uri.fspath()));
-                        },
-                        // Note: fastgltf::source::{BufferView,Vector} should not be handled since they are not used
-                        // for fastgltf::Buffer::data.
-                        [](const auto&) -> std::span<const std::byte> {
-                            throw AssetProcessError::UnsupportedSourceDataType;
-                        },
-                    }, buffer.data);
-                })
-                | std::ranges::to<std::vector>();
+            return bufferViewBytes[bufferViewIndex];
         }
     };
 }

--- a/overlays/meshoptimizer/fix-cmake.patch
+++ b/overlays/meshoptimizer/fix-cmake.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9e0beed..d28a04c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -137,13 +137,12 @@ if(MESHOPT_BUILD_GLTFPACK)
+         target_compile_definitions(gltfpack PRIVATE WITH_BASISU)
+         set_source_files_properties(gltf/basisenc.cpp gltf/basislib.cpp PROPERTIES INCLUDE_DIRECTORIES ${BASISU_PATH})
+ 
+-        if(NOT MSVC AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
++        if(NOT MSVC AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+             set_source_files_properties(gltf/basislib.cpp PROPERTIES COMPILE_OPTIONS -msse4.1)
+         endif()
+ 
+-        if(UNIX)
+-            target_link_libraries(gltfpack pthread)
+-        endif()
++        find_package(Threads REQUIRED)
++        target_link_libraries(gltfpack Threads::Threads)
+     endif()
+ endif()
+ 

--- a/overlays/meshoptimizer/portfile.cmake
+++ b/overlays/meshoptimizer/portfile.cmake
@@ -1,0 +1,54 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO zeux/meshoptimizer
+    REF v${VERSION}
+    SHA512 d8342aadd48c0f51aa014ba56ff4c97f4780194eabf78d8a867876fb49f5d103597748ec4aa3613e236e2c42c5ca58d46a9ad3b7c458de5e1f01546d9951bfb4
+    HEAD_REF master
+    PATCHES
+      fix-cmake.patch
+      upstream-896.patch # https://github.com/zeux/meshoptimizer/pull/896
+)
+
+# If we want basisu support in gltfpack we need a particular fork of basisu
+# We could modify this to support using the vcpkg version of basisu
+# but since this is only necessary for the gltfpack tool and not for the 
+# meshopt lib it shouldn't be too nasty to just grab this repo
+if ("gltfpack" IN_LIST FEATURES)
+  vcpkg_from_github(
+      OUT_SOURCE_PATH BASISU_PATH
+      REPO zeux/basis_universal
+      REF 88e813c46b3ff42e56ef947b3fa11eeee7a504b0
+      SHA512 cc9e4dbaed556fac30f4426ead9c8fb018ca8540bd1188849a90396192e410a5fdc6f38edbad07d2615583fbdfe01a79989d426caed7614d38b93731bbe3d4ae
+      HEAD_REF gltfpack
+  )
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+FEATURES
+  gltfpack  MESHOPT_BUILD_GLTFPACK
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED_LIBS)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+      ${FEATURE_OPTIONS}
+      -DMESHOPT_BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+      -DMESHOPT_BASISU_PATH=${BASISU_PATH}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/meshoptimizer)
+
+if ("gltfpack" IN_LIST FEATURES)
+  vcpkg_copy_tools(TOOL_NAMES gltfpack AUTO_CLEAN)
+endif()
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE.md" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/overlays/meshoptimizer/upstream-896.patch
+++ b/overlays/meshoptimizer/upstream-896.patch
@@ -1,0 +1,125 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index da4d6f87a..7f3f8003f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -104,6 +104,8 @@ if(MESHOPT_BUILD_SHARED_LIBS)
+         target_compile_definitions(meshoptimizer PUBLIC "MESHOPTIMIZER_API=__attribute__((visibility(\"default\")))")
+     endif()
+ 
++    target_compile_definitions(meshoptimizer PUBLIC MESHOPTIMIZER_ALLOC_EXPORT)
++
+     if(MESHOPT_STABLE_EXPORTS)
+ 		target_compile_definitions(meshoptimizer PUBLIC "MESHOPTIMIZER_EXPERIMENTAL=")
+     endif()
+diff --git a/src/allocator.cpp b/src/allocator.cpp
+index b8cb33c28..6b6083da2 100644
+--- a/src/allocator.cpp
++++ b/src/allocator.cpp
+@@ -1,8 +1,17 @@
+ // This file is part of meshoptimizer library; see meshoptimizer.h for version/license details
+ #include "meshoptimizer.h"
+ 
++#ifdef MESHOPTIMIZER_ALLOC_EXPORT
++meshopt_Allocator::Storage& meshopt_Allocator::storage()
++{
++	static Storage s = {::operator new, ::operator delete };
++	return s;
++}
++#endif
++
+ void meshopt_setAllocator(void* (MESHOPTIMIZER_ALLOC_CALLCONV* allocate)(size_t), void (MESHOPTIMIZER_ALLOC_CALLCONV* deallocate)(void*))
+ {
+-	meshopt_Allocator::Storage::allocate = allocate;
+-	meshopt_Allocator::Storage::deallocate = deallocate;
++	meshopt_Allocator::Storage& s = meshopt_Allocator::storage();
++	s.allocate = allocate;
++	s.deallocate = deallocate;
+ }
+diff --git a/src/meshoptimizer.h b/src/meshoptimizer.h
+index eacd14df2..2b5378a52 100644
+--- a/src/meshoptimizer.h
++++ b/src/meshoptimizer.h
+@@ -890,14 +890,21 @@ inline int meshopt_quantizeSnorm(float v, int N)
+ class meshopt_Allocator
+ {
+ public:
+-	template <typename T>
+-	struct StorageT
++	struct Storage
+ 	{
+-		static void* (MESHOPTIMIZER_ALLOC_CALLCONV* allocate)(size_t);
+-		static void (MESHOPTIMIZER_ALLOC_CALLCONV* deallocate)(void*);
++		void* (MESHOPTIMIZER_ALLOC_CALLCONV* allocate)(size_t);
++		void (MESHOPTIMIZER_ALLOC_CALLCONV* deallocate)(void*);
+ 	};
+ 
+-	typedef StorageT<void> Storage;
++#ifdef MESHOPTIMIZER_ALLOC_EXPORT
++	MESHOPTIMIZER_API static Storage& storage();
++#else
++	static Storage& storage()
++	{
++		static Storage s = {::operator new, ::operator delete };
++		return s;
++	}
++#endif
+ 
+ 	meshopt_Allocator()
+ 	    : blocks()
+@@ -908,14 +915,14 @@ class meshopt_Allocator
+ 	~meshopt_Allocator()
+ 	{
+ 		for (size_t i = count; i > 0; --i)
+-			Storage::deallocate(blocks[i - 1]);
++			storage().deallocate(blocks[i - 1]);
+ 	}
+ 
+ 	template <typename T>
+ 	T* allocate(size_t size)
+ 	{
+ 		assert(count < sizeof(blocks) / sizeof(blocks[0]));
+-		T* result = static_cast<T*>(Storage::allocate(size > size_t(-1) / sizeof(T) ? size_t(-1) : size * sizeof(T)));
++		T* result = static_cast<T*>(storage().allocate(size > size_t(-1) / sizeof(T) ? size_t(-1) : size * sizeof(T)));
+ 		blocks[count++] = result;
+ 		return result;
+ 	}
+@@ -923,7 +930,7 @@ class meshopt_Allocator
+ 	void deallocate(void* ptr)
+ 	{
+ 		assert(count > 0 && blocks[count - 1] == ptr);
+-		Storage::deallocate(ptr);
++		storage().deallocate(ptr);
+ 		count--;
+ 	}
+ 
+@@ -931,12 +938,6 @@ class meshopt_Allocator
+ 	void* blocks[24];
+ 	size_t count;
+ };
+-
+-// This makes sure that allocate/deallocate are lazily generated in translation units that need them and are deduplicated by the linker
+-template <typename T>
+-void* (MESHOPTIMIZER_ALLOC_CALLCONV* meshopt_Allocator::StorageT<T>::allocate)(size_t) = operator new;
+-template <typename T>
+-void (MESHOPTIMIZER_ALLOC_CALLCONV* meshopt_Allocator::StorageT<T>::deallocate)(void*) = operator delete;
+ #endif
+ 
+ /* Inline implementation for C++ templated wrappers */
+@@ -958,7 +959,7 @@ struct meshopt_IndexAdapter<T, false>
+ 	{
+ 		size_t size = count > size_t(-1) / sizeof(unsigned int) ? size_t(-1) : count * sizeof(unsigned int);
+ 
+-		data = static_cast<unsigned int*>(meshopt_Allocator::Storage::allocate(size));
++		data = static_cast<unsigned int*>(meshopt_Allocator::storage().allocate(size));
+ 
+ 		if (input)
+ 		{
+@@ -975,7 +976,7 @@ struct meshopt_IndexAdapter<T, false>
+ 				result[i] = T(data[i]);
+ 		}
+ 
+-		meshopt_Allocator::Storage::deallocate(data);
++		meshopt_Allocator::storage().deallocate(data);
+ 	}
+ };
+ 

--- a/overlays/meshoptimizer/vcpkg.json
+++ b/overlays/meshoptimizer/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "meshoptimizer",
+  "version": "0.24",
+  "description": "Mesh optimization library that makes meshes smaller and faster to render",
+  "homepage": "https://github.com/zeux/meshoptimizer",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "gltfpack": {
+      "description": "Build gltfpack tool",
+      "supports": "!uwp"
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,6 +16,7 @@
       ]
     },
     "imguizmo",
+    "meshoptimizer",
     "mikktspace",
     "nativefiledialog-extended",
     "stb",


### PR DESCRIPTION
<table>
    <thead>
        <tr>
            <th><a href="https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/DragonAttenuation">Dragon Attenuation (Meshopt)</a></th>
            <th><a href="https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/BrainStem">BrainStem (Meshopt)</a></th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td><img width="1392" alt="Dragon Attenuation (Quantized)" src="https://github.com/user-attachments/assets/e2ea91f8-ea3b-4073-bf24-d416859ca9b8" />
</td>
            <td>
<img width="1392" alt="BrainStem (Meshopt)" src="https://github.com/user-attachments/assets/4e8dab75-644e-44e2-a5f3-33708eeb030d" />
</td>
        </tr>
    </tbody>
</table>

This PR adds support for loading glTF 2.0 assets that use the [EXT_meshopt_compression](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_meshopt_compression/README.md) extension, using [meshoptimizer](https://github.com/zeux/meshoptimizer). To keep the implementation simple, compressed buffer views are handled during the construction of `AssetExternalBuffers`.

Note: [The latest version of the `<meshoptimizer.h>` header cannot currently be included in the global module fragment](https://github.com/zeux/meshoptimizer/issues/895). Although this issue has been fixed upstream, it has not yet been released as a vcpkg port. The current overlay port should be removed once the next official release is available.