### PR TITLE
Use buffer device addresses to pass the morph target weights, skin joint indices and inverse bind matrices.

### DIFF
--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -593,10 +593,11 @@ void vk_gltf_viewer::MainApp::run() {
                 },
                 [&](const control::task::MorphTargetWeightChanged &task) {
                     auto updateTargetWeightTask = [this, task](vulkan::Frame &frame) {
-                        const std::span targetWeights = getTargetWeights(gltf->asset.nodes[task.nodeIndex], gltf->asset);
-                        for (auto weightIndex = task.targetWeightStartIndex; float weight : targetWeights.subspan(task.targetWeightStartIndex, task.targetWeightCount)) {
-                            frame.gltfAsset->morphTargetWeightBuffer.value().updateWeight(task.nodeIndex, weightIndex++, weight);
-                        }
+                        std::ranges::copy(
+                            getTargetWeights(gltf->asset.nodes[task.nodeIndex], gltf->asset)
+                                .subspan(task.targetWeightStartIndex, task.targetWeightCount),
+                            frame.gltfAsset->morphTargetWeightBuffer.value().weights(task.nodeIndex)
+                                .subspan(task.targetWeightStartIndex, task.targetWeightCount).begin());
                     };
                     updateTargetWeightTask(frame);
                     deferredFrameUpdateTasks.push_back(std::move(updateTargetWeightTask));

--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -163,7 +163,6 @@ vk::raii::PhysicalDevice vk_gltf_viewer::vulkan::Gpu::selectPhysicalDevice(const
             !vulkan12Features.descriptorIndexing ||
             !vulkan12Features.descriptorBindingSampledImageUpdateAfterBind ||
             !vulkan12Features.descriptorBindingVariableDescriptorCount ||
-            !vulkan12Features.descriptorBindingPartiallyBound ||
             !vulkan12Features.runtimeDescriptorArray ||
             !vulkan12Features.separateDepthStencilLayouts ||
             !vulkan12Features.storageBuffer8BitAccess ||
@@ -285,7 +284,6 @@ vk::raii::Device vk_gltf_viewer::vulkan::Gpu::createDevice() {
             .setDescriptorIndexing(true)
             .setDescriptorBindingSampledImageUpdateAfterBind(true)
             .setDescriptorBindingVariableDescriptorCount(supportVariableDescriptorCount)
-            .setDescriptorBindingPartiallyBound(true)
             .setRuntimeDescriptorArray(true)
             .setSeparateDepthStencilLayouts(true)
             .setStorageBuffer8BitAccess(true)

--- a/interface/helpers/optional.cppm
+++ b/interface/helpers/optional.cppm
@@ -49,6 +49,31 @@ export template <std::invocable F>
 }
 
 /**
+ * @brief Get the address of the value contained in \p opt, or <tt>nullptr</tt> if \p opt is empty.
+ * @tparam T Optional inner type.
+ * @param opt Optional value to get the address of.
+ * @return Address of the value contained in \p opt, or <tt>nullptr</tt> if \p opt is empty.
+ */
+export template <typename T>
+[[nodiscard]] T *value_address(std::optional<T> &opt) noexcept {
+    if (opt) {
+        return std::addressof(*opt);
+    }
+    return nullptr;
+}
+
+/**
+ * @copydoc value_address(std::optional<T>&)
+ */
+export template <typename T>
+[[nodiscard]] const T *value_address(const std::optional<T> &opt) noexcept {
+    if (opt) {
+        return std::addressof(*opt);
+    }
+    return nullptr;
+}
+
+/**
  * @brief If all \p opts... contain values, invokes \p f with the contained values as arguments, and returns an std::optional that contains the result of that invocation; otherwise, returns an empty <tt>std::optional</tt>.
  *
  * This is generalization of <tt>std::optional::transform</tt> with multiple optional values.

--- a/interface/vulkan/SharedData.cppm
+++ b/interface/vulkan/SharedData.cppm
@@ -83,7 +83,7 @@ namespace vk_gltf_viewer::vulkan {
                     return std::pair<buffer::SkinJointIndices, buffer::InverseBindMatrices> {
                         std::piecewise_construct,
                         std::tie(asset, skinJointCountExclusiveScanWithCount, gpu.allocator, stagingBufferStorage),
-                        std::tie(asset, gpu.allocator, stagingBufferStorage, adapter),
+                        std::tie(asset, skinJointCountExclusiveScanWithCount, gpu.allocator, stagingBufferStorage, adapter),
                     };
                 }) },
                 textures { asset, directory, gpu, fallbackTexture, threadPool, adapter },
@@ -291,7 +291,7 @@ namespace vk_gltf_viewer::vulkan {
             }
 
             gltfAsset.emplace(asset, directory, orderedPrimitives, gpu, fallbackTexture, adapter);
-            if (!gpu.supportVariableDescriptorCount && assetDescriptorSetLayout.descriptorCounts[6] != textureCount) {
+            if (!gpu.supportVariableDescriptorCount && get<3>(assetDescriptorSetLayout.descriptorCounts) != textureCount) {
                 // If texture count is different, descriptor set layouts, pipeline layouts and pipelines have to be recreated.
                 nodeIndexPipelines.clear();
                 maskNodeIndexPipelines.clear();

--- a/interface/vulkan/buffer/InverseBindMatrices.cppm
+++ b/interface/vulkan/buffer/InverseBindMatrices.cppm
@@ -1,31 +1,31 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer.vulkan.buffer.InverseBindMatrices;
 
 import std;
 export import fastgltf;
-import glm; // TODO: use fastgltf::math::fmat4x4 when it gets being trivially copyable.
 
 export import vk_gltf_viewer.gltf.AssetExternalBuffers;
+export import vk_gltf_viewer.gltf.data_structure.SkinJointCountExclusiveScanWithCount;
 import vk_gltf_viewer.helpers.fastgltf;
 import vk_gltf_viewer.helpers.span;
-import vk_gltf_viewer.vulkan.buffer;
 export import vk_gltf_viewer.vulkan.buffer.StagingBufferStorage;
 import vk_gltf_viewer.vulkan.trait.PostTransferObject;
 
 namespace vk_gltf_viewer::vulkan::buffer {
-    export class InverseBindMatrices : trait::PostTransferObject {
+    export class InverseBindMatrices final : public vku::AllocatedBuffer, trait::PostTransferObject {
     public:
+        std::reference_wrapper<const gltf::ds::SkinJointCountExclusiveScanWithCount> skinJointCountExclusiveScanWithCount;
+        
         InverseBindMatrices(
             const fastgltf::Asset &asset,
+            const gltf::ds::SkinJointCountExclusiveScanWithCount& skinJointCountExclusiveScanWithCount LIFETIMEBOUND,
             vma::Allocator allocator,
             StagingBufferStorage &stagingBufferStorage,
             const gltf::AssetExternalBuffers &adapter
         );
-
-        [[nodiscard]] const vk::DescriptorBufferInfo &getDescriptorInfo() const noexcept;
-
-    private:
-        vku::AllocatedBuffer buffer;
-        vk::DescriptorBufferInfo descriptorInfo;
     };
 
 }
@@ -36,58 +36,64 @@ module :private;
 
 vk_gltf_viewer::vulkan::buffer::InverseBindMatrices::InverseBindMatrices(
     const fastgltf::Asset &asset,
+    const gltf::ds::SkinJointCountExclusiveScanWithCount& skinJointCountExclusiveScanWithCount,
     vma::Allocator allocator,
     StagingBufferStorage &stagingBufferStorage,
     const gltf::AssetExternalBuffers &adapter
-) : PostTransferObject { stagingBufferStorage },
-    buffer { [&]() {
-        // When a skin's inverseBindMatrices is not defined, identity matrices must be used. It first calculates
-        // the maximum number of skin joints count (=largestContinuousIdentityMatrixCount), and allocate
-        // contiguous identity matrices of size largestContinuousIdentityMatrixCount. Then, each skin's
-        // inverseBindMatrices can use the subspan of the contiguous identity matrices.
-        std::size_t largestContinuousIdentityMatrixCount = 0;
-        for (const fastgltf::Skin &skin : asset.skins) {
-            if (!skin.inverseBindMatrices && skin.joints.size() > largestContinuousIdentityMatrixCount) {
-                largestContinuousIdentityMatrixCount = skin.joints.size();
+) : AllocatedBuffer { 
+        allocator,
+        vk::BufferCreateInfo {
+            {},
+            sizeof(fastgltf::math::fmat4x4) * skinJointCountExclusiveScanWithCount.back(),
+            vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress | vk::BufferUsageFlagBits::eTransferSrc,
+        },
+        vma::AllocationCreateInfo {
+            vma::AllocationCreateFlagBits::eHostAccessSequentialWrite | vma::AllocationCreateFlagBits::eMapped,
+            vma::MemoryUsage::eAutoPreferHost,
+        },
+    },
+    PostTransferObject { stagingBufferStorage },
+    skinJointCountExclusiveScanWithCount { skinJointCountExclusiveScanWithCount } {
+    std::size_t maxSparseAccessorCount = 0;
+    std::size_t maxContinuousIdentityMatrixCount = 0;
+    for (const fastgltf::Skin &skin : asset.skins) {
+        if (skin.inverseBindMatrices) {
+            const fastgltf::Accessor &accessor = asset.accessors[*skin.inverseBindMatrices];
+            if (accessor.sparse) {
+                maxSparseAccessorCount = std::max(maxSparseAccessorCount, accessor.count);
             }
         }
-        const std::vector contiguousIdentityMatrices(largestContinuousIdentityMatrixCount, glm::identity<glm::mat4>());
+        else {
+            maxContinuousIdentityMatrixCount = std::max(maxContinuousIdentityMatrixCount, skin.joints.size());
+        }
+    }
 
-        std::vector<std::vector<fastgltf::math::fmat4x4>> sparseAccessorData;
-        std::vector<std::span<const glm::mat4>> matrices;
-        for (const fastgltf::Skin &skin : asset.skins) {
-            if (skin.inverseBindMatrices) {
-                const fastgltf::Accessor &accessor = asset.accessors[*skin.inverseBindMatrices];
-                if (accessor.sparse) {
-                    std::vector<fastgltf::math::fmat4x4> &v = sparseAccessorData.emplace_back(accessor.count);
-                    fastgltf::copyFromAccessor<fastgltf::math::fmat4x4>(asset, accessor, v.data(), adapter);
-                    matrices.push_back(reinterpret_span<const glm::mat4>(std::span { v }));
-                }
-                else {
-                    matrices.push_back(reinterpret_span<const glm::mat4>(fastgltf::getByteRegion(asset, accessor, adapter)));
-                }
+    auto sparseAccessorDataBuffer = std::make_unique_for_overwrite<fastgltf::math::fmat4x4[]>(maxSparseAccessorCount);
+    const auto contiguousIdentityMatrices = std::make_unique<fastgltf::math::fmat4x4[]>(maxContinuousIdentityMatrixCount);
+
+    vk::DeviceSize byteOffset = 0;
+    for (const fastgltf::Skin &skin : asset.skins) {
+        std::span<const fastgltf::math::fmat4x4> data;
+        if (skin.inverseBindMatrices) {
+            const fastgltf::Accessor &accessor = asset.accessors[*skin.inverseBindMatrices];
+            if (accessor.sparse) {
+                fastgltf::copyFromAccessor<fastgltf::math::fmat4x4>(asset, accessor, &sparseAccessorDataBuffer[0], adapter);
+                data = { &sparseAccessorDataBuffer[0], skin.joints.size() };
             }
             else {
-                matrices.push_back(contiguousIdentityMatrices);
+                data = reinterpret_span<const fastgltf::math::fmat4x4>(fastgltf::getByteRegion(asset, accessor, adapter)).subspan(0, skin.joints.size());
             }
-
-            // Only first N (=# of joints in a skin) matrices are used.
-            matrices.back() = matrices.back().subspan(0, skin.joints.size());
+        }
+        else {
+            data = { &contiguousIdentityMatrices[0], skin.joints.size() };
         }
 
-        vku::AllocatedBuffer result = createCombinedBuffer<true>(
-            allocator, matrices,
-            vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc,
-            vma::MemoryUsage::eAutoPreferHost).first;
+        const vk::DeviceSize byteSize = data.size_bytes();
+        allocator.copyMemoryToAllocation(data.data(), allocation, byteOffset, byteSize);
+        byteOffset += byteSize;
+    }
 
-        if (StagingBufferStorage::needStaging(result)) {
-            stagingBufferStorage.stage(result, vk::BufferUsageFlagBits::eTransferDst | vk::BufferUsageFlagBits::eStorageBuffer);
-        }
-
-        return result;
-    }() },
-    descriptorInfo { buffer, 0, vk::WholeSize } { }
-
-const vk::DescriptorBufferInfo & vk_gltf_viewer::vulkan::buffer::InverseBindMatrices::getDescriptorInfo() const noexcept {
-    return descriptorInfo;
+    if (StagingBufferStorage::needStaging(*this)) {
+        stagingBufferStorage.stage(*this, vk::BufferUsageFlagBits::eTransferDst | vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress);
+    }
 }

--- a/interface/vulkan/buffer/SkinJointIndices.cppm
+++ b/interface/vulkan/buffer/SkinJointIndices.cppm
@@ -1,3 +1,7 @@
+module;
+
+#include <lifetimebound.hpp>
+
 export module vk_gltf_viewer.vulkan.buffer.SkinJointIndices;
 
 import std;
@@ -5,27 +9,20 @@ export import fastgltf;
 export import vk_mem_alloc_hpp;
 
 export import vk_gltf_viewer.gltf.data_structure.SkinJointCountExclusiveScanWithCount;
-#ifdef _MSC_VER
-import vk_gltf_viewer.helpers.ranges;
-#endif
 export import vk_gltf_viewer.vulkan.buffer.StagingBufferStorage;
 import vk_gltf_viewer.vulkan.trait.PostTransferObject;
 
 namespace vk_gltf_viewer::vulkan::buffer {
-    export class SkinJointIndices : trait::PostTransferObject {
+    export class SkinJointIndices final : public vku::AllocatedBuffer, trait::PostTransferObject {
     public:
+        std::reference_wrapper<const gltf::ds::SkinJointCountExclusiveScanWithCount> skinJointCountExclusiveScanWithCount;
+
         SkinJointIndices(
             const fastgltf::Asset& asset,
-            const gltf::ds::SkinJointCountExclusiveScanWithCount& skinJointCountExclusiveScanWithCount,
+            const gltf::ds::SkinJointCountExclusiveScanWithCount& skinJointCountExclusiveScanWithCount LIFETIMEBOUND,
             vma::Allocator allocator,
             StagingBufferStorage &stagingBufferStorage
         );
-
-        [[nodiscard]] const vk::DescriptorBufferInfo &getDescriptorInfo() const noexcept;
-
-    private:
-        vku::AllocatedBuffer buffer;
-        vk::DescriptorBufferInfo descriptorInfo;
     };
 }
 
@@ -39,44 +36,36 @@ vk_gltf_viewer::vulkan::buffer::SkinJointIndices::SkinJointIndices(
     vma::Allocator allocator,
     StagingBufferStorage &stagingBufferStorage
 ) : PostTransferObject { stagingBufferStorage },
-    buffer { [&]() {
-        std::vector<std::uint32_t> combinedJointIndices(skinJointCountExclusiveScanWithCount.back());
-    #ifdef _MSC_VER
-        for (const auto& [skinIndex, skin] : asset.skins | ranges::views::enumerate) {
-            std::ranges::copy(
-                skin.joints | std::views::transform([](auto x) -> std::uint32_t { return x; }),
-                combinedJointIndices.begin() + skinJointCountExclusiveScanWithCount[skinIndex]);
-        }
-    #else
-        // TODO: this code triggers ICE at MainApp.cpp when compiling with MSVC. Need investigation.
-        for (const auto& [startIndex, skin] : std::views::zip(skinJointCountExclusiveScanWithCount, asset.skins)) {
-            std::ranges::copy(
-                skin.joints | std::views::transform([](auto x) -> std::uint32_t { return x; }),
-                combinedJointIndices.begin() + startIndex);
-        }
-    #endif
-        vku::AllocatedBuffer result {
-            allocator,
-            vk::BufferCreateInfo {
-                {},
-                sizeof(std::uint32_t) * combinedJointIndices.size(),
-                vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc,
-            },
-            vma::AllocationCreateInfo {
-                vma::AllocationCreateFlagBits::eHostAccessSequentialWrite,
-                vma::MemoryUsage::eAutoPreferHost,
-            },
-        };
-        allocator.copyMemoryToAllocation(combinedJointIndices.data(), result.allocation, 0, result.size);
+    AllocatedBuffer {
+        allocator,
+        vk::BufferCreateInfo {
+            {},
+            sizeof(std::uint32_t) * skinJointCountExclusiveScanWithCount.back(),
+            vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress | vk::BufferUsageFlagBits::eTransferSrc,
+        },
+        vma::AllocationCreateInfo {
+            vma::AllocationCreateFlagBits::eHostAccessSequentialWrite | vma::AllocationCreateFlagBits::eMapped,
+            vma::MemoryUsage::eAutoPreferHost,
+        },
+    },
+    skinJointCountExclusiveScanWithCount { skinJointCountExclusiveScanWithCount } {
+    // Get maximum joint count of all skins.
+    std::size_t maxJointCount = 0;
+    for (const fastgltf::Skin &skin : asset.skins) {
+        maxJointCount = std::max(maxJointCount, skin.joints.size());
+    }
+    auto convertedJointIndices = std::make_unique_for_overwrite<std::uint32_t[]>(maxJointCount);
 
-        if (StagingBufferStorage::needStaging(result)) {
-            stagingBufferStorage.stage(result, vk::BufferUsageFlagBits::eTransferDst | vk::BufferUsageFlagBits::eStorageBuffer);
-        }
+    vk::DeviceSize byteOffset = 0;
+    for (const fastgltf::Skin &skin : asset.skins) {
+        std::ranges::copy(skin.joints, &convertedJointIndices[0]);
 
-        return result;
-    }() },
-    descriptorInfo { buffer, 0, vk::WholeSize } { }
+        const vk::DeviceSize byteSize = sizeof(std::uint32_t) * skin.joints.size();
+        allocator.copyMemoryToAllocation(&convertedJointIndices[0], allocation, byteOffset, byteSize);
+        byteOffset += byteSize;
+    }
 
-const vk::DescriptorBufferInfo &vk_gltf_viewer::vulkan::buffer::SkinJointIndices::getDescriptorInfo() const noexcept {
-    return descriptorInfo;
+    if (StagingBufferStorage::needStaging(*this)) {
+        stagingBufferStorage.stage(*this, vk::BufferUsageFlagBits::eTransferDst | vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eShaderDeviceAddress);
+    }
 }

--- a/interface/vulkan/descriptor_set_layout/Asset.cppm
+++ b/interface/vulkan/descriptor_set_layout/Asset.cppm
@@ -9,7 +9,7 @@ import std;
 export import vk_gltf_viewer.vulkan.Gpu;
 
 namespace vk_gltf_viewer::vulkan::dsl {
-    export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
+    export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
         explicit Asset(const Gpu &gpu LIFETIMEBOUND);
         Asset(const Gpu &gpu LIFETIMEBOUND, std::uint32_t textureCount);
 
@@ -33,9 +33,6 @@ vk_gltf_viewer::vulkan::dsl::Asset::Asset(const Gpu &gpu)
             vku::unsafeProxy(getBindings(
                 { 1, vk::ShaderStageFlagBits::eVertex },
                 { 1, vk::ShaderStageFlagBits::eVertex },
-                { 1, vk::ShaderStageFlagBits::eVertex },
-                { 1, vk::ShaderStageFlagBits::eVertex },
-                { 1, vk::ShaderStageFlagBits::eVertex },
                 { 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment },
                 { maxTextureCount(gpu), vk::ShaderStageFlagBits::eFragment })),
         },
@@ -43,9 +40,6 @@ vk_gltf_viewer::vulkan::dsl::Asset::Asset(const Gpu &gpu)
             vku::unsafeProxy<vk::DescriptorBindingFlags>({
                 {},
                 {},
-                vk::DescriptorBindingFlagBits::ePartiallyBound,
-                vk::DescriptorBindingFlagBits::ePartiallyBound,
-                vk::DescriptorBindingFlagBits::ePartiallyBound,
                 {},
                 vk::DescriptorBindingFlagBits::eUpdateAfterBind | vk::DescriptorBindingFlagBits::eVariableDescriptorCount,
             }),
@@ -59,9 +53,6 @@ vk_gltf_viewer::vulkan::dsl::Asset::Asset(const Gpu &gpu, std::uint32_t textureC
             vku::unsafeProxy(getBindings(
                 { 1, vk::ShaderStageFlagBits::eVertex },
                 { 1, vk::ShaderStageFlagBits::eVertex },
-                { 1, vk::ShaderStageFlagBits::eVertex },
-                { 1, vk::ShaderStageFlagBits::eVertex },
-                { 1, vk::ShaderStageFlagBits::eVertex },
                 { 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment },
                 { textureCount, vk::ShaderStageFlagBits::eFragment })),
         },
@@ -69,9 +60,6 @@ vk_gltf_viewer::vulkan::dsl::Asset::Asset(const Gpu &gpu, std::uint32_t textureC
             vku::unsafeProxy<vk::DescriptorBindingFlags>({
                 {},
                 {},
-                vk::DescriptorBindingFlagBits::ePartiallyBound,
-                vk::DescriptorBindingFlagBits::ePartiallyBound,
-                vk::DescriptorBindingFlagBits::ePartiallyBound,
                 {},
                 vk::DescriptorBindingFlagBits::eUpdateAfterBind,
             }),

--- a/interface/vulkan/shader_type/Node.cppm
+++ b/interface/vulkan/shader_type/Node.cppm
@@ -11,9 +11,10 @@ export import vulkan_hpp;
 namespace vk_gltf_viewer::vulkan::shader_type {
     export struct Node {
         glm::mat4 worldTransform;
-        vk::DeviceAddress pInstancedWorldTransforms;
-        std::uint32_t morphTargetWeightStartIndex;
-        std::uint32_t skinJointIndexStartIndex;
+        vk::DeviceAddress pInstancedWorldTransformBuffer;
+        vk::DeviceAddress pMorphTargetWeightBuffer;
+        vk::DeviceAddress pSkinJointIndexBuffer;
+        vk::DeviceAddress pInverseBindMatrixBuffer;
     };
 }
 
@@ -21,7 +22,6 @@ namespace vk_gltf_viewer::vulkan::shader_type {
 module :private;
 #endif
 
-static_assert(sizeof(vk_gltf_viewer::vulkan::shader_type::Node) == 80);
-static_assert(offsetof(vk_gltf_viewer::vulkan::shader_type::Node, pInstancedWorldTransforms) == 64);
-static_assert(offsetof(vk_gltf_viewer::vulkan::shader_type::Node, morphTargetWeightStartIndex) == 72);
-static_assert(offsetof(vk_gltf_viewer::vulkan::shader_type::Node, skinJointIndexStartIndex) == 76);
+static_assert(sizeof(vk_gltf_viewer::vulkan::shader_type::Node) % 16 == 0);
+static_assert(offsetof(vk_gltf_viewer::vulkan::shader_type::Node, pInstancedWorldTransformBuffer) == 64);
+static_assert(offsetof(vk_gltf_viewer::vulkan::shader_type::Node, pMorphTargetWeightBuffer) == 72);

--- a/interface/vulkan/shader_type/Primitive.cppm
+++ b/interface/vulkan/shader_type/Primitive.cppm
@@ -24,7 +24,6 @@ namespace vk_gltf_viewer::vulkan::shader_type {
         std::uint8_t tangentByteStride;
         std::uint8_t colorByteStride;
         std::uint32_t materialIndex;
-        std::uint8_t _padding0_[8];
     };
 }
 
@@ -32,6 +31,6 @@ namespace vk_gltf_viewer::vulkan::shader_type {
 module :private;
 #endif
 
-static_assert(sizeof(vk_gltf_viewer::vulkan::shader_type::Primitive) == 96);
+static_assert(sizeof(vk_gltf_viewer::vulkan::shader_type::Primitive) % 8 == 0);
 static_assert(offsetof(vk_gltf_viewer::vulkan::shader_type::Primitive, positionByteStride) == 80);
 static_assert(offsetof(vk_gltf_viewer::vulkan::shader_type::Primitive, materialIndex) == 84);

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -3,6 +3,7 @@
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_buffer_reference_uvec2 : require
+#extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
@@ -19,15 +20,6 @@ layout (set = 0, binding = 0, std430) readonly buffer PrimitiveBuffer {
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
-};
-layout (set = 0, binding = 2) readonly buffer MorphTargetWeightBuffer {
-    float morphTargetWeights[];
-};
-layout (set = 0, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
-    uint skinJointIndices[];
-};
-layout (set = 0, binding = 4) readonly buffer InverseBindMatrixBuffer {
-    mat4 inverseBindMatrices[];
 };
 
 layout (push_constant) uniform PushConstant {

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -14,7 +14,7 @@ layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
 layout (constant_id = 1) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
 layout (constant_id = 2) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
-layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
+layout (set = 0, binding = 0, std430) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -26,10 +26,10 @@ layout (location = 1) in FRAG_VARIDIC_IN {
 
 layout (location = 0) out uvec2 outCoordinate;
 
-layout (set = 0, binding = 5, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 0, binding = 6) uniform sampler2D textures[];
+layout (set = 0, binding = 3) uniform sampler2D textures[];
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -3,6 +3,7 @@
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_buffer_reference_uvec2 : require
+#extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
@@ -36,16 +37,7 @@ layout (set = 0, binding = 0, std430) readonly buffer PrimitiveBuffer {
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 0, binding = 2) readonly buffer MorphTargetWeightBuffer {
-    float morphTargetWeights[];
-};
-layout (set = 0, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
-    uint skinJointIndices[];
-};
-layout (set = 0, binding = 4) readonly buffer InverseBindMatrixBuffer {
-    mat4 inverseBindMatrices[];
-};
-layout (set = 0, binding = 5, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -30,7 +30,7 @@ layout (location = 1) out VS_VARIADIC_OUT {
 } variadic_out;
 #endif
 
-layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
+layout (set = 0, binding = 0, std430) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {

--- a/shaders/mask_multi_node_mouse_picking.frag
+++ b/shaders/mask_multi_node_mouse_picking.frag
@@ -27,10 +27,10 @@ layout (location = 2) in FRAG_VARIADIC_IN {
 } variadic_in;
 #endif
 
-layout (set = 0, binding = 5, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 0, binding = 6) uniform sampler2D textures[];
+layout (set = 0, binding = 3) uniform sampler2D textures[];
 
 layout (set = 1, binding = 0) buffer MousePickingResultBuffer {
     uint packedBits[];

--- a/shaders/mask_node_index.frag
+++ b/shaders/mask_node_index.frag
@@ -27,10 +27,10 @@ layout (location = 2) in FRAG_VARIADIC_IN {
 
 layout (location = 0) out uint outNodeIndex;
 
-layout (set = 0, binding = 5, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 0, binding = 6) uniform sampler2D textures[];
+layout (set = 0, binding = 3) uniform sampler2D textures[];
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;

--- a/shaders/mask_node_index.vert
+++ b/shaders/mask_node_index.vert
@@ -3,6 +3,7 @@
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_buffer_reference_uvec2 : require
+#extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
@@ -37,16 +38,7 @@ layout (set = 0, binding = 0, std430) readonly buffer PrimitiveBuffer {
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 0, binding = 2) readonly buffer MorphTargetWeightBuffer {
-    float morphTargetWeights[];
-};
-layout (set = 0, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
-    uint skinJointIndices[];
-};
-layout (set = 0, binding = 4) readonly buffer InverseBindMatrixBuffer {
-    mat4 inverseBindMatrices[];
-};
-layout (set = 0, binding = 5, std430) readonly buffer MaterialBuffer {
+layout (set = 0, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/mask_node_index.vert
+++ b/shaders/mask_node_index.vert
@@ -31,7 +31,7 @@ layout (location = 2) out VS_VARIADIC_OUT {
 } variadic_out;
 #endif
 
-layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
+layout (set = 0, binding = 0, std430) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {

--- a/shaders/node_index.vert
+++ b/shaders/node_index.vert
@@ -16,7 +16,7 @@ layout (constant_id = 2) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) flat out uint outNodeIndex;
 
-layout (set = 0, binding = 0) readonly buffer PrimitiveBuffer {
+layout (set = 0, binding = 0, std430) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {

--- a/shaders/node_index.vert
+++ b/shaders/node_index.vert
@@ -3,6 +3,7 @@
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_buffer_reference_uvec2 : require
+#extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
@@ -21,15 +22,6 @@ layout (set = 0, binding = 0, std430) readonly buffer PrimitiveBuffer {
 };
 layout (set = 0, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
-};
-layout (set = 0, binding = 2) readonly buffer MorphTargetWeightBuffer {
-    float morphTargetWeights[];
-};
-layout (set = 0, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
-    uint skinJointIndices[];
-};
-layout (set = 0, binding = 4) readonly buffer InverseBindMatrixBuffer {
-    mat4 inverseBindMatrices[];
 };
 
 layout (push_constant) uniform PushConstant {

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -56,10 +56,10 @@ layout (set = 0, binding = 0, scalar) uniform SphericalHarmonicsBuffer {
 layout (set = 0, binding = 1) uniform samplerCube prefilteredmap;
 layout (set = 0, binding = 2) uniform sampler2D brdfmap;
 
-layout (set = 1, binding = 5, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 1, binding = 6) uniform sampler2D textures[];
+layout (set = 1, binding = 3) uniform sampler2D textures[];
 
 layout (push_constant, std430) uniform PushConstant {
     mat4 projectionView;

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -3,6 +3,7 @@
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_buffer_reference_uvec2 : require
+#extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
@@ -50,16 +51,7 @@ layout (set = 1, binding = 0, std430) readonly buffer PrimitiveBuffer {
 layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 1, binding = 2) readonly buffer MorphTargetWeightBuffer {
-    float morphTargetWeights[];
-};
-layout (set = 1, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
-    uint skinJointIndices[];
-};
-layout (set = 1, binding = 4) readonly buffer InverseBindMatrixBuffer {
-    mat4 inverseBindMatrices[];
-};
-layout (set = 1, binding = 5, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -44,7 +44,7 @@ layout (location = 2) out VS_VARIADIC_OUT {
 } variadic_out;
 #endif
 
-layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
+layout (set = 1, binding = 0, std430) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {

--- a/shaders/transform.glsl
+++ b/shaders/transform.glsl
@@ -12,12 +12,12 @@ mat4 getTransform(uint skinAttributeCount) {
     else {
         mat4 skinMatrix = mat4(0.0);
         for (uint i = 0; i < skinAttributeCount; ++i) {
-            uvec4 jointIndices = getJoints(i) + NODE.skinJointStartIndex;
+            uvec4 jointIndices = getJoints(i);
             vec4 weights = getWeights(i);
-            skinMatrix += weights.x * nodes[skinJointIndices[jointIndices.x]].worldTransform * inverseBindMatrices[jointIndices.x]
-                        + weights.y * nodes[skinJointIndices[jointIndices.y]].worldTransform * inverseBindMatrices[jointIndices.y]
-                        + weights.z * nodes[skinJointIndices[jointIndices.z]].worldTransform * inverseBindMatrices[jointIndices.z]
-                        + weights.w * nodes[skinJointIndices[jointIndices.w]].worldTransform * inverseBindMatrices[jointIndices.w];
+            skinMatrix += weights.x * nodes[NODE.skinJointIndices.data[jointIndices.x]].worldTransform * NODE.inverseBindMatrices.data[jointIndices.x]
+                        + weights.y * nodes[NODE.skinJointIndices.data[jointIndices.y]].worldTransform * NODE.inverseBindMatrices.data[jointIndices.y]
+                        + weights.z * nodes[NODE.skinJointIndices.data[jointIndices.z]].worldTransform * NODE.inverseBindMatrices.data[jointIndices.z]
+                        + weights.w * nodes[NODE.skinJointIndices.data[jointIndices.w]].worldTransform * NODE.inverseBindMatrices.data[jointIndices.w];
         }
         return skinMatrix;
     }

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -35,14 +35,17 @@ struct Material {
 
 #ifdef VERTEX_SHADER
 
-layout (buffer_reference) readonly buffer TransformMatrices { mat4 data[]; };
+layout (buffer_reference) readonly buffer Matrices { mat4 data[]; };
+layout (buffer_reference, buffer_reference_align = 4) readonly buffer MorphTargetWeights { float data[]; };
+layout (buffer_reference, buffer_reference_align = 4) readonly buffer SkinJointIndices { uint data[]; };
 
 struct Node {
     mat4 worldTransform;
-    TransformMatrices instancedWorldTransforms;
-    uint morphTargetWeightStartIndex;
-    uint skinJointStartIndex;
-}; // 80 bytes.
+    Matrices instancedWorldTransforms;
+    MorphTargetWeights morphTargetWeights;
+    SkinJointIndices skinJointIndices;
+    Matrices inverseBindMatrices;
+};
 
 struct Accessor {
     uvec2 bufferAddress;

--- a/shaders/types.glsl
+++ b/shaders/types.glsl
@@ -79,7 +79,6 @@ struct Primitive {
     uint8_t tangentByteStride;
     uint8_t colorByteStride;
     uint materialIndex;
-    vec2 _padding0_;
 };
 
 #endif

--- a/shaders/unlit_primitive.frag
+++ b/shaders/unlit_primitive.frag
@@ -30,10 +30,10 @@ layout (location = 0) out vec4 outColor;
 layout (location = 1) out float outRevealage;
 #endif
 
-layout (set = 1, binding = 5, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
-layout (set = 1, binding = 6) uniform sampler2D textures[];
+layout (set = 1, binding = 3) uniform sampler2D textures[];
 
 #if ALPHA_MODE == 0 || ALPHA_MODE == 2
 layout (early_fragment_tests) in;

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -3,6 +3,7 @@
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_buffer_reference_uvec2 : require
+#extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
 
@@ -38,16 +39,7 @@ layout (set = 1, binding = 0, std430) readonly buffer PrimitiveBuffer {
 layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {
     Node nodes[];
 };
-layout (set = 1, binding = 2) readonly buffer MorphTargetWeightBuffer {
-    float morphTargetWeights[];
-};
-layout (set = 1, binding = 3, std430) readonly buffer SkinJointIndexBuffer {
-    uint skinJointIndices[];
-};
-layout (set = 1, binding = 4) readonly buffer InverseBindMatrixBuffer {
-    mat4 inverseBindMatrices[];
-};
-layout (set = 1, binding = 5, std430) readonly buffer MaterialBuffer {
+layout (set = 1, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
 

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -32,7 +32,7 @@ layout (location = 1) out VS_VARIADIC_OUT {
 } variadic_out;
 #endif
 
-layout (set = 1, binding = 0) readonly buffer PrimitiveBuffer {
+layout (set = 1, binding = 0, std430) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
 };
 layout (set = 1, binding = 1, std430) readonly buffer NodeBuffer {

--- a/shaders/vertex_pulling.glsl
+++ b/shaders/vertex_pulling.glsl
@@ -62,7 +62,7 @@ vec3 getPosition(uint componentType, uint morphTargetWeightCount) {
         Accessor accessor = PRIMITIVE.positionMorphTargetAccessors.data[i];
         fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
 
-        float weight = morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
+        float weight = NODE.morphTargetWeights.data[i];
         switch (accessor.componentType) {
         case 0U: // BYTE
             position += weight * vec3(I8Vec3Ref(fetchAddress).data);
@@ -106,7 +106,7 @@ vec3 getNormal(uint componentType, uint morphTargetWeightCount) {
         Accessor accessor = PRIMITIVE.normalMorphTargetAccessors.data[i];
         fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
 
-        float weight = morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
+        float weight = NODE.morphTargetWeights.data[i];
         switch (accessor.componentType) {
         case 6U: // FLOAT
             normal += weight * Vec3Ref(fetchAddress).data;
@@ -145,7 +145,7 @@ vec4 getTangent(uint componentType, uint morphTargetWeightCount) {
         fetchAddress = getFetchAddress(accessor, gl_VertexIndex);
 
         // Tangent morph target only adds XYZ vertex tangent displacements.
-        float weight = morphTargetWeights[NODE.morphTargetWeightStartIndex + i];
+        float weight = NODE.morphTargetWeights.data[i];
         switch (accessor.componentType) {
         case 6U: // FLOAT
             tangent.xyz += weight * Vec3Ref(fetchAddress).data;


### PR DESCRIPTION
Instead of using storage buffer descriptor, directly passing them with addresses can reduce the descriptor set usage and simplify the shader code.