### PR TITLE
Simplify primitive rendering pipeline specialization constants declarations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ target_link_shader_variants(vk-gltf-viewer PRIVATE
         shaders/mask_multi_node_mouse_picking.frag
         shaders/mask_node_index.frag
         shaders/mask_node_index.vert
-    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ALPHA_ATTRIBUTE"
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_0_ALPHA_ATTRIBUTE"
     MACRO_VALUES
         "0 0" "0 1"
         "1 0" "1 1"
@@ -316,7 +316,7 @@ target_link_shader_variants(vk-gltf-viewer PRIVATE
 target_link_shader_variants(vk-gltf-viewer PRIVATE
     TARGET_ENV vulkan1.2
     FILES shaders/primitive.vert
-    MACRO_NAMES "TEXCOORD_COUNT" "HAS_COLOR_ATTRIBUTE" "FRAGMENT_SHADER_GENERATED_TBN"
+    MACRO_NAMES "TEXCOORD_COUNT" "HAS_COLOR_0_ATTRIBUTE" "FRAGMENT_SHADER_GENERATED_TBN"
     MACRO_VALUES
         "0 0 0" "0 0 1" "0 1 0" "0 1 1"
         "1 0 0" "1 0 1" "1 1 0" "1 1 1"
@@ -327,7 +327,7 @@ target_link_shader_variants(vk-gltf-viewer PRIVATE
 target_link_shader_variants(vk-gltf-viewer PRIVATE
     TARGET_ENV vulkan1.2
     FILES shaders/primitive.frag
-    MACRO_NAMES "TEXCOORD_COUNT" "HAS_COLOR_ATTRIBUTE" "FRAGMENT_SHADER_GENERATED_TBN" "ALPHA_MODE" "EXT_SHADER_STENCIL_EXPORT"
+    MACRO_NAMES "TEXCOORD_COUNT" "HAS_COLOR_0_ATTRIBUTE" "FRAGMENT_SHADER_GENERATED_TBN" "ALPHA_MODE" "EXT_SHADER_STENCIL_EXPORT"
     MACRO_VALUES
         "0 0 0 0 0" "0 0 0 1 0" "0 0 0 2 0" "0 0 1 0 0" "0 0 1 1 0" "0 0 1 2 0"
         "0 1 0 0 0" "0 1 0 1 0" "0 1 0 2 0" "0 1 1 0 0" "0 1 1 1 0" "0 1 1 2 0"
@@ -353,7 +353,7 @@ target_link_shader_variants(vk-gltf-viewer PRIVATE
 target_link_shader_variants(vk-gltf-viewer PRIVATE
     TARGET_ENV vulkan1.2
     FILES shaders/unlit_primitive.vert
-    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ATTRIBUTE"
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_0_ATTRIBUTE"
     MACRO_VALUES
         "0 0" "0 1"
         "1 0" "1 1"
@@ -361,7 +361,7 @@ target_link_shader_variants(vk-gltf-viewer PRIVATE
 target_link_shader_variants(vk-gltf-viewer PRIVATE
     TARGET_ENV vulkan1.2
     FILES shaders/unlit_primitive.frag
-    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_ATTRIBUTE" "ALPHA_MODE"
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_0_ATTRIBUTE" "ALPHA_MODE"
     MACRO_VALUES
         "0 0 0" "0 0 1" "0 0 2" "0 1 0" "0 1 1" "0 1 2"
         "1 0 0" "1 0 1" "1 0 2" "1 1 0" "1 1 1" "1 1 2"

--- a/impl/vulkan/Frame.cpp
+++ b/impl/vulkan/Frame.cpp
@@ -145,11 +145,6 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
     passthruOffset = task.passthruRect.offset;
     mousePickingInput = task.mousePickingInput;
 
-    static constexpr auto getGpuComponentType = [](const vkgltf::PrimitiveAttributeBuffers::AttributeInfoWithMorphTargets &info) noexcept -> std::uint8_t {
-        constexpr std::uint32_t byteComponentType = getGLComponentType(fastgltf::ComponentType::Byte);
-        return (info.attributeInfo.normalized ? 8U : 0U) | (getGLComponentType(info.attributeInfo.componentType) - byteComponentType);
-    };
-
     const auto criteriaGetter = [&](const fastgltf::Primitive &primitive) {
         const bool usePerFragmentEmissiveStencilExport = global::bloom.raw().mode == global::Bloom::Mode::PerFragment;
         CommandSeparationCriteria result {
@@ -165,75 +160,24 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             .cullMode = vk::CullModeFlagBits::eBack,
         };
 
-        const vkgltf::PrimitiveAttributeBuffers &accessors = sharedData.gltfAsset->primitiveAttributeBuffers.at(&primitive);
-
         // glTF 2.0 specification:
         //   Points or Lines with no NORMAL attribute SHOULD be rendered without lighting and instead use the sum of the
         //   base color value (as defined above, multiplied by COLOR_0 when present) and the emissive value.
         const bool isPrimitivePointsOrLineWithoutNormal
             = ranges::one_of(primitive.type, { fastgltf::PrimitiveType::Points, fastgltf::PrimitiveType::Lines, fastgltf::PrimitiveType::LineLoop, fastgltf::PrimitiveType::LineStrip })
-            && !accessors.normal;
+            && (primitive.findAttribute("NORMAL") == primitive.attributes.end());
 
         if (primitive.materialIndex) {
             const fastgltf::Material &material = task.gltf->asset.materials[*primitive.materialIndex];
             result.subpass = material.alphaMode == fastgltf::AlphaMode::Blend;
 
             if (material.unlit || isPrimitivePointsOrLineWithoutNormal) {
-                result.pipeline = sharedData.getUnlitPrimitiveRenderer({
-                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                    .positionComponentType = getGpuComponentType(accessors.position),
-                    .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
-                        return getGpuComponentType(accessors.texcoords.at(getTexcoordIndex(textureInfo)));
-                    }),
-                    .colorComponentCountAndType = [&]() -> std::optional<std::pair<std::uint8_t, std::uint8_t>> {
-                        if (accessors.colors.empty()) return std::nullopt;
-
-                        const fastgltf::Accessor &accessor = task.gltf->asset.accessors[primitive.findAttribute("COLOR_0")->accessorIndex];
-                        return std::pair { static_cast<std::uint8_t>(getNumComponents(accessor.type)), getGpuComponentType(accessors.colors[0]) };
-                    }(),
-                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-                    .baseColorTextureTransform = material.pbrData.baseColorTexture && material.pbrData.baseColorTexture->transform,
-                    .alphaMode = material.alphaMode,
-                });
-
+                result.pipeline = sharedData.getUnlitPrimitiveRenderer(primitive);
                 // Disable stencil reference dynamic state when using unlit rendering pipeline.
                 result.stencilReference.reset();
             }
             else {
-                result.pipeline = sharedData.getPrimitiveRenderer({
-                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                    .positionComponentType = getGpuComponentType(accessors.position),
-                    .normalComponentType = accessors.normal.transform(getGpuComponentType),
-                    .tangentComponentType = accessors.tangent.transform(getGpuComponentType),
-                    .texcoordComponentTypes = accessors.texcoords
-                        | std::views::transform(getGpuComponentType)
-                        | std::ranges::to<boost::container::static_vector<std::uint8_t, 4>>(),
-                    .colorComponentCountAndType = [&]() -> std::optional<std::pair<std::uint8_t, std::uint8_t>> {
-                        if (accessors.colors.empty()) return std::nullopt;
-
-                        const fastgltf::Accessor &accessor = task.gltf->asset.accessors[primitive.findAttribute("COLOR_0")->accessorIndex];
-                        return std::pair { static_cast<std::uint8_t>(getNumComponents(accessor.type)), getGpuComponentType(accessors.colors[0]) };
-                    }(),
-                    .fragmentShaderGeneratedTBN = !accessors.normal.has_value(),
-                    .morphTargetWeightCount = static_cast<std::uint32_t>(std::max({
-                        accessors.position.morphTargets.size(),
-                        accessors.normal.transform([](const auto &info) { return info.morphTargets.size(); }).value_or(std::size_t{}),
-                        accessors.tangent.transform([](const auto &info) { return info.morphTargets.size(); }).value_or(std::size_t{}),
-                    })),
-                    .hasPositionMorphTarget = !accessors.position.morphTargets.empty(),
-                    .hasNormalMorphTarget = accessors.normal && !accessors.normal->morphTargets.empty(),
-                    .hasTangentMorphTarget = accessors.tangent && !accessors.tangent->morphTargets.empty(),
-                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-                    .baseColorTextureTransform = material.pbrData.baseColorTexture && material.pbrData.baseColorTexture->transform,
-                    .metallicRoughnessTextureTransform = material.pbrData.metallicRoughnessTexture && material.pbrData.metallicRoughnessTexture->transform,
-                    .normalTextureTransform = material.normalTexture && material.normalTexture->transform,
-                    .occlusionTextureTransform = material.occlusionTexture && material.occlusionTexture->transform,
-                    .emissiveTextureTransform = material.emissiveTexture && material.emissiveTexture->transform,
-                    .alphaMode = material.alphaMode,
-                    .usePerFragmentEmissiveStencilExport = usePerFragmentEmissiveStencilExport,
-                });
-
+                result.pipeline = sharedData.getPrimitiveRenderer(primitive, usePerFragmentEmissiveStencilExport);
                 if (!usePerFragmentEmissiveStencilExport) {
                     result.stencilReference.emplace(material.emissiveStrength > 1.f ? 1U : 0U);
                 }
@@ -241,43 +185,12 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             result.cullMode = material.doubleSided ? vk::CullModeFlagBits::eNone : vk::CullModeFlagBits::eBack;
         }
         else if (isPrimitivePointsOrLineWithoutNormal) {
-            result.pipeline = sharedData.getUnlitPrimitiveRenderer({
-                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                .positionComponentType = getGpuComponentType(accessors.position),
-                .colorComponentCountAndType = [&]() -> std::optional<std::pair<std::uint8_t, std::uint8_t>> {
-                    if (accessors.colors.empty()) return std::nullopt;
-
-                    const fastgltf::Accessor &accessor = task.gltf->asset.accessors[primitive.findAttribute("COLOR_0")->accessorIndex];
-                    return std::pair { static_cast<std::uint8_t>(getNumComponents(accessor.type)), getGpuComponentType(accessors.colors[0]) };
-                }(),
-                .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-            });
-
+            result.pipeline = sharedData.getUnlitPrimitiveRenderer(primitive);
             // Disable stencil reference dynamic state when using unlit rendering pipeline.
             result.stencilReference.reset();
         }
         else {
-            result.pipeline = sharedData.getPrimitiveRenderer({
-                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                // TANGENT, TEXCOORD_<i> and their corresponding morph targets are unnecessary as there is no texture.
-                .positionComponentType = getGpuComponentType(accessors.position),
-                .normalComponentType = accessors.normal.transform(getGpuComponentType),
-                .colorComponentCountAndType = [&]() -> std::optional<std::pair<std::uint8_t, std::uint8_t>> {
-                    if (accessors.colors.empty()) return std::nullopt;
-
-                    const fastgltf::Accessor &accessor = task.gltf->asset.accessors[primitive.findAttribute("COLOR_0")->accessorIndex];
-                    return std::pair { static_cast<std::uint8_t>(getNumComponents(accessor.type)), getGpuComponentType(accessors.colors[0]) };
-                }(),
-                .fragmentShaderGeneratedTBN = !accessors.normal.has_value(),
-                .morphTargetWeightCount = std::max<std::uint32_t>(
-                    accessors.position.morphTargets.size(),
-                    accessors.normal.transform([](const auto &info) { return info.morphTargets.size(); }).value_or(std::size_t{})),
-                .hasPositionMorphTarget = !accessors.position.morphTargets.empty(),
-                .hasNormalMorphTarget = accessors.normal && !accessors.normal->morphTargets.empty(),
-                .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-                .usePerFragmentEmissiveStencilExport = usePerFragmentEmissiveStencilExport,
-            });
+            result.pipeline = sharedData.getPrimitiveRenderer(primitive, usePerFragmentEmissiveStencilExport);
         }
         return result;
     };
@@ -291,47 +204,18 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             .cullMode = vk::CullModeFlagBits::eBack,
         };
 
-        const vkgltf::PrimitiveAttributeBuffers &accessors = sharedData.gltfAsset->primitiveAttributeBuffers.at(&primitive);
         if (primitive.materialIndex) {
             const fastgltf::Material& material = task.gltf->asset.materials[*primitive.materialIndex];
             if (material.alphaMode == fastgltf::AlphaMode::Mask) {
-                result.pipeline = sharedData.getMaskNodeIndexRenderer({
-                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                    .positionComponentType = getGpuComponentType(accessors.position),
-                    .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
-                        return getGpuComponentType(accessors.texcoords.at(getTexcoordIndex(textureInfo)));
-                    }),
-                    .colorAlphaComponentType = [&]() -> std::optional<std::uint8_t> {
-                        if (accessors.colors.empty()) return std::nullopt;
-
-                        const fastgltf::Accessor &accessor = task.gltf->asset.accessors[primitive.findAttribute("COLOR_0")->accessorIndex];
-                        // Alpha value exists only if COLOR_0 is Vec4 type.
-                        if (accessor.type != fastgltf::AccessorType::Vec4) return std::nullopt;
-
-                        return getGpuComponentType(accessors.colors[0]);
-                    }(),
-                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-                    .baseColorTextureTransform = material.pbrData.baseColorTexture && material.pbrData.baseColorTexture->transform,
-                });
+                result.pipeline = sharedData.getMaskNodeIndexRenderer(primitive);
             }
             else {
-                result.pipeline = sharedData.getNodeIndexRenderer({
-                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                    .positionComponentType = getGpuComponentType(accessors.position),
-                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-                });
+                result.pipeline = sharedData.getNodeIndexRenderer(primitive);
             }
             result.cullMode = material.doubleSided ? vk::CullModeFlagBits::eNone : vk::CullModeFlagBits::eBack;
         }
         else {
-            result.pipeline = sharedData.getNodeIndexRenderer({
-                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                .positionComponentType = getGpuComponentType(accessors.position),
-                .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-            });
+            result.pipeline = sharedData.getNodeIndexRenderer(primitive);
         }
         return result;
     };
@@ -345,46 +229,17 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             .cullMode = vk::CullModeFlagBits::eNone,
         };
 
-        const vkgltf::PrimitiveAttributeBuffers &accessors = sharedData.gltfAsset->primitiveAttributeBuffers.at(&primitive);
         if (primitive.materialIndex) {
             const fastgltf::Material& material = task.gltf->asset.materials[*primitive.materialIndex];
             if (material.alphaMode == fastgltf::AlphaMode::Mask) {
-                result.pipeline = sharedData.getMaskMultiNodeMousePickingRenderer({
-                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                    .positionComponentType = getGpuComponentType(accessors.position),
-                    .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
-                        return getGpuComponentType(accessors.texcoords.at(getTexcoordIndex(textureInfo)));
-                    }),
-                    .colorAlphaComponentType = [&]() -> std::optional<std::uint8_t> {
-                        if (accessors.colors.empty()) return std::nullopt;
-
-                        const fastgltf::Accessor &accessor = task.gltf->asset.accessors[primitive.findAttribute("COLOR_0")->accessorIndex];
-                        // Alpha value exists only if COLOR_0 is Vec4 type.
-                        if (accessor.type != fastgltf::AccessorType::Vec4) return std::nullopt;
-
-                        return getGpuComponentType(accessors.colors[0]);
-                    }(),
-                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-                    .baseColorTextureTransform = material.pbrData.baseColorTexture && material.pbrData.baseColorTexture->transform,
-                });
+                result.pipeline = sharedData.getMaskMultiNodeMousePickingRenderer(primitive);
             }
             else {
-                result.pipeline = sharedData.getMultiNodeMousePickingRenderer({
-                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                    .positionComponentType = getGpuComponentType(accessors.position),
-                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-                });
+                result.pipeline = sharedData.getMultiNodeMousePickingRenderer(primitive);
             }
         }
         else {
-            result.pipeline = sharedData.getMultiNodeMousePickingRenderer({
-                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                .positionComponentType = getGpuComponentType(accessors.position),
-                .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-            });
+            result.pipeline = sharedData.getMultiNodeMousePickingRenderer(primitive);
         }
         return result;
     };
