### PR TITLE
Implemented primitive material assigning/changing/unassigning features.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ target_sources(vk-gltf-viewer PRIVATE
         interface/gltf/SceneInverseHierarchy.cppm
         interface/gltf/StateCachedNodeVisibilityStructure.cppm
         interface/gltf/TextureUsage.cppm
+        interface/gltf/util.cppm
         interface/gui/dialog.cppm
         interface/helpers/AggregateHasher.cppm
         interface/helpers/concepts.cppm

--- a/extlibs/module-ports/imgui/imgui.cppm
+++ b/extlibs/module-ports/imgui/imgui.cppm
@@ -149,6 +149,7 @@ namespace ImGui {
     export using ImGui::SetNextItemAllowOverlap;
     export using ImGui::SetNextItemWidth;
     export using ImGui::SetNextWindowPos;
+    export using ImGui::SmallButton;
     export using ImGui::TableHeadersRow;
     export using ImGui::TableNextRow;
     export using ImGui::TableSetColumnIndex;

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -668,8 +668,19 @@ void vk_gltf_viewer::MainApp::run() {
                     const bool isPrimitiveBufferHostVisible = vku::contains(
                         gpu.allocator.getAllocationMemoryProperties(vkAssetExtended->primitiveBuffer.allocation),
                         vk::MemoryPropertyFlagBits::eHostVisible);
-                    for (const auto &[primitive, originalMaterialIndex] : assetExtended->materialVariantsMapping) {
-                        const std::size_t materialIndex = primitive->mappings.at(task.variantIndex).value_or(originalMaterialIndex);
+                    for (const auto &[primitive, originalMaterialIndex] : assetExtended->originalMaterialIndexByPrimitive) {
+                        if (primitive->mappings.empty()) {
+                            // Primitive material has no variants.
+                            continue;
+                        }
+
+                        std::size_t materialIndex;
+                        if (const auto &i = primitive->mappings.at(task.variantIndex)) {
+                            materialIndex = *i;
+                        }
+                        else {
+                            materialIndex = originalMaterialIndex.value();;
+                        }
                         primitive->materialIndex.emplace(materialIndex);
 
                         const std::size_t primitiveIndex = vkAssetExtended->primitiveBuffer.getPrimitiveIndex(*primitive);

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -1452,6 +1452,15 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::nodeInspector(gltf::AssetExten
                                     });
                                 }
 
+                                if (ImGui::Selectable("[Assign new material...]")) {
+                                    const std::size_t newMaterialIndex = assetExtended.asset.materials.size();
+                                    assetExtended.asset.materials.push_back({});
+                                    tasks.emplace(std::in_place_type<task::MaterialAdded>);
+
+                                    primitive.materialIndex.emplace(newMaterialIndex);
+                                    primitiveMaterialChanged = true;
+                                }
+
                                 ImGui::EndCombo();
                             }
 

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -11,6 +11,7 @@ module vk_gltf_viewer.imgui.TaskCollector;
 import imgui.math;
 
 import vk_gltf_viewer.global;
+import vk_gltf_viewer.gltf.util;
 import vk_gltf_viewer.gui.dialog;
 import vk_gltf_viewer.helpers.concepts;
 import vk_gltf_viewer.helpers.fastgltf;
@@ -1013,10 +1014,28 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialVariants(gltf::AssetEx
             selected = static_cast<int>(*assetExtended.imGuiSelectedMaterialVariantsIndex);
         }
 
-        for (const auto &[i, variantName] : assetExtended.asset.materialVariants | ranges::views::enumerate) {
-            if (ImGui::RadioButton(variantName.c_str(), &selected, i)) {
+        for (const auto &[variantIndex, variantName] : assetExtended.asset.materialVariants | ranges::views::enumerate) {
+            if (ImGui::RadioButton(variantName.c_str(), &selected, variantIndex)) {
+                // Apply material variants.
+                for (fastgltf::Mesh &mesh : assetExtended.asset.meshes) {
+                    for (fastgltf::Primitive &primitive : mesh.primitives) {
+                        if (primitive.mappings.empty()) {
+                            // Primitive is not affected by KHR_materials_variants.
+                            continue;
+                        }
+
+                        if (const auto &variantMaterialIndex = primitive.mappings.at(variantIndex)) {
+                            primitive.materialIndex.emplace(*variantMaterialIndex);
+                        }
+                        else {
+                            const auto &originalMaterialIndex = assetExtended.originalMaterialIndexByPrimitive.at(&primitive);
+                            primitive.materialIndex.emplace(originalMaterialIndex.value());
+                        }
+
+                        tasks.emplace(std::in_place_type<task::PrimitiveMaterialChanged>, &primitive);
+                    }
+                }
                 assetExtended.imGuiSelectedMaterialVariantsIndex.emplace(selected);
-                tasks.emplace(std::in_place_type<task::SelectMaterialVariants>, i);
             }
         }
     }
@@ -1406,20 +1425,69 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::nodeInspector(gltf::AssetExten
                     for (auto &&[primitiveIndex, primitive]: mesh.primitives | ranges::views::enumerate) {
                         if (ImGui::CollapsingHeader(tempStringBuffer.write("Primitive {}", primitiveIndex).view().c_str())) {
                             ImGui::LabelText("Type", "%s", to_string(primitive.type).c_str());
+
+                            bool primitiveMaterialChanged = false;
+
+                            const char* previewValue = "-";
                             if (primitive.materialIndex) {
-                                ImGui::WithID(*primitive.materialIndex, [&]() {
-                                    ImGui::WithLabel("Material"sv, [&]() {
-                                        if (ImGui::TextLink(getDisplayName(assetExtended.asset, assetExtended.asset.materials[*primitive.materialIndex]).c_str())) {
-                                            makeWindowVisible("Material Editor");
-                                            assetExtended.imGuiSelectedMaterialIndex.emplace(*primitive.materialIndex);
-                                        }
-                                    });
-                                });
+                                previewValue = getDisplayName(assetExtended.asset, assetExtended.asset.materials[*primitive.materialIndex]).c_str();
                             }
-                            else {
-                                ImGui::WithDisabled([]() {
-                                    ImGui::LabelText("Material", "-");
-                                });
+
+                            if (ImGui::BeginCombo("Material", previewValue)) {
+                                if (ImGui::Selectable(primitive.materialIndex ? "[Unassign material...]" : "-", !primitive.materialIndex) && primitive.materialIndex) {
+                                    // Unassign material.
+                                    primitive.materialIndex.reset();
+                                    primitiveMaterialChanged = true;
+                                }
+
+                                for (const auto &[materialIndex, material] : assetExtended.asset.materials | ranges::views::enumerate) {
+                                    ImGui::WithID(materialIndex, [&] {
+                                        ImGui::WithDisabled([&] {
+                                            if (ImGui::Selectable(getDisplayName(assetExtended.asset, material).c_str(), primitive.materialIndex == materialIndex) &&
+                                                primitive.materialIndex != materialIndex) {
+                                                primitive.materialIndex.emplace(materialIndex);
+                                                primitiveMaterialChanged = true;
+                                            }
+                                        }, !gltf::isMaterialCompatible(material, primitive));
+                                    });
+                                }
+
+                                ImGui::EndCombo();
+                            }
+
+                            const auto &originalMaterialIndex = assetExtended.originalMaterialIndexByPrimitive.at(&primitive);
+                            if (to_optional(primitive.materialIndex) != originalMaterialIndex) {
+                                ImGui::SameLine();
+                                if (ImGui::SmallButton("Reset")) {
+                                    if (originalMaterialIndex) {
+                                        primitive.materialIndex.emplace(*originalMaterialIndex);
+                                    }
+                                    else {
+                                        primitive.materialIndex.reset();
+                                    }
+                                    primitiveMaterialChanged = true;
+                                }
+                            }
+
+                            if (primitiveMaterialChanged) {
+                                if (!primitive.mappings.empty()) {
+                                    // If primitive is affected by KHR_materials_variants, current active material variant
+                                    // index needed to be recalculated.
+                                    assetExtended.imGuiSelectedMaterialVariantsIndex = gltf::getActiveMaterialVariantIndex(
+                                        assetExtended.asset,
+                                        [&](const fastgltf::Primitive &primitive) {
+                                            return assetExtended.originalMaterialIndexByPrimitive.at(&primitive);
+                                        });
+                                }
+
+                                // Assign assetExtended.imGuiSelectedMaterialIndex as primitive material index (maybe nullopt).
+                                if ((assetExtended.imGuiSelectedMaterialIndex = primitive.materialIndex)) {
+                                    // If assigned material is not nullopt, open the material editor.
+                                    // It will show the assigned material.
+                                    makeWindowVisible("Material Editor");
+                                }
+
+                                tasks.emplace(std::in_place_type<task::PrimitiveMaterialChanged>, &primitive);
                             }
 
                             attributeTable(

--- a/impl/control/ImGuiTaskCollector.cpp
+++ b/impl/control/ImGuiTaskCollector.cpp
@@ -1007,9 +1007,12 @@ void vk_gltf_viewer::control::ImGuiTaskCollector::materialEditor(gltf::AssetExte
 }
 
 void vk_gltf_viewer::control::ImGuiTaskCollector::materialVariants(gltf::AssetExtended &assetExtended) {
-    assert(assetExtended.imGuiSelectedMaterialVariantsIndex.has_value());
     if (ImGui::Begin("Material Variants")) {
-        int selected = *assetExtended.imGuiSelectedMaterialVariantsIndex;
+        int selected = -1;
+        if (assetExtended.imGuiSelectedMaterialVariantsIndex) {
+            selected = static_cast<int>(*assetExtended.imGuiSelectedMaterialVariantsIndex);
+        }
+
         for (const auto &[i, variantName] : assetExtended.asset.materialVariants | ranges::views::enumerate) {
             if (ImGui::RadioButton(variantName.c_str(), &selected, i)) {
                 assetExtended.imGuiSelectedMaterialVariantsIndex.emplace(selected);

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -1,6 +1,7 @@
 export module vk_gltf_viewer.control.Task;
 
 import std;
+export import fastgltf;
 export import glm;
 export import imgui.internal;
 
@@ -58,7 +59,7 @@ namespace vk_gltf_viewer::control {
             std::size_t materialIndex;
             Property property;
         };
-        struct SelectMaterialVariants { std::size_t variantIndex; };
+        struct PrimitiveMaterialChanged { const fastgltf::Primitive *primitive; };
         struct MorphTargetWeightChanged { std::size_t nodeIndex; std::size_t targetWeightStartIndex; std::size_t targetWeightCount; };
         struct BloomModeChanged{};
     }
@@ -84,7 +85,7 @@ namespace vk_gltf_viewer::control {
         task::NodeLocalTransformChanged,
         task::NodeWorldTransformChanged,
         task::MaterialPropertyChanged,
-        task::SelectMaterialVariants,
+        task::PrimitiveMaterialChanged,
         task::MorphTargetWeightChanged,
         task::BloomModeChanged>;
 }

--- a/interface/control/Task.cppm
+++ b/interface/control/Task.cppm
@@ -33,7 +33,7 @@ namespace vk_gltf_viewer::control {
          * transforms will be changed to match their original world transform.
          */
         struct NodeWorldTransformChanged { std::size_t nodeIndex; };
-
+        struct MaterialAdded { };
         struct MaterialPropertyChanged {
             enum Property {
                 AlphaCutoff,
@@ -84,6 +84,7 @@ namespace vk_gltf_viewer::control {
         task::HoverNodeFromGui,
         task::NodeLocalTransformChanged,
         task::NodeWorldTransformChanged,
+        task::MaterialAdded,
         task::MaterialPropertyChanged,
         task::PrimitiveMaterialChanged,
         task::MorphTargetWeightChanged,

--- a/interface/gltf/util.cppm
+++ b/interface/gltf/util.cppm
@@ -1,0 +1,116 @@
+export module vk_gltf_viewer.gltf.util;
+
+import std;
+export import fastgltf;
+
+import vk_gltf_viewer.helpers.concepts;
+import vk_gltf_viewer.helpers.fastgltf;
+import vk_gltf_viewer.helpers.ranges;
+
+namespace vk_gltf_viewer::gltf {
+    /**
+     * @brief Get what material variant is used for given \p asset.
+     *
+     * You may need to pass your own \p originalMaterialIndexGetter, if asset primitive material is modified. In the
+     * case, you can first store the primitive's material index at the asset loading and use it.
+     *
+     * @param asset Asset to determine.
+     * @param originalMaterialIndexGetter Functor that returns the material index for given primitive.
+     * @return Index of the active material variant, or std::nullopt if there's no matching material variant.
+     */
+    export
+    [[nodiscard]] std::optional<std::size_t> getActiveMaterialVariantIndex(
+        const fastgltf::Asset &asset,
+        concepts::signature_of<std::optional<std::size_t>(const fastgltf::Primitive&)> auto &&originalMaterialIndexGetter = [](const fastgltf::Primitive &primitive) noexcept {
+            return to_optional(primitive.materialIndex);
+        }
+    ) {
+        // Primitives that are affected by KHR_materials_variants.
+        auto variantPrimitives
+            = asset.meshes
+            | std::views::transform(&fastgltf::Mesh::primitives)
+            | std::views::join
+            | std::views::filter([](const fastgltf::Primitive &primitive) noexcept {
+                return !primitive.mappings.empty();
+            });
+
+        for (std::size_t variantIndex : ranges::views::upto(asset.materialVariants.size())) {
+            if (std::ranges::all_of(variantPrimitives, [&](const fastgltf::Primitive &primitive) {
+                if (const auto &variantMaterialIndex = primitive.mappings.at(variantIndex)) {
+                    return primitive.materialIndex == *variantMaterialIndex;
+                }
+                else {
+                    return to_optional(primitive.materialIndex) == std::invoke(originalMaterialIndexGetter, primitive);
+                }
+            })) {
+                return variantIndex;
+            }
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Check whether the given material is compatible with the primitive.
+     *
+     * A material is compatible with a primitive if all the following conditions are met:
+     * - If the material has a normal texture, the primitive must be either non-indexed or having NORMAL attribute.
+     *   - Note: If non-indexed, NORMAL and TANGENT are generated in shader.
+     *   - Note: For indexed primitives, TANGENT attribute is optional, as it is generated at the asset loading time.
+     * - All TEXCOORD_<i>s referenced by the material textures must be presented in the primitive attributes.
+     *
+     * @param material Material to check.
+     * @param primitive Primitive to check against.
+     * @return <true</true> if the material is compatible with the primitive, <false>false</false> otherwise.
+     */
+    export
+    [[nodiscard]] bool isMaterialCompatible(const fastgltf::Material &material, const fastgltf::Primitive &primitive) noexcept;
+}
+
+#if !defined(__GNUC__) || defined(__clang__)
+module :private;
+#endif
+
+using namespace std::string_view_literals;
+
+bool vk_gltf_viewer::gltf::isMaterialCompatible(const fastgltf::Material &material, const fastgltf::Primitive &primitive) noexcept {
+	// Refer the function doxygen comment for the logic detail.
+	bool canHaveNormalTexture = !primitive.indicesAccessor.has_value();
+	std::size_t texcoordCount = 0;
+	for (const auto &[attributeName, _] : primitive.attributes) {
+		if (attributeName == "NORMAL"sv) {
+			canHaveNormalTexture = true;
+		}
+		else if (attributeName.starts_with("TEXCOORD_"sv)) {
+			++texcoordCount;
+		}
+	}
+
+	if (const auto &texture = material.pbrData.baseColorTexture) {
+		if (getTexcoordIndex(*texture) >= texcoordCount) {
+			return false;
+		}
+	}
+	if (const auto &texture = material.pbrData.metallicRoughnessTexture) {
+		if (getTexcoordIndex(*texture) >= texcoordCount) {
+			return false;
+		}
+	}
+	if (const auto &texture = material.normalTexture) {
+		if (!canHaveNormalTexture || getTexcoordIndex(*texture) >= texcoordCount) {
+			return false;
+		}
+	}
+	if (const auto &texture = material.occlusionTexture) {
+		if (getTexcoordIndex(*texture) >= texcoordCount) {
+			return false;
+		}
+	}
+	if (const auto &texture = material.emissiveTexture) {
+		if (getTexcoordIndex(*texture) >= texcoordCount) {
+			return false;
+		}
+	}
+
+	return true;
+
+}

--- a/interface/helpers/fastgltf.cppm
+++ b/interface/helpers/fastgltf.cppm
@@ -24,6 +24,14 @@ import vk_gltf_viewer.helpers.type_map;
     }
 
 namespace fastgltf {
+    export template <typename T>
+    [[nodiscard]] std::optional<T> to_optional(OptionalWithFlagValue<T> v) noexcept {
+        if (v) {
+            return *v;
+        }
+        return std::nullopt;
+    }
+
     export
     [[nodiscard]] cpp_util::cstring_view to_string(PrimitiveType value) noexcept;
 

--- a/interface/vulkan/buffer/Materials.cppm
+++ b/interface/vulkan/buffer/Materials.cppm
@@ -1,5 +1,7 @@
 module;
 
+#include <cassert>
+
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vk_gltf_viewer.vulkan.buffer.Materials;
@@ -17,6 +19,38 @@ namespace vk_gltf_viewer::vulkan::buffer {
         vk::DescriptorBufferInfo descriptorInfo;
 
         Materials(const fastgltf::Asset &asset, vma::Allocator allocator, vkgltf::StagingBufferStorage &stagingBufferStorage);
+
+        /**
+         * @brief Replace self with a new buffer with doubled size.
+         *
+         * The original data is preserved by:
+         * - If the old buffer data can be copied to the new buffer in host, data is copied and <tt>std::nullopt</tt> returned.
+         * - Otherwise, \p transferCommandBuffer is recorded and the old buffer is returned. You must retain the lifetime
+         *   of the returned buffer until the command buffer is executed.
+         *
+         * @param transferCommandBuffer If buffer is not host-visible memory and so is unable to be updated from the host, this command buffer will be used for recording the buffer update command. Then, its execution MUST be synchronized to be available to the buffer usage. Otherwise, this parameter is unused.
+         * @return <tt>std::nullopt</tt> if the buffer is host-visible memory and the data is copied, or an <tt>AllocatedBuffer</tt> with the old buffer data recorded in \p transferCommandBuffer.
+         */
+        [[nodiscard]] std::optional<AllocatedBuffer> enlarge(vk::CommandBuffer transferCommandBuffer);
+
+        /**
+         * @brief Check if a material can be added at the end of the buffer.
+         * @return <tt>true</tt> if the buffer has enough space to store a new material, <tt>false</tt> otherwise.
+         */
+        [[nodiscard]] bool canAddMaterial() const noexcept;
+
+        /**
+         * Add new material at the end of the buffer.
+         *
+         * Buffer must have enough space to store the new material. You can use <tt>canAddMaterial()</tt> to check
+         * if the buffer can store the new material. If the method returns <tt>false</tt>, use
+         * <tt>enlarge(vk::CommandBuffer)</tt> to enlarge the buffer by 2x capacity.
+         *
+         * @param material Material to add.
+         * @param transferCommandBuffer If buffer is not host-visible memory and so is unable to be updated from the host, this command buffer will be used for recording the buffer update command. Then, its execution MUST be synchronized to be available to the buffer usage. Otherwise, this parameter is unused.
+         * @return <tt>true</tt> if the buffer is not host-visible memory and the update command is recorded, <tt>false</tt> otherwise.
+         */
+        [[nodiscard]] bool add(const fastgltf::Material &material, vk::CommandBuffer transferCommandBuffer);
 
         /**
          * @brief Update material property with field accessor.
@@ -52,6 +86,12 @@ namespace vk_gltf_viewer::vulkan::buffer {
                 return true;
             }
         }
+
+    private:
+        /**
+         * @brief Count of the currently stored materials, including the fallback material.
+         */
+        std::size_t count;
     };
 }
 
@@ -68,6 +108,77 @@ module :private;
     };
 }
 
+[[nodiscard]] vk_gltf_viewer::vulkan::shader_type::Material getShaderMaterial(const fastgltf::Material &material) {
+    vk_gltf_viewer::vulkan::shader_type::Material result {
+        .baseColorFactor = glm::gtc::make_vec4(material.pbrData.baseColorFactor.data()),
+        .metallicFactor = material.pbrData.metallicFactor,
+        .roughnessFactor = material.pbrData.roughnessFactor,
+        .emissive = material.emissiveStrength * glm::gtc::make_vec3(material.emissiveFactor.data()),
+        .alphaCutOff = material.alphaCutoff,
+        .ior = material.ior,
+    };
+
+    if (const auto& baseColorTexture = material.pbrData.baseColorTexture) {
+        result.baseColorTexcoordIndex = baseColorTexture->texCoordIndex;
+        result.baseColorTextureIndex = static_cast<std::uint16_t>(baseColorTexture->textureIndex) + 1;
+
+        if (const auto &transform = baseColorTexture->transform) {
+            result.baseColorTextureTransform = getTextureTransform(*transform);
+            if (transform->texCoordIndex) {
+                result.baseColorTexcoordIndex = *transform->texCoordIndex;
+            }
+        }
+    }
+    if (const auto& metallicRoughnessTexture = material.pbrData.metallicRoughnessTexture) {
+        result.metallicRoughnessTexcoordIndex = metallicRoughnessTexture->texCoordIndex;
+        result.metallicRoughnessTextureIndex = static_cast<std::uint16_t>(metallicRoughnessTexture->textureIndex) + 1;
+
+        if (const auto &transform = metallicRoughnessTexture->transform) {
+            result.metallicRoughnessTextureTransform = getTextureTransform(*transform);
+            if (transform->texCoordIndex) {
+                result.metallicRoughnessTexcoordIndex = *transform->texCoordIndex;
+            }
+        }
+    }
+    if (const auto& normalTexture = material.normalTexture) {
+        result.normalTexcoordIndex = normalTexture->texCoordIndex;
+        result.normalTextureIndex = static_cast<std::uint16_t>(normalTexture->textureIndex) + 1;
+        result.normalScale = normalTexture->scale;
+
+        if (const auto &transform = normalTexture->transform) {
+            result.normalTextureTransform = getTextureTransform(*transform);
+            if (transform->texCoordIndex) {
+                result.normalTexcoordIndex = *transform->texCoordIndex;
+            }
+        }
+    }
+    if (const auto& occlusionTexture = material.occlusionTexture) {
+        result.occlusionTexcoordIndex = occlusionTexture->texCoordIndex;
+        result.occlusionTextureIndex = static_cast<std::uint16_t>(occlusionTexture->textureIndex) + 1;
+        result.occlusionStrength = occlusionTexture->strength;
+
+        if (const auto &transform = occlusionTexture->transform) {
+            result.occlusionTextureTransform = getTextureTransform(*transform);
+            if (transform->texCoordIndex) {
+                result.occlusionTexcoordIndex = *transform->texCoordIndex;
+            }
+        }
+    }
+    if (const auto& emissiveTexture = material.emissiveTexture) {
+        result.emissiveTexcoordIndex = emissiveTexture->texCoordIndex;
+        result.emissiveTextureIndex = static_cast<std::uint16_t>(emissiveTexture->textureIndex) + 1;
+
+        if (const auto &transform = emissiveTexture->transform) {
+            result.emissiveTextureTransform = getTextureTransform(*transform);
+            if (transform->texCoordIndex) {
+                result.emissiveTexcoordIndex = *transform->texCoordIndex;
+            }
+        }
+    }
+
+    return result;
+}
+
 vk_gltf_viewer::vulkan::buffer::Materials::Materials(
     const fastgltf::Asset &asset,
     vma::Allocator allocator,
@@ -77,92 +188,78 @@ vk_gltf_viewer::vulkan::buffer::Materials::Materials(
         vk::BufferCreateInfo {
             {},
             sizeof(shader_type::Material) * (1 + asset.materials.size()), // +1 for fallback material.
-            vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc,
+            vk::BufferUsageFlagBits::eStorageBuffer
+                | vk::BufferUsageFlagBits::eTransferSrc /* might be copy source when enlarging the buffer */,
         },
         vma::AllocationCreateInfo {
             vma::AllocationCreateFlagBits::eHostAccessSequentialWrite | vma::AllocationCreateFlagBits::eMapped,
             vma::MemoryUsage::eAutoPreferHost,
         },
     },
-    descriptorInfo { *this, 0, vk::WholeSize } {
+    descriptorInfo { *this, 0, vk::WholeSize },
+    count { 1 + asset.materials.size() } {
     auto it = std::span { static_cast<shader_type::Material*>(allocator.getAllocationInfo(allocation).pMappedData), 1 + asset.materials.size() }.begin();
     *it++ = {}; // Initialize fallback material.
-    std::ranges::transform(asset.materials, it, [](const fastgltf::Material &material) {
-        shader_type::Material result {
-            .baseColorFactor = glm::gtc::make_vec4(material.pbrData.baseColorFactor.data()),
-            .metallicFactor = material.pbrData.metallicFactor,
-            .roughnessFactor = material.pbrData.roughnessFactor,
-            .emissive = material.emissiveStrength * glm::gtc::make_vec3(material.emissiveFactor.data()),
-            .alphaCutOff = material.alphaCutoff,
-            .ior = material.ior,
-        };
-
-        if (const auto& baseColorTexture = material.pbrData.baseColorTexture) {
-            result.baseColorTexcoordIndex = baseColorTexture->texCoordIndex;
-            result.baseColorTextureIndex = static_cast<std::uint16_t>(baseColorTexture->textureIndex) + 1;
-
-            if (const auto &transform = baseColorTexture->transform) {
-                result.baseColorTextureTransform = getTextureTransform(*transform);
-                if (transform->texCoordIndex) {
-                    result.baseColorTexcoordIndex = *transform->texCoordIndex;
-                }
-            }
-        }
-        if (const auto& metallicRoughnessTexture = material.pbrData.metallicRoughnessTexture) {
-            result.metallicRoughnessTexcoordIndex = metallicRoughnessTexture->texCoordIndex;
-            result.metallicRoughnessTextureIndex = static_cast<std::uint16_t>(metallicRoughnessTexture->textureIndex) + 1;
-
-            if (const auto &transform = metallicRoughnessTexture->transform) {
-                result.metallicRoughnessTextureTransform = getTextureTransform(*transform);
-                if (transform->texCoordIndex) {
-                    result.metallicRoughnessTexcoordIndex = *transform->texCoordIndex;
-                }
-            }
-        }
-        if (const auto& normalTexture = material.normalTexture) {
-            result.normalTexcoordIndex = normalTexture->texCoordIndex;
-            result.normalTextureIndex = static_cast<std::uint16_t>(normalTexture->textureIndex) + 1;
-            result.normalScale = normalTexture->scale;
-
-            if (const auto &transform = normalTexture->transform) {
-                result.normalTextureTransform = getTextureTransform(*transform);
-                if (transform->texCoordIndex) {
-                    result.normalTexcoordIndex = *transform->texCoordIndex;
-                }
-            }
-        }
-        if (const auto& occlusionTexture = material.occlusionTexture) {
-            result.occlusionTexcoordIndex = occlusionTexture->texCoordIndex;
-            result.occlusionTextureIndex = static_cast<std::uint16_t>(occlusionTexture->textureIndex) + 1;
-            result.occlusionStrength = occlusionTexture->strength;
-
-            if (const auto &transform = occlusionTexture->transform) {
-                result.occlusionTextureTransform = getTextureTransform(*transform);
-                if (transform->texCoordIndex) {
-                    result.occlusionTexcoordIndex = *transform->texCoordIndex;
-                }
-            }
-        }
-        if (const auto& emissiveTexture = material.emissiveTexture) {
-            result.emissiveTexcoordIndex = emissiveTexture->texCoordIndex;
-            result.emissiveTextureIndex = static_cast<std::uint16_t>(emissiveTexture->textureIndex) + 1;
-
-            if (const auto &transform = emissiveTexture->transform) {
-                result.emissiveTextureTransform = getTextureTransform(*transform);
-                if (transform->texCoordIndex) {
-                    result.emissiveTexcoordIndex = *transform->texCoordIndex;
-                }
-            }
-        }
-        return result;
-    });
+    std::ranges::transform(asset.materials, it, getShaderMaterial);
 
     if (!vku::contains(allocator.getAllocationMemoryProperties(allocation), vk::MemoryPropertyFlagBits::eHostCoherent)) {
         // Created buffer is non-coherent. Flush the mapped memory range.
         allocator.flushAllocation(allocation, 0, size);
     }
 
-    if (stagingBufferStorage.stage(*this, vk::BufferUsageFlagBits::eStorageBuffer)) {
+    if (stagingBufferStorage.stage(*this, vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransferSrc /* might be copy source when enlarging the buffer */)) {
         descriptorInfo.buffer = *this;
+    }
+}
+
+std::optional<vku::AllocatedBuffer> vk_gltf_viewer::vulkan::buffer::Materials::enlarge(vk::CommandBuffer transferCommandBuffer) {
+    // Create new buffer with doubled size.
+    AllocatedBuffer newBuffer {
+        allocator,
+        vk::BufferCreateInfo {
+            {},
+            size * 2,
+            vk::BufferUsageFlagBits::eTransferDst /* copy destination */
+                | vk::BufferUsageFlagBits::eStorageBuffer
+                | vk::BufferUsageFlagBits::eTransferSrc /* might be copy source when enlarging the buffer */,
+        },
+        vma::AllocationCreateInfo {
+            {},
+            vma::MemoryUsage::eAutoPreferDevice,
+        },
+    };
+
+    descriptorInfo.buffer = newBuffer;
+
+    if (vku::contains(allocator.getAllocationMemoryProperties(allocation), vk::MemoryPropertyFlagBits::eHostCached) &&
+        vku::contains(allocator.getAllocationMemoryProperties(newBuffer.allocation), vk::MemoryPropertyFlagBits::eHostVisible)) {
+        // Old buffer data can be copied to the new buffer in host.
+        allocator.copyMemoryToAllocation(allocator.getAllocationInfo(allocation).pMappedData, newBuffer.allocation, 0, size);
+
+        static_cast<AllocatedBuffer&>(*this) = std::move(newBuffer);
+        return std::nullopt;
+    }
+    else {
+        // Copy needed to be done in GPU.
+        transferCommandBuffer.copyBuffer(*this, newBuffer, vk::BufferCopy { 0, 0, size });
+        return std::exchange(static_cast<AllocatedBuffer&>(*this), std::move(newBuffer));
+    }
+}
+
+bool vk_gltf_viewer::vulkan::buffer::Materials::canAddMaterial() const noexcept {
+    return sizeof(shader_type::Material) * (count + 1) <= size;
+}
+
+bool vk_gltf_viewer::vulkan::buffer::Materials::add(const fastgltf::Material &material, vk::CommandBuffer transferCommandBuffer) {
+    assert(canAddMaterial() && "Buffer size is not enough to push back a new material.");
+
+    const shader_type::Material shaderMaterial = getShaderMaterial(material);
+    if (vku::contains(allocator.getAllocationMemoryProperties(allocation), vk::MemoryPropertyFlagBits::eHostVisible)) {
+        allocator.copyMemoryToAllocation(&shaderMaterial, allocation, sizeof(shader_type::Material) * count++, sizeof(shader_type::Material));
+        return false;
+    }
+    else {
+        transferCommandBuffer.updateBuffer(*this, sizeof(shader_type::Material) * count++, sizeof(shader_type::Material), &shaderMaterial);
+        return true;
     }
 }


### PR DESCRIPTION
This PR implements the functionality of

- adding new material to the material buffer and assign it to a primitive,
- changing primitive material with compatibility check,
- and unassign primitive material (in the case, default material is used).

And also fixed some minor bugs:

- The application was always selecting the first material variants when loading an asset with [`KHR_materials_variants`](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_variants/README.md), even if the asset does not uses the first material variants by default. Now application calculates what material variants are used at the loading time and correctly select it.
- If `KHR_materials_variants` has variants that are differing by alpha mode/unlit/double sided, the application was not correctly render the changed properties. Now draw commands are always re-generated when a primitive material is changed, and will reflect the changes.

**Demonstration: assigning material to material-less primitive**

https://github.com/user-attachments/assets/42b4a699-af39-42ce-8276-323d7dd9a2b5

- When primitive material is changed and is different from the initial state, *Reset* button is appeared in the next of the combo box, can be used to restore the original material index.

**Demonstration: changing primitive material and go back on**

https://github.com/user-attachments/assets/6e00215c-9529-4fc1-bcc3-76811fa668a9

- When selecting material with combo box, incompatible material is disabled.
- When changing material of a primitive that is affected by `KHR_materials_variants`, currently active material variant index is recalculated. If there's no matching material variant index, radio button selection is disappeared.