### PR TITLE
Convert triangle fan topology to triangle list at asset loading time for Apple system.

### DIFF
--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -300,7 +300,6 @@ vk::raii::Device vk_gltf_viewer::vulkan::Gpu::createDevice() {
         vk::PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT { supportAttachmentFeedbackLoopLayout },
 #if __APPLE__
         vk::PhysicalDevicePortabilitySubsetFeaturesKHR{}
-            .setTriangleFans(true)
             .setImageViewFormatSwizzle(true),
         vk::PhysicalDeviceHostImageCopyFeatures { true },
 #endif

--- a/interface/vulkan/gltf/AssetExtended.cppm
+++ b/interface/vulkan/gltf/AssetExtended.cppm
@@ -58,6 +58,17 @@ vk_gltf_viewer::vulkan::gltf::AssetExtended::AssetExtended(
     combinedIndexBuffer { asset, gpu.allocator, vkgltf::CombinedIndexBuffer::Config {
         .adapter = externalBuffers,
         .promoteUnsignedByteToUnsignedShort = !gpu.supportUint8Index,
+        .topologyConvertFn = [](fastgltf::PrimitiveType type) noexcept {
+            if (type == fastgltf::PrimitiveType::LineLoop) {
+                return fastgltf::PrimitiveType::LineStrip;
+            }
+        #if __APPLE__
+            if (type == fastgltf::PrimitiveType::TriangleFan) {
+                return fastgltf::PrimitiveType::Triangles;
+            }
+        #endif
+            return type;
+        },
         .usageFlags = vk::BufferUsageFlagBits::eIndexBuffer | vk::BufferUsageFlagBits::eTransferSrc,
         .queueFamilies = gpu.queueFamilies.uniqueIndices,
         .stagingInfo = vku::unsafeAddress(vkgltf::StagingInfo { stagingBufferStorage }),


### PR DESCRIPTION
# Overview

This PR fixes malformed rendering when using triangle fan topology primitive in MoltenVK, by converting it to the triangle list topology at the asset loading time. Also it generalizes the primitive topology conversion mechanism in `vkgltf::CombinedIndexBuffer`.

<table>
    <thead>
        <tr>
            <th>Model</th>
            <th>Before</th>
            <th>After</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td><a href="https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/MeshPrimitiveModes/README.md">MeshPrimitiveModes</a></td>
            <td>
<img width="1392" height="860" alt="Screenshot 2025-08-01 at 1 15 36 PM" src="https://github.com/user-attachments/assets/47759ec8-eaab-42f2-92e4-62bd34a63f88" />
</td>
            <td>
<img width="1392" height="860" alt="Screenshot 2025-08-01 at 1 14 19 PM" src="https://github.com/user-attachments/assets/9885be70-903c-4b9d-ac0c-3a4221cf1cf5" />
</td>
        </tr>
        <tr>
            <td><a href="https://github.com/KhronosGroup/glTF-Sample-Assets/pull/110">TopologiesWithoutIndices</a></td>
            <td>
<img width="1392" height="860" alt="Screenshot 2025-08-01 at 1 41 52 PM" src="https://github.com/user-attachments/assets/9d2fab26-3312-402d-8f58-86dde662a506" />
</td>
            <td>
<img width="1392" height="860" alt="Screenshot 2025-08-01 at 1 41 36 PM" src="https://github.com/user-attachments/assets/063eb292-c8d2-4baf-90f8-3a983a7e760e" />
</td>
        </tr>
    </tbody>
</table>

# Background

- Metal does not support triangle fan topology, therefore [MoltenVK tries to emulate it by generate index buffer and record indirect command buffer](https://github.com/KhronosGroup/MoltenVK/pull/1962). This operation cannot be done in a `MTLRenderCommandEncoder` execution, it is inevitable to break the render pass, and introduces overhead. Also, it is observed that this emulation is very buggy when drawing triangle fan primitive with indirect draw command.
- Although unrelated to the current implementation of the application, sometimes the primitive topology needs to be converted to the list format (e.g., using `VK_EXT_mesh_shader`).

# Implementation Details

## Changes in `vkgltf::CombinedIndexBuffer`

`vkgltf::CombinedIndexBuffer::Config` sturcture's `processLineLoopAsLineStrip` boolean field is now replaced with `topologyConvertFn` function type, functioning with more generalized mechanism.

This function has signature of `(fastgltf::PrmitiveType) -> fastgltf::PrimitiveType`, and is invoked with every primitive's type in the given asset. When the return value of the function is different from its input, topology conversion is processed.

The internal helper function, `convertIndices`, returns the bytes data of the converted indices and its size (as `std::unique_ptr<std::byte[]>` doesn't contain the allocation size info by itself). The assembly of the result indices by `dstTopology`, is equivalent to the assembly of `indices` by `srcTopology`.

Currently these combinations of topology conversion are implemented:

- LineStrip -> Lines
- LineLoop -> Lines
- LineLoop -> LineStrip
- TriangleStrip -> Triangles
- TriangleFan -> Triangles

which is quite intuitive (other combinations are theoretically impossible; usually, triangle list topology cannot be converted to the triangle strip unless it uses primitive restart), but there's one exception: TriangleFan -> TriangleStrip is not implemented even if it is theoretically possible, due to its implementation complexity. But usually list topology is most performant in the modern hardware and therefore it is discouraged to use triangle strip topology.

By default, this function parameter is set to return the input primitive type as-is, except for LineLoop, which returns LineStrip, to preserve the previous behavior.

## In Application

Now the `vkgltf::CombinedIndexBuffer::Config::topologyConvertFn` is now set as:

```c++
if (type == fastgltf::PrimitiveType::LineLoop) {
    return fastgltf::PrimitiveType::LineStrip;
}
#if __APPLE__
if (type == fastgltf::PrimitiveType::TriangleFan) {
    return fastgltf::PrimitiveType::Triangles;
}
#endif
return type;
```

and requirements `vk::PhysicalDevicePortabilitySubsetFeaturesKHR::triangleFans` requirement is removed in Apple system.