@@ -398,47 +253,18 @@ vk_gltf_viewer::vulkan::Frame::UpdateResult vk_gltf_viewer::vulkan::Frame::updat
             .cullMode = vk::CullModeFlagBits::eBack,
         };
 
-        const vkgltf::PrimitiveAttributeBuffers &accessors = sharedData.gltfAsset->primitiveAttributeBuffers.at(&primitive);
         if (primitive.materialIndex) {
             const fastgltf::Material &material = task.gltf->asset.materials[*primitive.materialIndex];
             if (material.alphaMode == fastgltf::AlphaMode::Mask) {
-                result.pipeline = sharedData.getMaskJumpFloodSeedRenderer({
-                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                    .positionComponentType = getGpuComponentType(accessors.position),
-                    .baseColorTexcoordComponentType = material.pbrData.baseColorTexture.transform([&](const fastgltf::TextureInfo &textureInfo) {
-                        return getGpuComponentType(accessors.texcoords.at(getTexcoordIndex(textureInfo)));
-                    }),
-                    .colorAlphaComponentType = [&]() -> std::optional<std::uint8_t> {
-                        if (accessors.colors.empty()) return std::nullopt;
-
-                        const fastgltf::Accessor &accessor = task.gltf->asset.accessors[primitive.findAttribute("COLOR_0")->accessorIndex];
-                        // Alpha value exists only if COLOR_0 is Vec4 type.
-                        if (accessor.type != fastgltf::AccessorType::Vec4) return std::nullopt;
-
-                        return getGpuComponentType(accessors.colors[0]);
-                    }(),
-                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-                    .baseColorTextureTransform = material.pbrData.baseColorTexture && material.pbrData.baseColorTexture->transform,
-                });
+                result.pipeline = sharedData.getMaskJumpFloodSeedRenderer(primitive);
             }
             else {
-                result.pipeline = sharedData.getJumpFloodSeedRenderer({
-                    .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                    .positionComponentType = getGpuComponentType(accessors.position),
-                    .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                    .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-                });
+                result.pipeline = sharedData.getJumpFloodSeedRenderer(primitive);
             }
             result.cullMode = material.doubleSided ? vk::CullModeFlagBits::eNone : vk::CullModeFlagBits::eBack;
         }
         else {
-            result.pipeline = sharedData.getJumpFloodSeedRenderer({
-                .topologyClass = value_if(!sharedData.gpu.supportDynamicPrimitiveTopologyUnrestricted, [&]() { return getTopologyClass(getPrimitiveTopology(primitive.type)); }),
-                .positionComponentType = getGpuComponentType(accessors.position),
-                .positionMorphTargetWeightCount = static_cast<std::uint32_t>(accessors.position.morphTargets.size()),
-                .skinAttributeCount = static_cast<std::uint32_t>(accessors.joints.size()),
-            });
+            result.pipeline = sharedData.getJumpFloodSeedRenderer(primitive);
         }
         return result;
     };

--- a/interface/helpers/vulkan.cppm
+++ b/interface/helpers/vulkan.cppm
@@ -3,41 +3,6 @@ export module vk_gltf_viewer.helpers.vulkan;
 import std;
 export import vulkan_hpp;
 
-import vk_gltf_viewer.helpers.ranges;
-
-export enum class TopologyClass : std::uint8_t {
-    Point,
-    Line,
-    Triangle,
-    Patch,
-};
-
-/**
- * Get topology class from \p primitiveTopology.
- *
- * You can find more information about the term "Topology Class" from Vulkan specification.
- * https://vkdoc.net/chapters/drawing#drawing-primitive-topology-class
- *
- * @param primitiveTopology Primitive topology.
- * @return Topology class.
- */
-export
-[[nodiscard]] TopologyClass getTopologyClass(vk::PrimitiveTopology primitiveTopology) noexcept;
-
-/**
- * @brief Get one of the <tt>vk::PrimitiveTopology</tt> type that is match to the given \p topologyClass.
- *
- * This function is useful when you're using dynamic state for primitive topology (VK_EXT_extended_dynamic_state), and
- * system GPU does not support <tt>VkPhysicalDeviceExtendedDynamicState3PropertiesEXT::dynamicPrimitiveTopologyUnrestricted</tt>.
- * You can pass the representative primitive topology to the PSO initialization and change the primitive topology dynamically.
- *
- * @param topologyClass Topology class.
- * @return One of the <tt>vk::PrimitiveTopology</tt> type that is match to the given \p topologyClass.
- * @note Currently its implementation returns XXXList type of primitive topology, but you should not rely on this behavior.
- */
-export
-[[nodiscard]] vk::PrimitiveTopology getRepresentativePrimitiveTopology(TopologyClass topologyClass) noexcept;
-
 /**
  * @brief Convert sRGB format to linear format, or vice versa.
  * @param format Format to convert. Must have the corresponding sRGB toggled format.
@@ -58,41 +23,6 @@ export
 #if !defined(__GNUC__) || defined(__clang__)
 module :private;
 #endif
-
-TopologyClass getTopologyClass(vk::PrimitiveTopology primitiveTopology) noexcept {
-    switch (primitiveTopology) {
-    case vk::PrimitiveTopology::ePointList:
-        return TopologyClass::Point;
-    case vk::PrimitiveTopology::eLineList:
-    case vk::PrimitiveTopology::eLineStrip:
-    case vk::PrimitiveTopology::eLineListWithAdjacency:
-    case vk::PrimitiveTopology::eLineStripWithAdjacency:
-        return TopologyClass::Line;
-    case vk::PrimitiveTopology::eTriangleList:
-    case vk::PrimitiveTopology::eTriangleStrip:
-    case vk::PrimitiveTopology::eTriangleFan:
-    case vk::PrimitiveTopology::eTriangleListWithAdjacency:
-    case vk::PrimitiveTopology::eTriangleStripWithAdjacency:
-        return TopologyClass::Triangle;
-    case vk::PrimitiveTopology::ePatchList:
-        return TopologyClass::Patch;
-    }
-    std::unreachable();
-}
-
-vk::PrimitiveTopology getRepresentativePrimitiveTopology(TopologyClass topologyClass) noexcept {
-    switch (topologyClass) {
-    case TopologyClass::Point:
-        return vk::PrimitiveTopology::ePointList;
-    case TopologyClass::Line:
-        return vk::PrimitiveTopology::eLineList;
-    case TopologyClass::Triangle:
-        return vk::PrimitiveTopology::eTriangleList;
-    case TopologyClass::Patch:
-        return vk::PrimitiveTopology::ePatchList;
-    }
-    std::unreachable();
-}
 
 vk::Format convertSrgb(vk::Format format) {
     switch (format) {
@@ -139,7 +69,7 @@ vk::Format convertSrgb(vk::Format format) {
 }
 
 bool isSrgbFormat(vk::Format format) noexcept {
-    return ranges::one_of(format, {
+    for (vk::Format candidate : {
         vk::Format::eR8Srgb, vk::Format::eR8G8Srgb, vk::Format::eR8G8B8Srgb, vk::Format::eB8G8R8Srgb,
         vk::Format::eR8G8B8A8Srgb, vk::Format::eB8G8R8A8Srgb, vk::Format::eA8B8G8R8SrgbPack32,
         vk::Format::eBc1RgbSrgbBlock, vk::Format::eBc1RgbaSrgbBlock, vk::Format::eBc2SrgbBlock,
@@ -151,5 +81,11 @@ bool isSrgbFormat(vk::Format format) noexcept {
         vk::Format::eAstc10x8SrgbBlock, vk::Format::eAstc10x10SrgbBlock, vk::Format::eAstc12x10SrgbBlock,
         vk::Format::eAstc12x12SrgbBlock, vk::Format::ePvrtc12BppSrgbBlockIMG, vk::Format::ePvrtc14BppSrgbBlockIMG,
         vk::Format::ePvrtc22BppSrgbBlockIMG, vk::Format::ePvrtc24BppSrgbBlockIMG,
-    });
+    }) {
+        if (format == candidate) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/interface/shader_selector/mask_jump_flood_seed_frag.cppm
+++ b/interface/shader_selector/mask_jump_flood_seed_frag.cppm
@@ -7,12 +7,12 @@ import vk_gltf_viewer.helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ALPHA_ATTRIBUTE) {
+    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_0_ALPHA_ATTRIBUTE) {
         return std::visit(
             [](auto... Is) -> std::span<const unsigned int> {
                 return shader::mask_jump_flood_seed_frag<Is...>;
             },
             iota_map<2>::get_variant(HAS_BASE_COLOR_TEXTURE),
-            iota_map<2>::get_variant(HAS_COLOR_ALPHA_ATTRIBUTE));
+            iota_map<2>::get_variant(HAS_COLOR_0_ALPHA_ATTRIBUTE));
     }
 }

--- a/interface/shader_selector/mask_jump_flood_seed_vert.cppm
+++ b/interface/shader_selector/mask_jump_flood_seed_vert.cppm
@@ -7,12 +7,12 @@ import vk_gltf_viewer.helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_vert(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ALPHA_ATTRIBUTE) {
+    [[nodiscard]] std::span<const unsigned int> mask_jump_flood_seed_vert(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_0_ALPHA_ATTRIBUTE) {
         return std::visit(
             [](auto... Is) -> std::span<const unsigned int> {
                 return shader::mask_jump_flood_seed_vert<Is...>;
             },
             iota_map<2>::get_variant(HAS_BASE_COLOR_TEXTURE),
-            iota_map<2>::get_variant(HAS_COLOR_ALPHA_ATTRIBUTE));
+            iota_map<2>::get_variant(HAS_COLOR_0_ALPHA_ATTRIBUTE));
     }
 }

--- a/interface/shader_selector/mask_multi_node_mouse_picking_frag.cppm
+++ b/interface/shader_selector/mask_multi_node_mouse_picking_frag.cppm
@@ -7,12 +7,12 @@ import vk_gltf_viewer.helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> mask_multi_node_mouse_picking_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ALPHA_ATTRIBUTE) {
+    [[nodiscard]] std::span<const unsigned int> mask_multi_node_mouse_picking_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_0_ALPHA_ATTRIBUTE) {
         return std::visit(
             [](auto... Is) -> std::span<const unsigned int> {
                 return shader::mask_multi_node_mouse_picking_frag<Is...>;
             },
             iota_map<2>::get_variant(HAS_BASE_COLOR_TEXTURE),
-            iota_map<2>::get_variant(HAS_COLOR_ALPHA_ATTRIBUTE));
+            iota_map<2>::get_variant(HAS_COLOR_0_ALPHA_ATTRIBUTE));
     }
 }

--- a/interface/shader_selector/mask_node_index_frag.cppm
+++ b/interface/shader_selector/mask_node_index_frag.cppm
@@ -7,12 +7,12 @@ import vk_gltf_viewer.helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> mask_node_index_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ALPHA_ATTRIBUTE) {
+    [[nodiscard]] std::span<const unsigned int> mask_node_index_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_0_ALPHA_ATTRIBUTE) {
         return std::visit(
             [](auto... Is) -> std::span<const unsigned int> {
                 return shader::mask_node_index_frag<Is...>;
             },
             iota_map<2>::get_variant(HAS_BASE_COLOR_TEXTURE),
-            iota_map<2>::get_variant(HAS_COLOR_ALPHA_ATTRIBUTE));
+            iota_map<2>::get_variant(HAS_COLOR_0_ALPHA_ATTRIBUTE));
     }
 }

--- a/interface/shader_selector/mask_node_index_vert.cppm
+++ b/interface/shader_selector/mask_node_index_vert.cppm
@@ -7,12 +7,12 @@ import vk_gltf_viewer.helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> mask_node_index_vert(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ALPHA_ATTRIBUTE) {
+    [[nodiscard]] std::span<const unsigned int> mask_node_index_vert(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_0_ALPHA_ATTRIBUTE) {
         return std::visit(
             [](auto... Is) -> std::span<const unsigned int> {
                 return shader::mask_node_index_vert<Is...>;
             },
             iota_map<2>::get_variant(HAS_BASE_COLOR_TEXTURE),
-            iota_map<2>::get_variant(HAS_COLOR_ALPHA_ATTRIBUTE));
+            iota_map<2>::get_variant(HAS_COLOR_0_ALPHA_ATTRIBUTE));
     }
 }

--- a/interface/shader_selector/primitive_frag.cppm
+++ b/interface/shader_selector/primitive_frag.cppm
@@ -7,13 +7,13 @@ import vk_gltf_viewer.helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> primitive_frag(int TEXCOORD_COUNT, int HAS_COLOR_ATTRIBUTE, int FRAGMENT_SHADER_GENERATED_TBN, int ALPHA_MODE, int EXT_SHADER_STENCIL_EXPORT) {
+    [[nodiscard]] std::span<const unsigned int> primitive_frag(int TEXCOORD_COUNT, int HAS_COLOR_0_ATTRIBUTE, int FRAGMENT_SHADER_GENERATED_TBN, int ALPHA_MODE, int EXT_SHADER_STENCIL_EXPORT) {
         return std::visit(
             [](auto ...Is) -> std::span<const unsigned int> {
                 return shader::primitive_frag<Is...>;
             },
             iota_map<5>::get_variant(TEXCOORD_COUNT),
-            iota_map<2>::get_variant(HAS_COLOR_ATTRIBUTE),
+            iota_map<2>::get_variant(HAS_COLOR_0_ATTRIBUTE),
             iota_map<2>::get_variant(FRAGMENT_SHADER_GENERATED_TBN),
             iota_map<3>::get_variant(ALPHA_MODE),
             iota_map<2>::get_variant(EXT_SHADER_STENCIL_EXPORT));

--- a/interface/shader_selector/primitive_vert.cppm
+++ b/interface/shader_selector/primitive_vert.cppm
@@ -7,13 +7,13 @@ import vk_gltf_viewer.helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> primitive_vert(int TEXCOORD_COUNT, int HAS_COLOR_ATTRIBUTE, int FRAGMENT_SHADER_GENERATED_TBN) {
+    [[nodiscard]] std::span<const unsigned int> primitive_vert(int TEXCOORD_COUNT, int HAS_COLOR_0_ATTRIBUTE, int FRAGMENT_SHADER_GENERATED_TBN) {
         return std::visit(
             [](auto ...Is) -> std::span<const unsigned int> {
                 return shader::primitive_vert<Is...>;
             },
             iota_map<5>::get_variant(TEXCOORD_COUNT),
-            iota_map<2>::get_variant(HAS_COLOR_ATTRIBUTE),
+            iota_map<2>::get_variant(HAS_COLOR_0_ATTRIBUTE),
             iota_map<2>::get_variant(FRAGMENT_SHADER_GENERATED_TBN));
     }
 }

--- a/interface/shader_selector/unlit_primitive_frag.cppm
+++ b/interface/shader_selector/unlit_primitive_frag.cppm
@@ -7,13 +7,13 @@ import vk_gltf_viewer.helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> unlit_primitive_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ATTRIBUTE, int ALPHA_MODE) {
+    [[nodiscard]] std::span<const unsigned int> unlit_primitive_frag(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_0_ATTRIBUTE, int ALPHA_MODE) {
         return std::visit(
             [](auto... Is) -> std::span<const unsigned int> {
                 return shader::unlit_primitive_frag<Is...>;
             },
             iota_map<2>::get_variant(HAS_BASE_COLOR_TEXTURE),
-            iota_map<2>::get_variant(HAS_COLOR_ATTRIBUTE),
+            iota_map<2>::get_variant(HAS_COLOR_0_ATTRIBUTE),
             iota_map<3>::get_variant(ALPHA_MODE));
     }
 }

--- a/interface/shader_selector/unlit_primitive_vert.cppm
+++ b/interface/shader_selector/unlit_primitive_vert.cppm
@@ -7,12 +7,12 @@ import vk_gltf_viewer.helpers.type_map;
 
 namespace vk_gltf_viewer::shader_selector {
     export
-    [[nodiscard]] std::span<const unsigned int> unlit_primitive_vert(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_ATTRIBUTE) {
+    [[nodiscard]] std::span<const unsigned int> unlit_primitive_vert(int HAS_BASE_COLOR_TEXTURE, int HAS_COLOR_0_ATTRIBUTE) {
         return std::visit(
             [](auto... Is) -> std::span<const unsigned int> {
                 return shader::unlit_primitive_vert<Is...>;
             },
             iota_map<2>::get_variant(HAS_BASE_COLOR_TEXTURE),
-            iota_map<2>::get_variant(HAS_COLOR_ATTRIBUTE));
+            iota_map<2>::get_variant(HAS_COLOR_0_ATTRIBUTE));
     }
 }

--- a/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
+++ b/interface/vulkan/pipeline/JumpFloodSeedRenderer.cppm
@@ -1,13 +1,13 @@
 export module vk_gltf_viewer:vulkan.pipeline.JumpFloodSeedRenderer;
 
 import std;
+export import fastgltf;
 import vku;
 import :shader.jump_flood_seed_vert;
 import :shader.jump_flood_seed_frag;
 import :shader_selector.mask_jump_flood_seed_vert;
 import :shader_selector.mask_jump_flood_seed_frag;
 
-export import vk_gltf_viewer.helpers.vulkan;
 export import vk_gltf_viewer.vulkan.pl.PrimitiveNoShading;
 import vk_gltf_viewer.vulkan.specialization_constants.SpecializationMap;
 
@@ -17,10 +17,11 @@ import vk_gltf_viewer.vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class JumpFloodSeedRendererSpecialization {
     public:
-        std::optional<TopologyClass> topologyClass;
-        std::uint8_t positionComponentType = 0;
-        std::uint32_t positionMorphTargetWeightCount = 0;
-        std::uint32_t skinAttributeCount = 0;
+        std::optional<vk::PrimitiveTopology> topologyClass; // Only list topology will be used in here.
+        fastgltf::ComponentType positionComponentType;
+        bool positionNormalized;
+        std::uint32_t positionMorphTargetCount;
+        std::uint32_t skinAttributeCount;
 
         [[nodiscard]] bool operator==(const JumpFloodSeedRendererSpecialization&) const = default;
 
@@ -44,7 +45,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     *pipelineLayout, 1, true)
                     .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                         {},
-                        topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
+                        topologyClass.value_or(vk::PrimitiveTopology::eTriangleList),
                     }))
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},
@@ -70,24 +71,31 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     private:
         struct VertexShaderSpecializationData {
             std::uint32_t positionComponentType;
-            std::uint32_t positionMorphTargetWeightCount;
+            vk::Bool32 positionNormalized;
+            std::uint32_t positionMorphTargetCount;
             std::uint32_t skinAttributeCount;
         };
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            return { positionComponentType, positionMorphTargetWeightCount, skinAttributeCount };
+            return {
+                .positionComponentType = getGLComponentType(positionComponentType),
+                .positionNormalized = positionNormalized,
+                .positionMorphTargetCount = positionMorphTargetCount,
+                .skinAttributeCount = skinAttributeCount,
+            };
         }
     };
 
     export class MaskJumpFloodSeedRendererSpecialization {
     public:
-        std::optional<TopologyClass> topologyClass;
-        std::uint8_t positionComponentType;
-        std::optional<std::uint8_t> baseColorTexcoordComponentType;
-        std::optional<std::uint8_t> colorAlphaComponentType;
-        std::uint32_t positionMorphTargetWeightCount = 0;
-        std::uint32_t skinAttributeCount = 0;
-        bool baseColorTextureTransform = false;
+        std::optional<vk::PrimitiveTopology> topologyClass; // Only list topology will be used in here.
+        fastgltf::ComponentType positionComponentType;
+        bool positionNormalized;
+        std::optional<std::pair<fastgltf::ComponentType, bool>> baseColorTexcoordComponentTypeAndNormalized;
+        std::optional<fastgltf::ComponentType> color0AlphaComponentType;
+        std::uint32_t positionMorphTargetCount;
+        std::uint32_t skinAttributeCount;
+        bool baseColorTextureTransform;
 
         [[nodiscard]] bool operator==(const MaskJumpFloodSeedRendererSpecialization&) const = default;
 
@@ -118,7 +126,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     *pipelineLayout, 1, true)
                     .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                         {},
-                        topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
+                        topologyClass.value_or(vk::PrimitiveTopology::eTriangleList),
                     }))
                     .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                         {},
@@ -144,9 +152,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     private:
         struct VertexShaderSpecializationData {
             std::uint32_t positionComponentType;
-            std::uint32_t texcoordComponentType = 5126; // FLOAT
-            std::uint32_t colorComponentType = 5126; // FLOAT
-            std::uint32_t positionMorphTargetWeightCount;
+            vk::Bool32 positionNormalized;
+            std::uint32_t baseColorTexcoordComponentType;
+            vk::Bool32 baseColorTexcoordNormalized;
+            std::uint32_t color0ComponentType;
+            std::uint32_t positionMorphTargetCount;
             std::uint32_t skinAttributeCount;
         };
 
@@ -156,23 +166,23 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] std::array<int, 2> getVertexShaderVariants() const noexcept {
             return {
-                baseColorTexcoordComponentType.has_value(),
-                colorAlphaComponentType.has_value(),
+                baseColorTexcoordComponentTypeAndNormalized.has_value(),
+                color0AlphaComponentType.has_value(),
             };
         }
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
-                .positionComponentType = positionComponentType,
-                .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
+                .positionComponentType = getGLComponentType(positionComponentType),
+                .positionNormalized = positionNormalized,
+                .color0ComponentType = color0AlphaComponentType.transform(fastgltf::getGLComponentType).value_or(0U),
+                .positionMorphTargetCount = positionMorphTargetCount,
                 .skinAttributeCount = skinAttributeCount,
             };
 
-            if (baseColorTexcoordComponentType) {
-                result.texcoordComponentType = *baseColorTexcoordComponentType;
-            }
-            if (colorAlphaComponentType) {
-                result.colorComponentType = *colorAlphaComponentType;
+            if (baseColorTexcoordComponentTypeAndNormalized) {
+                result.baseColorTexcoordComponentType = getGLComponentType(baseColorTexcoordComponentTypeAndNormalized->first);
+                result.baseColorTexcoordNormalized = baseColorTexcoordComponentTypeAndNormalized->second;
             }
 
             return result;
@@ -180,8 +190,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] std::array<int, 2> getFragmentShaderVariants() const noexcept {
             return {
-                baseColorTexcoordComponentType.has_value(),
-                colorAlphaComponentType.has_value(),
+                baseColorTexcoordComponentTypeAndNormalized.has_value(),
+                color0AlphaComponentType.has_value(),
             };
         }
 

--- a/interface/vulkan/pipeline/MultiNodeMousePickingRenderer.cppm
+++ b/interface/vulkan/pipeline/MultiNodeMousePickingRenderer.cppm
@@ -1,13 +1,13 @@
 export module vk_gltf_viewer:vulkan.pipeline.MultiNodeMousePickingRenderer;
 
 import std;
+export import fastgltf;
 import vku;
 import :shader.node_index_vert;
 import :shader_selector.mask_node_index_vert;
 import :shader.multi_node_mouse_picking_frag;
 import :shader_selector.mask_multi_node_mouse_picking_frag;
 
-export import vk_gltf_viewer.helpers.vulkan;
 export import vk_gltf_viewer.vulkan.Gpu;
 export import vk_gltf_viewer.vulkan.pl.MultiNodeMousePicking;
 import vk_gltf_viewer.vulkan.specialization_constants.SpecializationMap;
@@ -18,10 +18,11 @@ import vk_gltf_viewer.vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class MultiNodeMousePickingRendererSpecialization {
     public:
-        std::optional<TopologyClass> topologyClass;
-        std::uint8_t positionComponentType = 0;
-        std::uint32_t positionMorphTargetWeightCount = 0;
-        std::uint32_t skinAttributeCount = 0;
+        std::optional<vk::PrimitiveTopology> topologyClass; // Only list topology will be used in here.
+        fastgltf::ComponentType positionComponentType;
+        bool positionNormalized;
+        std::uint32_t positionMorphTargetCount;
+        std::uint32_t skinAttributeCount;
 
         [[nodiscard]] bool operator==(const MultiNodeMousePickingRendererSpecialization&) const = default;
 
@@ -46,7 +47,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     *pipelineLayout, 0, gpu.workaround.attachmentLessRenderPass)
                     .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                         {},
-                        topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
+                        topologyClass.value_or(vk::PrimitiveTopology::eTriangleList),
                     }))
                     .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                         {},
@@ -75,24 +76,31 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     private:
         struct VertexShaderSpecializationData {
             std::uint32_t positionComponentType;
-            std::uint32_t positionMorphTargetWeightCount;
+            vk::Bool32 positionNormalized;
+            std::uint32_t positionMorphTargetCount;
             std::uint32_t skinAttributeCount;
         };
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            return { positionComponentType, positionMorphTargetWeightCount, skinAttributeCount };
+            return {
+                .positionComponentType = getGLComponentType(positionComponentType),
+                .positionNormalized = positionNormalized,
+                .positionMorphTargetCount = positionMorphTargetCount,
+                .skinAttributeCount = skinAttributeCount,
+            };
         }
     };
 
     export class MaskMultiNodeMousePickingRendererSpecialization {
     public:
-        std::optional<TopologyClass> topologyClass;
-        std::uint8_t positionComponentType;
-        std::optional<std::uint8_t> baseColorTexcoordComponentType;
-        std::optional<std::uint8_t> colorAlphaComponentType;
-        std::uint32_t positionMorphTargetWeightCount = 0;
-        std::uint32_t skinAttributeCount = 0;
-        bool baseColorTextureTransform = false;
+        std::optional<vk::PrimitiveTopology> topologyClass; // Only list topology will be used in here.
+        fastgltf::ComponentType positionComponentType;
+        bool positionNormalized;
+        std::optional<std::pair<fastgltf::ComponentType, bool>> baseColorTexcoordComponentTypeAndNormalized;
+        std::optional<fastgltf::ComponentType> color0AlphaComponentType;
+        std::uint32_t positionMorphTargetCount;
+        std::uint32_t skinAttributeCount;
+        bool baseColorTextureTransform;
 
         [[nodiscard]] bool operator==(const MaskMultiNodeMousePickingRendererSpecialization&) const = default;
 
@@ -124,7 +132,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                     *pipelineLayout, 0, gpu.workaround.attachmentLessRenderPass)
                     .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                         {},
-                        topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
+                        topologyClass.value_or(vk::PrimitiveTopology::eTriangleList),
                     }))
                     .setPRasterizationState(vku::unsafeAddress(vk::PipelineRasterizationStateCreateInfo {
                         {},
@@ -153,9 +161,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     private:
         struct VertexShaderSpecializationData {
             std::uint32_t positionComponentType;
-            std::uint32_t texcoordComponentType = 5126; // FLOAT
-            std::uint32_t colorComponentType = 5126; // FLOAT
-            std::uint32_t positionMorphTargetWeightCount;
+            vk::Bool32 positionNormalized;
+            std::uint32_t baseColorTexcoordComponentType;
+            vk::Bool32 baseColorTexcoordNormalized;
+            std::uint32_t color0ComponentType;
+            std::uint32_t positionMorphTargetCount;
             std::uint32_t skinAttributeCount;
         };
 
@@ -165,23 +175,23 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] std::array<int, 2> getVertexShaderVariants() const noexcept {
             return {
-                baseColorTexcoordComponentType.has_value(),
-                colorAlphaComponentType.has_value(),
+                baseColorTexcoordComponentTypeAndNormalized.has_value(),
+                color0AlphaComponentType.has_value(),
             };
         }
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
-                .positionComponentType = positionComponentType,
-                .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
+                .positionComponentType = getGLComponentType(positionComponentType),
+                .positionNormalized = positionNormalized,
+                .color0ComponentType = color0AlphaComponentType.transform(fastgltf::getGLComponentType).value_or(0U),
+                .positionMorphTargetCount = positionMorphTargetCount,
                 .skinAttributeCount = skinAttributeCount,
             };
 
-            if (baseColorTexcoordComponentType) {
-                result.texcoordComponentType = *baseColorTexcoordComponentType;
-            }
-            if (colorAlphaComponentType) {
-                result.colorComponentType = *colorAlphaComponentType;
+            if (baseColorTexcoordComponentTypeAndNormalized) {
+                result.baseColorTexcoordComponentType = getGLComponentType(baseColorTexcoordComponentTypeAndNormalized->first);
+                result.baseColorTexcoordNormalized = baseColorTexcoordComponentTypeAndNormalized->second;
             }
 
             return result;
@@ -189,8 +199,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] std::array<int, 2> getFragmentShaderVariants() const noexcept {
             return {
-                baseColorTexcoordComponentType.has_value(),
-                colorAlphaComponentType.has_value(),
+                baseColorTexcoordComponentTypeAndNormalized.has_value(),
+                color0AlphaComponentType.has_value(),
             };
         }
 

--- a/interface/vulkan/pipeline/NodeIndexRenderer.cppm
+++ b/interface/vulkan/pipeline/NodeIndexRenderer.cppm
@@ -1,13 +1,13 @@
 export module vk_gltf_viewer:vulkan.pipeline.NodeIndexRenderer;
 
 import std;
+export import fastgltf;
 import vku;
 import :shader.node_index_frag;
 import :shader.node_index_vert;
 import :shader_selector.mask_node_index_frag;
 import :shader_selector.mask_node_index_vert;
 
-export import vk_gltf_viewer.helpers.vulkan;
 export import vk_gltf_viewer.vulkan.pl.PrimitiveNoShading;
 export import vk_gltf_viewer.vulkan.rp.MousePicking;
 import vk_gltf_viewer.vulkan.specialization_constants.SpecializationMap;
@@ -18,10 +18,11 @@ import vk_gltf_viewer.vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class NodeIndexRendererSpecialization {
     public:
-        std::optional<TopologyClass> topologyClass;
-        std::uint8_t positionComponentType = 0;
-        std::uint32_t positionMorphTargetWeightCount = 0;
-        std::uint32_t skinAttributeCount = 0;
+        std::optional<vk::PrimitiveTopology> topologyClass; // Only list topology will be used in here.
+        fastgltf::ComponentType positionComponentType;
+        bool positionNormalized;
+        std::uint32_t positionMorphTargetCount;
+        std::uint32_t skinAttributeCount;
 
         [[nodiscard]] bool operator==(const NodeIndexRendererSpecialization&) const = default;
 
@@ -45,7 +46,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 *pipelineLayout, 1, true)
                 .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                     {},
-                    topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
+                    topologyClass.value_or(vk::PrimitiveTopology::eTriangleList),
                 }))
                 .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                     {},
@@ -68,24 +69,31 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     private:
         struct VertexShaderSpecializationData {
             std::uint32_t positionComponentType;
-            std::uint32_t positionMorphTargetWeightCount;
+            vk::Bool32 positionNormalized;
+            std::uint32_t positionMorphTargetCount;
             std::uint32_t skinAttributeCount;
         };
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
-            return { positionComponentType, positionMorphTargetWeightCount, skinAttributeCount };
+            return {
+                .positionComponentType = getGLComponentType(positionComponentType),
+                .positionNormalized = positionNormalized,
+                .positionMorphTargetCount = positionMorphTargetCount,
+                .skinAttributeCount = skinAttributeCount,
+            };
         }
     };
 
     export class MaskNodeIndexRendererSpecialization {
     public:
-        std::optional<TopologyClass> topologyClass;
-        std::uint8_t positionComponentType;
-        std::optional<std::uint8_t> baseColorTexcoordComponentType;
-        std::optional<std::uint8_t> colorAlphaComponentType;
-        std::uint32_t positionMorphTargetWeightCount = 0;
-        std::uint32_t skinAttributeCount = 0;
-        bool baseColorTextureTransform = false;
+        std::optional<vk::PrimitiveTopology> topologyClass; // Only list topology will be used in here.
+        fastgltf::ComponentType positionComponentType;
+        bool positionNormalized;
+        std::optional<std::pair<fastgltf::ComponentType, bool>> baseColorTexcoordComponentTypeAndNormalized;
+        std::optional<fastgltf::ComponentType> color0AlphaComponentType;
+        std::uint32_t positionMorphTargetCount;
+        std::uint32_t skinAttributeCount;
+        bool baseColorTextureTransform;
 
         [[nodiscard]] bool operator==(const MaskNodeIndexRendererSpecialization&) const = default;
 
@@ -116,7 +124,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
                 *pipelineLayout, 1, true)
                 .setPInputAssemblyState(vku::unsafeAddress(vk::PipelineInputAssemblyStateCreateInfo {
                     {},
-                    topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
+                    topologyClass.value_or(vk::PrimitiveTopology::eTriangleList),
                 }))
                 .setPDepthStencilState(vku::unsafeAddress(vk::PipelineDepthStencilStateCreateInfo {
                     {},
@@ -139,9 +147,11 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     private:
         struct VertexShaderSpecializationData {
             std::uint32_t positionComponentType;
-            std::uint32_t texcoordComponentType = 5126; // FLOAT
-            std::uint32_t colorComponentType = 5126; // FLOAT
-            std::uint32_t positionMorphTargetWeightCount;
+            vk::Bool32 positionNormalized;
+            std::uint32_t baseColorTexcoordComponentType;
+            vk::Bool32 baseColorTexcoordNormalized;
+            std::uint32_t color0ComponentType;
+            std::uint32_t positionMorphTargetCount;
             std::uint32_t skinAttributeCount;
         };
 
@@ -151,23 +161,23 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] std::array<int, 2> getVertexShaderVariants() const noexcept {
             return {
-                baseColorTexcoordComponentType.has_value(),
-                colorAlphaComponentType.has_value(),
+                baseColorTexcoordComponentTypeAndNormalized.has_value(),
+                color0AlphaComponentType.has_value(),
             };
         }
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
-                .positionComponentType = positionComponentType,
-                .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
+                .positionComponentType = getGLComponentType(positionComponentType),
+                .positionNormalized = positionNormalized,
+                .color0ComponentType = color0AlphaComponentType.transform(fastgltf::getGLComponentType).value_or(0U),
+                .positionMorphTargetCount = positionMorphTargetCount,
                 .skinAttributeCount = skinAttributeCount,
             };
 
-            if (baseColorTexcoordComponentType) {
-                result.texcoordComponentType = *baseColorTexcoordComponentType;
-            }
-            if (colorAlphaComponentType) {
-                result.colorComponentType = *colorAlphaComponentType;
+            if (baseColorTexcoordComponentTypeAndNormalized) {
+                result.baseColorTexcoordComponentType = getGLComponentType(baseColorTexcoordComponentTypeAndNormalized->first);
+                result.baseColorTexcoordNormalized = baseColorTexcoordComponentTypeAndNormalized->second;
             }
 
             return result;
@@ -175,8 +185,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] std::array<int, 2> getFragmentShaderVariants() const noexcept {
             return {
-                baseColorTexcoordComponentType.has_value(),
-                colorAlphaComponentType.has_value(),
+                baseColorTexcoordComponentTypeAndNormalized.has_value(),
+                color0AlphaComponentType.has_value(),
             };
         }
 

--- a/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
+++ b/interface/vulkan/pipeline/UnlitPrimitiveRenderer.cppm
@@ -11,7 +11,6 @@ import :shader_selector.unlit_primitive_frag;
 import :shader_selector.unlit_primitive_vert;
 
 import vk_gltf_viewer.helpers.ranges;
-export import vk_gltf_viewer.helpers.vulkan;
 export import vk_gltf_viewer.vulkan.pl.Primitive;
 export import vk_gltf_viewer.vulkan.rp.Scene;
 import vk_gltf_viewer.vulkan.specialization_constants.SpecializationMap;
@@ -22,13 +21,14 @@ import vk_gltf_viewer.vulkan.specialization_constants.SpecializationMap;
 namespace vk_gltf_viewer::vulkan::inline pipeline {
     export class UnlitPrimitiveRendererSpecialization {
     public:
-        std::optional<TopologyClass> topologyClass;
-        std::uint8_t positionComponentType;
-        std::optional<std::uint8_t> baseColorTexcoordComponentType;
-        std::optional<std::pair<std::uint8_t, std::uint8_t>> colorComponentCountAndType;
-        std::uint32_t positionMorphTargetWeightCount = 0;
-        std::uint32_t skinAttributeCount = 0;
-        bool baseColorTextureTransform = false;
+        std::optional<vk::PrimitiveTopology> topologyClass; // Only list topology will be used in here.
+        fastgltf::ComponentType positionComponentType;
+        bool positionNormalized;
+        std::optional<std::pair<fastgltf::ComponentType, bool>> baseColorTexcoordComponentTypeAndNormalized;
+        std::optional<std::pair<fastgltf::ComponentType, std::uint8_t>> color0ComponentTypeAndCount;
+        std::uint32_t positionMorphTargetCount;
+        std::uint32_t skinAttributeCount;
+        bool baseColorTextureTransform;
         fastgltf::AlphaMode alphaMode;
 
         [[nodiscard]] bool operator==(const UnlitPrimitiveRendererSpecialization&) const noexcept = default;
@@ -65,7 +65,7 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
             const vk::PipelineInputAssemblyStateCreateInfo inputAssemblyStateCreateInfo {
                 {},
-                topologyClass.transform(getRepresentativePrimitiveTopology).value_or(vk::PrimitiveTopology::eTriangleList),
+                topologyClass.value_or(vk::PrimitiveTopology::eTriangleList),
             };
 
             switch (alphaMode) {
@@ -170,10 +170,12 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
     private:
         struct VertexShaderSpecializationData {
             std::uint32_t positionComponentType;
-            std::uint32_t texcoordComponentType = 5126; // FLOAT
-            std::uint32_t colorComponentCount = 0;
-            std::uint32_t colorComponentType = 5126; // FLOAT
-            std::uint32_t positionMorphTargetWeightCount;
+            vk::Bool32 positionNormalized;
+            std::uint32_t baseColorTexcoordComponentType;
+            vk::Bool32 baseColorTexcoordNormalized;
+            std::uint32_t color0ComponentType;
+            std::uint32_t color0ComponentCount;
+            std::uint32_t positionMorphTargetCount;
             std::uint32_t skinAttributeCount;
         };
 
@@ -183,26 +185,27 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] std::array<int, 2> getVertexShaderVariants() const noexcept {
             return {
-                baseColorTexcoordComponentType.has_value(),
-                colorComponentCountAndType.has_value(),
+                baseColorTexcoordComponentTypeAndNormalized.has_value(),
+                color0ComponentTypeAndCount.has_value(),
             };
         }
 
         [[nodiscard]] VertexShaderSpecializationData getVertexShaderSpecializationData() const {
             VertexShaderSpecializationData result {
-                .positionComponentType = positionComponentType,
-                .positionMorphTargetWeightCount = positionMorphTargetWeightCount,
+                .positionComponentType = getGLComponentType(positionComponentType),
+                .positionNormalized = positionNormalized,
+                .positionMorphTargetCount = positionMorphTargetCount,
                 .skinAttributeCount = skinAttributeCount,
             };
 
-            if (baseColorTexcoordComponentType) {
-                result.texcoordComponentType = *baseColorTexcoordComponentType;
+            if (baseColorTexcoordComponentTypeAndNormalized) {
+                result.baseColorTexcoordComponentType = getGLComponentType(baseColorTexcoordComponentTypeAndNormalized->first);
+                result.baseColorTexcoordNormalized = baseColorTexcoordComponentTypeAndNormalized->second;
             }
 
-            if (colorComponentCountAndType) {
-                assert(ranges::one_of(colorComponentCountAndType->first, { 3, 4 }));
-                result.colorComponentCount = colorComponentCountAndType->first;
-                result.colorComponentType = colorComponentCountAndType->second;
+            if (color0ComponentTypeAndCount) {
+                result.color0ComponentType = getGLComponentType(color0ComponentTypeAndCount->first);
+                result.color0ComponentCount = color0ComponentTypeAndCount->second;
             }
 
             return result;
@@ -210,8 +213,8 @@ namespace vk_gltf_viewer::vulkan::inline pipeline {
 
         [[nodiscard]] std::array<int, 3> getFragmentShaderVariants() const noexcept {
             return {
-                baseColorTexcoordComponentType.has_value(),
-                colorComponentCountAndType.has_value(),
+                baseColorTexcoordComponentTypeAndNormalized.has_value(),
+                color0ComponentTypeAndCount.has_value(),
                 static_cast<int>(alphaMode),
             };
         }

--- a/shaders/jump_flood_seed.vert
+++ b/shaders/jump_flood_seed.vert
@@ -12,8 +12,9 @@
 #include "types.glsl"
 
 layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
-layout (constant_id = 1) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
-layout (constant_id = 2) const uint SKIN_ATTRIBUTE_COUNT = 0;
+layout (constant_id = 1) const bool POSITION_NORMALIZED = false;
+layout (constant_id = 2) const uint POSITION_MORPH_TARGET_COUNT = 0;
+layout (constant_id = 3) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (set = 0, binding = 0, std430) readonly buffer PrimitiveBuffer {
     Primitive primitives[];
@@ -30,7 +31,7 @@ layout (push_constant) uniform PushConstant {
 #include "transform.glsl"
 
 void main(){
-    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_NORMALIZED, POSITION_MORPH_TARGET_COUNT);
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
     gl_PointSize = 1.0;
 }

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -8,7 +8,7 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
+#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_0_ALPHA_ATTRIBUTE
 
 layout (constant_id = 0) const bool BASE_COLOR_TEXTURE_TRANSFORM = false;
 
@@ -18,8 +18,8 @@ layout (location = 1) in FRAG_VARIDIC_IN {
 #if HAS_BASE_COLOR_TEXTURE
     vec2 baseColorTexcoord;
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    float colorAlpha;
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    float color0Alpha;
 #endif
 } variadic_in;
 #endif
@@ -40,8 +40,8 @@ void main(){
     }
     baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord).a;
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    baseColorAlpha *= variadic_in.colorAlpha;
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    baseColorAlpha *= variadic_in.color0Alpha;
 #endif
     if (baseColorAlpha < MATERIAL.alphaCutoff) discard;
 

--- a/shaders/mask_jump_flood_seed.vert
+++ b/shaders/mask_jump_flood_seed.vert
@@ -11,13 +11,15 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-#define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
+#define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_0_ALPHA_ATTRIBUTE
 
 layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
-layout (constant_id = 1) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 3) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
-layout (constant_id = 4) const uint SKIN_ATTRIBUTE_COUNT = 0;
+layout (constant_id = 1) const bool POSITION_NORMALIZED = false;
+layout (constant_id = 2) const uint BASE_COLOR_TEXCOORD_COMPONENT_TYPE = 0;
+layout (constant_id = 3) const bool BASE_COLOR_TEXCOORD_NORMALIZED = false;
+layout (constant_id = 4) const uint COLOR_0_COMPONENT_TYPE = 0;
+layout (constant_id = 5) const uint POSITION_MORPH_TARGET_COUNT = 0;
+layout (constant_id = 6) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -25,8 +27,8 @@ layout (location = 1) out VS_VARIADIC_OUT {
 #if HAS_BASE_COLOR_TEXTURE
     vec2 baseColorTexcoord;
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    float colorAlpha;
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    float color0Alpha;
 #endif
 } variadic_out;
 #endif
@@ -51,13 +53,13 @@ layout (push_constant, std430) uniform PushConstant {
 void main(){
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE
-    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex), TEXCOORD_COMPONENT_TYPE);
+    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex), BASE_COLOR_TEXCOORD_COMPONENT_TYPE, BASE_COLOR_TEXCOORD_NORMALIZED);
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    variadic_out.colorAlpha = getColorAlpha(COLOR_COMPONENT_TYPE);
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    variadic_out.color0Alpha = getColor0Alpha(COLOR_0_COMPONENT_TYPE);
 #endif
 
-    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_NORMALIZED, POSITION_MORPH_TARGET_COUNT);
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
     gl_PointSize = 1.0;
 }

--- a/shaders/mask_multi_node_mouse_picking.frag
+++ b/shaders/mask_multi_node_mouse_picking.frag
@@ -10,7 +10,7 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
+#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_0_ALPHA_ATTRIBUTE
 
 layout (constant_id = 0) const bool BASE_COLOR_TEXTURE_TRANSFORM = false;
 
@@ -21,8 +21,8 @@ layout (location = 2) in FRAG_VARIADIC_IN {
 #if HAS_BASE_COLOR_TEXTURE
     vec2 baseColorTexcoord;
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    float colorAlpha;
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    float color0Alpha;
 #endif
 } variadic_in;
 #endif
@@ -45,8 +45,8 @@ void main(){
     }
     baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord).a;
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    baseColorAlpha *= variadic_in.colorAlpha;
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    baseColorAlpha *= variadic_in.color0Alpha;
 #endif
     if (baseColorAlpha < MATERIAL.alphaCutoff) discard;
 

--- a/shaders/mask_node_index.frag
+++ b/shaders/mask_node_index.frag
@@ -8,7 +8,7 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
+#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_0_ALPHA_ATTRIBUTE
 
 layout (constant_id = 0) const bool BASE_COLOR_TEXTURE_TRANSFORM = false;
 
@@ -19,8 +19,8 @@ layout (location = 2) in FRAG_VARIADIC_IN {
 #if HAS_BASE_COLOR_TEXTURE
     vec2 baseColorTexcoord;
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    float colorAlpha;
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    float color0Alpha;
 #endif
 } variadic_in;
 #endif
@@ -41,8 +41,8 @@ void main(){
     }
     baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord).a;
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    baseColorAlpha *= variadic_in.colorAlpha;
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    baseColorAlpha *= variadic_in.color0Alpha;
 #endif
     if (baseColorAlpha < MATERIAL.alphaCutoff) discard;
 

--- a/shaders/mask_node_index.vert
+++ b/shaders/mask_node_index.vert
@@ -11,13 +11,15 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-#define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ALPHA_ATTRIBUTE
+#define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_0_ALPHA_ATTRIBUTE
 
 layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
-layout (constant_id = 1) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 2) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 3) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
-layout (constant_id = 4) const uint SKIN_ATTRIBUTE_COUNT = 0;
+layout (constant_id = 1) const bool POSITION_NORMALIZED = false;
+layout (constant_id = 2) const uint BASE_COLOR_TEXCOORD_COMPONENT_TYPE = 0;
+layout (constant_id = 3) const bool BASE_COLOR_TEXCOORD_NORMALIZED = false;
+layout (constant_id = 4) const uint COLOR_0_COMPONENT_TYPE = 0;
+layout (constant_id = 5) const uint POSITION_MORPH_TARGET_COUNT = 0;
+layout (constant_id = 6) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) flat out uint outNodeIndex;
 layout (location = 1) flat out uint outMaterialIndex;
@@ -26,8 +28,8 @@ layout (location = 2) out VS_VARIADIC_OUT {
 #if HAS_BASE_COLOR_TEXTURE
     vec2 baseColorTexcoord;
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    float colorAlpha;
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    float color0Alpha;
 #endif
 } variadic_out;
 #endif
@@ -53,13 +55,13 @@ void main(){
     outNodeIndex = NODE_INDEX;
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE
-    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex), TEXCOORD_COMPONENT_TYPE);
+    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex), BASE_COLOR_TEXCOORD_COMPONENT_TYPE, BASE_COLOR_TEXCOORD_NORMALIZED);
 #endif
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-    variadic_out.colorAlpha = getColorAlpha(COLOR_COMPONENT_TYPE);
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+    variadic_out.color0Alpha = getColor0Alpha(COLOR_0_COMPONENT_TYPE);
 #endif
 
-    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_NORMALIZED, POSITION_MORPH_TARGET_COUNT);
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
     gl_PointSize = 1.0;
 }

--- a/shaders/node_index.vert
+++ b/shaders/node_index.vert
@@ -12,8 +12,9 @@
 #include "types.glsl"
 
 layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
-layout (constant_id = 1) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
-layout (constant_id = 2) const uint SKIN_ATTRIBUTE_COUNT = 0;
+layout (constant_id = 1) const bool POSITION_NORMALIZED = false;
+layout (constant_id = 2) const uint POSITION_MORPH_TARGET_COUNT = 0;
+layout (constant_id = 3) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) flat out uint outNodeIndex;
 
@@ -34,7 +35,7 @@ layout (push_constant) uniform PushConstant {
 void main(){
     outNodeIndex = NODE_INDEX;
 
-    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_NORMALIZED, POSITION_MORPH_TARGET_COUNT);
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);
     gl_PointSize = 1.0;
 }

--- a/shaders/primitive.frag
+++ b/shaders/primitive.frag
@@ -15,7 +15,7 @@
 #include "spherical_harmonics.glsl"
 #include "types.glsl"
 
-#define HAS_VARIADIC_IN !FRAGMENT_SHADER_GENERATED_TBN || TEXCOORD_COUNT >= 1 || HAS_COLOR_ATTRIBUTE
+#define HAS_VARIADIC_IN !FRAGMENT_SHADER_GENERATED_TBN || TEXCOORD_COUNT >= 1 || HAS_COLOR_0_ATTRIBUTE
 
 layout (constant_id = 0) const uint PACKED_TEXTURE_TRANSFORMS = 0; // [FALSE, FALSE, FALSE, FALSE, FALSE]
 
@@ -39,8 +39,8 @@ layout (location = 2) in FS_VARIADIC_IN {
 #error "Maximum texcoord count exceeded."
 #endif
 
-#if HAS_COLOR_ATTRIBUTE
-    vec4 color;
+#if HAS_COLOR_0_ATTRIBUTE
+    vec4 color0;
 #endif
 } variadic_in;
 #endif
@@ -137,8 +137,8 @@ void main(){
     }
     baseColor *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord);
 #endif
-#if HAS_COLOR_ATTRIBUTE
-    baseColor *= variadic_in.color;
+#if HAS_COLOR_0_ATTRIBUTE
+    baseColor *= variadic_in.color0;
 #endif
 
     float metallic = MATERIAL.metallicFactor;

--- a/shaders/primitive.vert
+++ b/shaders/primitive.vert
@@ -11,13 +11,26 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-#define HAS_VARIADIC_OUT !FRAGMENT_SHADER_GENERATED_TBN || TEXCOORD_COUNT >= 1 || HAS_COLOR_ATTRIBUTE
+#define HAS_VARIADIC_OUT !FRAGMENT_SHADER_GENERATED_TBN || TEXCOORD_COUNT >= 1 || HAS_COLOR_0_ATTRIBUTE
 
-layout (constant_id = 0) const uint PACKED_ATTRIBUTE_COMPONENT_TYPES = 0;
-layout (constant_id = 1) const uint COLOR_COMPONENT_COUNT = 0;
-layout (constant_id = 2) const uint MORPH_TARGET_WEIGHT_COUNT = 0;
-layout (constant_id = 3) const uint PACKED_MORPH_TARGET_AVAILABILITY = 0;
-layout (constant_id = 4) const uint SKIN_ATTRIBUTE_COUNT = 0;
+layout (constant_id =  0) const uint POSITION_COMPONENT_TYPE = 0;
+layout (constant_id =  1) const bool POSITION_NORMALIZED = false;
+layout (constant_id =  2) const uint NORMAL_COMPONENT_TYPE = 0;
+layout (constant_id =  3) const uint TANGENT_COMPONENT_TYPE = 0;
+layout (constant_id =  4) const uint TEXCOORD_0_COMPONENT_TYPE = 0;
+layout (constant_id =  5) const uint TEXCOORD_1_COMPONENT_TYPE = 0;
+layout (constant_id =  6) const uint TEXCOORD_2_COMPONENT_TYPE = 0;
+layout (constant_id =  7) const uint TEXCOORD_3_COMPONENT_TYPE = 0;
+layout (constant_id =  8) const bool TEXCOORD_0_NORMALIZED = false;
+layout (constant_id =  9) const bool TEXCOORD_1_NORMALIZED = false;
+layout (constant_id = 10) const bool TEXCOORD_2_NORMALIZED = false;
+layout (constant_id = 11) const bool TEXCOORD_3_NORMALIZED = false;
+layout (constant_id = 12) const uint COLOR_0_COMPONENT_TYPE = 0;
+layout (constant_id = 13) const uint COLOR_0_COMPONENT_COUNT = 0;
+layout (constant_id = 14) const uint POSITION_MORPH_TARGET_COUNT = 0;
+layout (constant_id = 15) const uint NORMAL_MORPH_TARGET_COUNT = 0;
+layout (constant_id = 16) const uint TANGENT_MORPH_TARGET_COUNT = 0;
+layout (constant_id = 17) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) out vec3 outPosition;
 layout (location = 1) flat out uint outMaterialIndex;
@@ -39,8 +52,8 @@ layout (location = 2) out VS_VARIADIC_OUT {
 #error "Maximum texcoord count exceeded."
 #endif
 
-#if HAS_COLOR_ATTRIBUTE
-    vec4 color;
+#if HAS_COLOR_0_ATTRIBUTE
+    vec4 color0;
 #endif
 } variadic_out;
 #endif
@@ -66,32 +79,37 @@ layout (push_constant, std430) uniform PushConstant {
 void main(){
     mat4 transform = getTransform(SKIN_ATTRIBUTE_COUNT);
 
-    vec3 inPosition = getPosition(PACKED_ATTRIBUTE_COMPONENT_TYPES & 0xFU, (PACKED_MORPH_TARGET_AVAILABILITY & 0x1U) == 0x1U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_NORMALIZED, POSITION_MORPH_TARGET_COUNT);
     outPosition = (transform * vec4(inPosition, 1.0)).xyz;
 
     outMaterialIndex = MATERIAL_INDEX;
 
 #if !FRAGMENT_SHADER_GENERATED_TBN
-    vec3 inNormal = getNormal((PACKED_ATTRIBUTE_COMPONENT_TYPES >> 4U) & 0xFU, (PACKED_MORPH_TARGET_AVAILABILITY & 0x2U) == 0x2U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
+    vec3 inNormal = getNormal(NORMAL_COMPONENT_TYPE, NORMAL_MORPH_TARGET_COUNT);
     variadic_out.tbn[2] = normalize(mat3(transform) * inNormal); // N
 
     if (MATERIAL.normalTextureIndex != 0US){
-        vec4 inTangent = getTangent((PACKED_ATTRIBUTE_COMPONENT_TYPES >> 8U) & 0xFU, (PACKED_MORPH_TARGET_AVAILABILITY & 0x4U) == 0x4U ? MORPH_TARGET_WEIGHT_COUNT : 0U);
+        vec4 inTangent = getTangent(TANGENT_COMPONENT_TYPE, TANGENT_MORPH_TARGET_COUNT);
         variadic_out.tbn[0] = normalize(mat3(transform) * inTangent.xyz); // T
         variadic_out.tbn[1] = cross(variadic_out.tbn[2], variadic_out.tbn[0]) * -inTangent.w; // B
     }
 #endif
 
 #if TEXCOORD_COUNT == 1
-    variadic_out.texcoord = getTexcoord(0, (PACKED_ATTRIBUTE_COMPONENT_TYPES >> 12U) & 0xFU);
+    variadic_out.texcoord = getTexcoord(0, TEXCOORD_0_COMPONENT_TYPE, TEXCOORD_0_NORMALIZED);
 #elif TEXCOORD_COUNT >= 2
-    for (uint i = 0; i < TEXCOORD_COUNT; i++){
-        variadic_out.texcoords[i] = getTexcoord(i, (PACKED_ATTRIBUTE_COMPONENT_TYPES >> (12U + 4U * i)) & 0xFU);
-    }
+    variadic_out.texcoords[0] = getTexcoord(0, TEXCOORD_0_COMPONENT_TYPE, TEXCOORD_0_NORMALIZED);
+    variadic_out.texcoords[1] = getTexcoord(1, TEXCOORD_1_COMPONENT_TYPE, TEXCOORD_1_NORMALIZED);
+#if TEXCOORD_COUNT >= 3
+    variadic_out.texcoords[2] = getTexcoord(2, TEXCOORD_2_COMPONENT_TYPE, TEXCOORD_2_NORMALIZED);
+#endif
+#if TEXCOORD_COUNT == 4
+    variadic_out.texcoords[3] = getTexcoord(3, TEXCOORD_3_COMPONENT_TYPE, TEXCOORD_3_NORMALIZED);
+#endif
 #endif
 
-#if HAS_COLOR_ATTRIBUTE
-    variadic_out.color = getColor(PACKED_ATTRIBUTE_COMPONENT_TYPES >> 28U);
+#if HAS_COLOR_0_ATTRIBUTE
+    variadic_out.color0 = getColor0(COLOR_0_COMPONENT_TYPE, COLOR_0_COMPONENT_COUNT);
 #endif
 
     gl_Position = pc.projectionView * vec4(outPosition, 1.0);

--- a/shaders/unlit_primitive.frag
+++ b/shaders/unlit_primitive.frag
@@ -8,7 +8,7 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ATTRIBUTE
+#define HAS_VARIADIC_IN HAS_BASE_COLOR_TEXTURE || HAS_COLOR_0_ATTRIBUTE
 
 layout (constant_id = 0) const bool BASE_COLOR_TEXTURE_TRANSFORM = false;
 
@@ -19,8 +19,8 @@ layout (location = 1) in FS_VARIADIC_IN {
     vec2 baseColorTexcoord;
 #endif
 
-#if HAS_COLOR_ATTRIBUTE
-    vec4 color;
+#if HAS_COLOR_0_ATTRIBUTE
+    vec4 color0;
 #endif
 } variadic_in;
 #endif
@@ -75,8 +75,8 @@ void main(){
     }
     baseColor *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord);
 #endif
-#if HAS_COLOR_ATTRIBUTE
-    baseColor *= variadic_in.color;
+#if HAS_COLOR_0_ATTRIBUTE
+    baseColor *= variadic_in.color0;
 #endif
 
     writeOutput(baseColor);

--- a/shaders/unlit_primitive.vert
+++ b/shaders/unlit_primitive.vert
@@ -11,14 +11,16 @@
 #include "indexing.glsl"
 #include "types.glsl"
 
-#define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_ATTRIBUTE
+#define HAS_VARIADIC_OUT HAS_BASE_COLOR_TEXTURE || HAS_COLOR_0_ATTRIBUTE
 
 layout (constant_id = 0) const uint POSITION_COMPONENT_TYPE = 0;
-layout (constant_id = 1) const uint TEXCOORD_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 2) const uint COLOR_COMPONENT_COUNT = 0;
-layout (constant_id = 3) const uint COLOR_COMPONENT_TYPE = 6; // FLOAT
-layout (constant_id = 4) const uint POSITION_MORPH_TARGET_WEIGHT_COUNT = 0;
-layout (constant_id = 5) const uint SKIN_ATTRIBUTE_COUNT = 0;
+layout (constant_id = 1) const bool POSITION_NORMALIZED = false;
+layout (constant_id = 2) const uint BASE_COLOR_TEXCOORD_COMPONENT_TYPE = 0;
+layout (constant_id = 3) const bool BASE_COLOR_TEXCOORD_NORMALIZED = false;
+layout (constant_id = 4) const uint COLOR_0_COMPONENT_TYPE = 0;
+layout (constant_id = 5) const uint COLOR_0_COMPONENT_COUNT = 0;
+layout (constant_id = 6) const uint POSITION_MORPH_TARGET_COUNT = 0;
+layout (constant_id = 7) const uint SKIN_ATTRIBUTE_COUNT = 0;
 
 layout (location = 0) flat out uint outMaterialIndex;
 #if HAS_VARIADIC_OUT
@@ -27,8 +29,8 @@ layout (location = 1) out VS_VARIADIC_OUT {
     vec2 baseColorTexcoord;
 #endif
 
-#if HAS_COLOR_ATTRIBUTE
-    vec4 color;
+#if HAS_COLOR_0_ATTRIBUTE
+    vec4 color0;
 #endif
 } variadic_out;
 #endif
@@ -52,15 +54,15 @@ layout (push_constant, std430) uniform PushConstant {
 #include "transform.glsl"
 
 void main(){
-    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_MORPH_TARGET_WEIGHT_COUNT);
+    vec3 inPosition = getPosition(POSITION_COMPONENT_TYPE, POSITION_NORMALIZED, POSITION_MORPH_TARGET_COUNT);
 
     outMaterialIndex = MATERIAL_INDEX;
 #if HAS_BASE_COLOR_TEXTURE
-    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex), TEXCOORD_COMPONENT_TYPE);
+    variadic_out.baseColorTexcoord = getTexcoord(uint(MATERIAL.baseColorTexcoordIndex), BASE_COLOR_TEXCOORD_COMPONENT_TYPE, BASE_COLOR_TEXCOORD_NORMALIZED);
 #endif
 
-#if HAS_COLOR_ATTRIBUTE
-    variadic_out.color = getColor(COLOR_COMPONENT_TYPE);
+#if HAS_COLOR_0_ATTRIBUTE
+    variadic_out.color0 = getColor0(COLOR_0_COMPONENT_TYPE, COLOR_0_COMPONENT_COUNT);
 #endif
 
     gl_Position = pc.projectionView * getTransform(SKIN_ATTRIBUTE_COUNT) * vec4(inPosition, 1.0);

--- a/shaders/vertex_pulling.glsl
+++ b/shaders/vertex_pulling.glsl
@@ -21,41 +21,48 @@ layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer Ve
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer UIntRef { uint data; };
 layout (std430, buffer_reference, buffer_reference_align = 4) readonly buffer UVec2Ref { uvec2 data; };
 
-vec3 getPosition(uint componentType, uint morphTargetWeightCount) {
-    uvec2 fetchAddress = add64(PRIMITIVE.positionAccessor.bufferAddress, PRIMITIVE.positionAccessor.stride * uint(gl_VertexIndex));
+vec3 getPosition(uint componentType, bool normalized, uint morphTargetWeightCount) {
     vec3 position;
+
+    uvec2 fetchAddress = add64(PRIMITIVE.positionAccessor.bufferAddress, PRIMITIVE.positionAccessor.stride * uint(gl_VertexIndex));
     switch (componentType) {
-    case 0U: // BYTE
-        position = vec3(I8Vec3Ref(fetchAddress).data);
+    case 5120U: // BYTE
+        if (normalized) {
+            position = unpackSnorm4x8(UIntRef(fetchAddress).data).xyz;
+        }
+        else {
+            position = vec3(I8Vec3Ref(fetchAddress).data);
+        }
         break;
-    case 1U: // UNSIGNED BYTE
-        position = vec3(U8Vec3Ref(fetchAddress).data);
+    case 5121U: // UNSIGNED BYTE
+        if (normalized) {
+            position = unpackUnorm4x8(UIntRef(fetchAddress).data).xyz;
+        }
+        else {
+            position = vec3(U8Vec3Ref(fetchAddress).data);
+        }
         break;
-    case 2U: // SHORT
-        position = vec3(I16Vec3Ref(fetchAddress).data);
+    case 5122U: // SHORT
+        if (normalized) {
+            uvec2 fetched = UVec2Ref(fetchAddress).data;
+            position = vec3(unpackSnorm2x16(fetched.x), unpackSnorm2x16(fetched.y).x);
+        }
+        else {
+            position = vec3(I16Vec3Ref(fetchAddress).data);
+        }
         break;
-    case 3U: // UNSIGNED SHORT
-        position = vec3(U16Vec3Ref(fetchAddress).data);
+    case 5123U: // UNSIGNED SHORT
+        if (normalized) {
+            uvec2 fetched = UVec2Ref(fetchAddress).data;
+            position = vec3(unpackUnorm2x16(fetched.x), unpackUnorm2x16(fetched.y).x);
+        }
+        else {
+            position = vec3(U16Vec3Ref(fetchAddress).data);
+        }
         break;
-    case 6U: // FLOAT
+    case 5126U: // FLOAT
         position = Vec3Ref(fetchAddress).data;
         break;
-    case 8U: // BYTE normalized
-        position = unpackSnorm4x8(UIntRef(fetchAddress).data).xyz;
-        break;
-    case 9U: // UNSIGNED BYTE normalized
-        position = unpackUnorm4x8(UIntRef(fetchAddress).data).xyz;
-        break;
-    case 10U: { // SHORT normalized
-        uvec2 fetched = UVec2Ref(fetchAddress).data;
-        position = vec3(unpackSnorm2x16(fetched.x), unpackSnorm2x16(fetched.y).x);
-        break;
-    }
-    case 11U: { // UNSIGNED SHORT normalized
-        uvec2 fetched = UVec2Ref(fetchAddress).data;
-        position = vec3(unpackUnorm2x16(fetched.x), unpackUnorm2x16(fetched.y).x);
-        break;
-    }
     }
 
     for (uint i = 0; i < morphTargetWeightCount; i++) {
@@ -70,7 +77,7 @@ vec3 getPosition(uint componentType, uint morphTargetWeightCount) {
         case 2U: // SHORT
             position += weight * vec3(I16Vec3Ref(fetchAddress).data);
             break;
-        case 6U:
+        case 6U: // FLOAT
             position += weight * Vec3Ref(fetchAddress).data;
             break;
         case 8U: // BYTE normalized
@@ -87,16 +94,17 @@ vec3 getPosition(uint componentType, uint morphTargetWeightCount) {
 }
 
 vec3 getNormal(uint componentType, uint morphTargetWeightCount) {
-    uvec2 fetchAddress = add64(PRIMITIVE.normalAccessor.bufferAddress, PRIMITIVE.normalAccessor.stride * uint(gl_VertexIndex));
     vec3 normal;
+
+    uvec2 fetchAddress = add64(PRIMITIVE.normalAccessor.bufferAddress, PRIMITIVE.normalAccessor.stride * uint(gl_VertexIndex));
     switch (componentType) {
-    case 6U: // FLOAT
+    case 5126U: // FLOAT
         normal = Vec3Ref(fetchAddress).data;
         break;
-    case 8U: // BYTE normalized
+    case 5120U: // BYTE normalized
         normal = unpackSnorm4x8(UIntRef(fetchAddress).data).xyz;
         break;
-    case 10U: // SHORT normalized
+    case 5122U: // SHORT normalized
         uvec2 fetched = UVec2Ref(fetchAddress).data;
         normal = vec3(unpackSnorm2x16(fetched.x), unpackSnorm2x16(fetched.y).x);
         break;
@@ -125,16 +133,17 @@ vec3 getNormal(uint componentType, uint morphTargetWeightCount) {
 }
 
 vec4 getTangent(uint componentType, uint morphTargetWeightCount) {
-    uvec2 fetchAddress = add64(PRIMITIVE.tangentAccessor.bufferAddress, PRIMITIVE.tangentAccessor.stride * uint(gl_VertexIndex));
     vec4 tangent;
+
+    uvec2 fetchAddress = add64(PRIMITIVE.tangentAccessor.bufferAddress, PRIMITIVE.tangentAccessor.stride * uint(gl_VertexIndex));
     switch (componentType) {
-    case 6U: // FLOAT
+    case 5126U: // FLOAT
         tangent = Vec4Ref(fetchAddress).data;
         break;
-    case 8U: // BYTE normalized
+    case 5120U: // BYTE normalized
         tangent = unpackSnorm4x8(UIntRef(fetchAddress).data);
         break;
-    case 10U: // SHORT normalized
+    case 5122U: // SHORT normalized
         uvec2 fetched = UVec2Ref(fetchAddress).data;
         tangent = vec4(unpackSnorm2x16(fetched.x), unpackSnorm2x16(fetched.y));
         break;
@@ -164,54 +173,66 @@ vec4 getTangent(uint componentType, uint morphTargetWeightCount) {
 }
 
 #if TEXCOORD_COUNT >= 1 || HAS_BASE_COLOR_TEXTURE
-vec2 getTexcoord(uint texcoordIndex, uint componentType){
+vec2 getTexcoord(uint texcoordIndex, uint componentType, bool normalized){
     uvec2 fetchAddress = getFetchAddress(PRIMITIVE.texcoordAccessors[texcoordIndex], gl_VertexIndex);
 
     switch (componentType) {
-    case 0U: // BYTE
-        return vec2(I8Vec2Ref(fetchAddress).data);
-    case 1U: // UNSIGNED BYTE
-        return vec2(U8Vec2Ref(fetchAddress).data);
-    case 2U: // SHORT
-        return vec2(I16Vec2Ref(fetchAddress).data);
-    case 3U: // UNSIGNED SHORT
-        return vec2(U16Vec2Ref(fetchAddress).data);
-    case 6U: // FLOAT
+    case 5120U: // BYTE
+        if (normalized) {
+            return unpackSnorm4x8(UIntRef(fetchAddress).data).xy;
+        }
+        else {
+            return vec2(I8Vec2Ref(fetchAddress).data);
+        }
+    case 5121U: // UNSIGNED BYTE
+        if (normalized) {
+            return unpackUnorm4x8(UIntRef(fetchAddress).data).xy;
+        }
+        else {
+            return vec2(U8Vec2Ref(fetchAddress).data);
+        }
+    case 5122U: // SHORT
+        if (normalized) {
+            return unpackSnorm2x16(UIntRef(fetchAddress).data);
+        }
+        else {
+            return vec2(I16Vec2Ref(fetchAddress).data);
+        }
+    case 5123U: // UNSIGNED SHORT
+        if (normalized) {
+            return unpackUnorm2x16(UIntRef(fetchAddress).data);
+        }
+        else {
+            return vec2(U16Vec2Ref(fetchAddress).data);
+        }
+    case 5126U: // FLOAT
         return Vec2Ref(fetchAddress).data;
-    case 8U: // BYTE normalized
-        return unpackSnorm4x8(UIntRef(fetchAddress).data).xy;
-    case 9U: // UNSIGNED BYTE normalized
-        return unpackUnorm4x8(UIntRef(fetchAddress).data).xy;
-    case 10U: // SHORT normalized
-        return unpackSnorm2x16(UIntRef(fetchAddress).data);
-    case 11U: // UNSIGNED SHORT normalized
-        return unpackUnorm2x16(UIntRef(fetchAddress).data);
     }
     return vec2(0.0); // unreachable.
 }
 #endif
 
-#if HAS_COLOR_ATTRIBUTE
-vec4 getColor(uint componentType) {
+#if HAS_COLOR_0_ATTRIBUTE
+vec4 getColor0(uint componentType, uint componentCount) {
     uvec2 fetchAddress = add64(PRIMITIVE.color0Accessor.bufferAddress, PRIMITIVE.color0Accessor.stride * uint(gl_VertexIndex));
-    if (COLOR_COMPONENT_COUNT == 3U) {
+    if (componentCount == 3U) {
         switch (componentType) {
-        case 6U: // FLOAT
+        case 5126U: // FLOAT
             return vec4(Vec3Ref(fetchAddress).data, 1.0);
-        case 9U: // UNSIGNED BYTE normalized
+        case 5121U: // UNSIGNED BYTE normalized
             return vec4(unpackUnorm4x8(UIntRef(fetchAddress).data).xyz, 1.0);
-        case 11U: // UNSIGNED SHORT normalized
+        case 5123U: // UNSIGNED SHORT normalized
             uvec2 fetched = UVec2Ref(fetchAddress).data;
             return vec4(unpackUnorm2x16(fetched.x), unpackUnorm2x16(fetched.y).x, 1.0);
         }
     }
-    else if (COLOR_COMPONENT_COUNT == 4U) {
+    else if (componentCount == 4U) {
         switch (componentType) {
-        case 6U: // FLOAT
+        case 5126U: // FLOAT
             return Vec4Ref(fetchAddress).data;
-        case 9U: // UNSIGNED BYTE normalized
+        case 5121U: // UNSIGNED BYTE normalized
             return unpackUnorm4x8(UIntRef(fetchAddress).data);
-        case 11U: // UNSIGNED SHORT normalized
+        case 5123U: // UNSIGNED SHORT normalized
             uvec2 fetched = UVec2Ref(fetchAddress).data;
             return vec4(unpackUnorm2x16(fetched.x), unpackUnorm2x16(fetched.y));
         }
@@ -220,17 +241,17 @@ vec4 getColor(uint componentType) {
 }
 #endif
 
-#if HAS_COLOR_ALPHA_ATTRIBUTE
-float getColorAlpha(uint componentType) {
+#if HAS_COLOR_0_ALPHA_ATTRIBUTE
+float getColor0Alpha(uint componentType) {
     // Here uint64_t address should not be used because adding the size of RGB components to it will make 64-bit
     // integer arithmetic instruction.
     uint fetchIndex = PRIMITIVE.color0Accessor.stride * uint(gl_VertexIndex);
     switch (componentType) {
-    case 6U: // FLOAT
+    case 5126U: // FLOAT
         return FloatRef(add64(PRIMITIVE.color0Accessor.bufferAddress, fetchIndex + 12 /* skip rgb */)).data;
-    case 9U: // UNSIGNED BYTE normalized
+    case 5121U: // UNSIGNED BYTE normalized
         return unpackUnorm4x8(UIntRef(add64(PRIMITIVE.color0Accessor.bufferAddress, fetchIndex)).data).a;
-    case 11U: // UNSIGNED SHORT normalized
+    case 5123U: // UNSIGNED SHORT normalized
         return unpackUnorm2x16(UIntRef(add64(PRIMITIVE.color0Accessor.bufferAddress, fetchIndex + 4 /* skip rg */)).data).g;
     }
     return 1.0; // unreachable.


### PR DESCRIPTION
Reopen https://github.com/stripe2933/vk-gltf-viewer/pull/105, which was closed by https://github.com/stripe2933/vk-gltf-viewer/pull/106 due to some missing commits.