### PR TITLE
Separate images and samplers in Apple system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,11 +313,20 @@ target_link_shaders(vk-gltf-viewer PRIVATE
 target_link_shader_variants(vk-gltf-viewer PRIVATE
     TARGET_ENV vulkan1.2
     FILES
-        shaders/mask_jump_flood_seed.frag
         shaders/mask_jump_flood_seed.vert
+        shaders/mask_node_index.vert
+    MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_0_ALPHA_ATTRIBUTE"
+    MACRO_VALUES
+        "0 0" "0 1"
+        "1 0" "1 1"
+)
+target_link_shader_variants(vk-gltf-viewer PRIVATE
+    TARGET_ENV vulkan1.2
+    MACRO_DEFS "SEPARATE_IMAGE_SAMPLER=$<PLATFORM_ID:Darwin>"
+    FILES
+        shaders/mask_jump_flood_seed.frag
         shaders/mask_multi_node_mouse_picking.frag
         shaders/mask_node_index.frag
-        shaders/mask_node_index.vert
     MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_0_ALPHA_ATTRIBUTE"
     MACRO_VALUES
         "0 0" "0 1"
@@ -336,6 +345,7 @@ target_link_shader_variants(vk-gltf-viewer PRIVATE
 )
 target_link_shader_variants(vk-gltf-viewer PRIVATE
     TARGET_ENV vulkan1.2
+    MACRO_DEFS "SEPARATE_IMAGE_SAMPLER=$<PLATFORM_ID:Darwin>"
     FILES shaders/primitive.frag
     MACRO_NAMES "TEXCOORD_COUNT" "HAS_COLOR_0_ATTRIBUTE" "FRAGMENT_SHADER_GENERATED_TBN" "ALPHA_MODE" "EXT_SHADER_STENCIL_EXPORT"
     MACRO_VALUES
@@ -370,6 +380,7 @@ target_link_shader_variants(vk-gltf-viewer PRIVATE
 )
 target_link_shader_variants(vk-gltf-viewer PRIVATE
     TARGET_ENV vulkan1.2
+    MACRO_DEFS "SEPARATE_IMAGE_SAMPLER=$<PLATFORM_ID:Darwin>"
     FILES shaders/unlit_primitive.frag
     MACRO_NAMES "HAS_BASE_COLOR_TEXTURE" "HAS_COLOR_0_ATTRIBUTE" "ALPHA_MODE"
     MACRO_VALUES

--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ The extensions and feature used in this application are quite common in the mode
   - `VkPhysicalDeviceVulkan12Features`
     - `bufferDeviceAddress`
     - `descriptorIndexing`
-    - `descriptorBindingSampledImageUpdateAfterBind`
     - `descriptorBindingPartiallyBound`
+    - `descriptorBindingSampledImageUpdateAfterBind`
+    - `descriptorBindingVariableDescriptorCount`
     - `runtimeDescriptorArray`
     - `separateDepthStencilLayouts`
     - `storageBuffer8BitAccess`
@@ -120,7 +121,6 @@ The extensions and feature used in this application are quite common in the mode
     - `timelineSemaphore`
     - `shaderInt8`
     - (optional) `drawIndirectCount` (If not presented, GPU frustum culling will be unavailable and fallback to the CPU frustum culling.)
-    - (optional) `descriptorBindingVariableDescriptorCount` (If not presented, graphics pipelines are dependent to the asset texture count; for every asset loading, the pipelines will be recreated as their texture count is changing.)
   - `VkPhysicalDeviceDynamicRenderingFeatures`
   - `VkPhysicalDeviceSynchronization2Features`
   - `VkPhysicalDeviceExtendedDynamicStateFeaturesEXT`
@@ -129,7 +129,9 @@ The extensions and feature used in this application are quite common in the mode
 - Device Limits
   - Subgroup size must be at least 16.
   - Sampler anisotropy must support 16x.
-  - Loading asset texture count must be less than `maxDescriptorSetUpdateAfterBindSampledImages`
+  - Available asset texture count is restricted by:
+    - For Apple system, sampler and image count must be less than `maxDescriptorSetUpdateAfterBindSamplers` and `maxDescriptorSetUpdateAfterBindSampledImages`, respectively.
+    - Otherwise, texture count must be less than `maxDescriptorSetUpdateAfterBindSamplers`.
 
 </details>
 

--- a/impl/MainApp.cpp
+++ b/impl/MainApp.cpp
@@ -569,7 +569,7 @@ void vk_gltf_viewer::MainApp::run() {
                     }
 
                     // Add the new material to the material buffer.
-                    hasUpdateData |= vkAsset.materialBuffer.add(assetExtended->asset.materials.back(), sharedDataUpdateCommandBuffer);
+                    hasUpdateData |= vkAsset.materialBuffer.add(assetExtended->asset, assetExtended->asset.materials.back(), sharedDataUpdateCommandBuffer);
                 },
                 [&](const control::task::MaterialPropertyChanged &task) {
                     const fastgltf::Material &changedMaterial = assetExtended->asset.materials[task.materialIndex];
@@ -1027,7 +1027,7 @@ void vk_gltf_viewer::MainApp::loadGltf(const std::filesystem::path &path) {
     // TODO: I'm aware that there are better solutions compare to the waitIdle, but I don't have much time for it
     //  so I'll just use it for now.
     gpu.device.waitIdle();
-    sharedData.setAsset(std::move(vkAssetExtended));
+    sharedData.assetExtended = std::move(vkAssetExtended);
     for (vulkan::Frame &frame : frames) {
         frame.updateAsset();
     }

--- a/impl/vulkan/Gpu.cpp
+++ b/impl/vulkan/Gpu.cpp
@@ -89,6 +89,7 @@ vk_gltf_viewer::vulkan::Gpu::Gpu(const vk::raii::Instance &instance, vk::Surface
         vk::PhysicalDeviceDescriptorIndexingProperties>();
     subgroupSize = subgroupProps.subgroupSize;
     maxPerStageDescriptorUpdateAfterBindSamplers = descriptorIndexingProps.maxPerStageDescriptorUpdateAfterBindSamplers;
+    maxPerStageDescriptorUpdateAfterBindSampledImages = descriptorIndexingProps.maxPerStageDescriptorUpdateAfterBindSampledImages;
 
 	// Retrieve physical device memory properties.
 	const vk::PhysicalDeviceMemoryProperties memoryProperties = physicalDevice.getMemoryProperties();
@@ -240,14 +241,8 @@ vk::raii::Device vk_gltf_viewer::vulkan::Gpu::createDevice() {
     // using Metal compute command encoder, therefore it breaks the render pass and has performance defect. Since the
     // application already has CPU index conversion path, disable it.
     supportUint8Index = false;
-
-    // MoltenVK with Metal Argument Buffer does not work with variable descriptor count.
-    // Tracked issue: https://github.com/KhronosGroup/MoltenVK/issues/2343
-    // TODO: Remove this workaround when the issue is fixed.
-    supportVariableDescriptorCount = false;
 #else
     supportUint8Index = indexTypeUint8Features.indexTypeUint8;
-    supportVariableDescriptorCount = vulkan12Features.descriptorBindingVariableDescriptorCount;
 #endif
 
     if (availableExtensionNames.contains(vk::EXTExtendedDynamicStateExtensionName)) {
@@ -284,8 +279,9 @@ vk::raii::Device vk_gltf_viewer::vulkan::Gpu::createDevice() {
         vk::PhysicalDeviceVulkan12Features{}
             .setBufferDeviceAddress(true)
             .setDescriptorIndexing(true)
+            .setDescriptorBindingPartiallyBound(true)
             .setDescriptorBindingSampledImageUpdateAfterBind(true)
-            .setDescriptorBindingVariableDescriptorCount(supportVariableDescriptorCount)
+            .setDescriptorBindingVariableDescriptorCount(true)
             .setRuntimeDescriptorArray(true)
             .setSeparateDepthStencilLayouts(true)
             .setStorageBuffer8BitAccess(true)

--- a/interface/vulkan/Frame.cppm
+++ b/interface/vulkan/Frame.cppm
@@ -74,9 +74,6 @@ namespace vk_gltf_viewer::vulkan {
 
             vku::MappedBuffer mousePickingResultBuffer;
 
-            // Used only if GPU does not support variable descriptor count.
-            std::optional<vk::raii::DescriptorPool> descriptorPool;
-
             std::variant<std::monostate, vk::Offset2D, vk::Rect2D> mousePickingInput;
 
             explicit GltfAsset(const SharedData &sharedData LIFETIMEBOUND);

--- a/interface/vulkan/Gpu.cppm
+++ b/interface/vulkan/Gpu.cppm
@@ -64,10 +64,10 @@ namespace vk_gltf_viewer::vulkan {
         bool supportAttachmentFeedbackLoopLayout;
         std::uint32_t subgroupSize;
         std::uint32_t maxPerStageDescriptorUpdateAfterBindSamplers;
+        std::uint32_t maxPerStageDescriptorUpdateAfterBindSampledImages;
         bool supportShaderImageLoadStoreLod;
         bool supportShaderTrinaryMinMax;
         bool supportShaderStencilExport;
-        bool supportVariableDescriptorCount;
         bool supportR8SrgbImageFormat;
         bool supportR8G8SrgbImageFormat;
         bool supportS8UintDepthStencilAttachment;

--- a/interface/vulkan/descriptor_set_layout/Asset.cppm
+++ b/interface/vulkan/descriptor_set_layout/Asset.cppm
@@ -9,16 +9,37 @@ import std;
 export import vk_gltf_viewer.vulkan.Gpu;
 
 namespace vk_gltf_viewer::vulkan::dsl {
+#if __APPLE__
+    // Metal does not have a concept of combined image sampler, so MoltenVK mimics it by mixing them. This makes the
+    // available texture count tied to VkPhysicalDeviceDescriptorIndexingProperties::maxPerStageDescriptorUpdateAfterBindSamplers,
+    // which is very small (16) when not using Metal Argument Buffer. It is also buggy when using Metal Argument Buffer,
+    // due to the poor implementation.
+    //
+    // For workaround, we'll manually separate the sampler and image (see SEPARATE_IMAGE_SAMPLER macro definition in the
+    // primitive rendering pipeline's fragment shader).
+    export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eSampler, vk::DescriptorType::eSampledImage> {
+#else
     export struct Asset : vku::DescriptorSetLayout<vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eStorageBuffer, vk::DescriptorType::eCombinedImageSampler> {
+#endif
         explicit Asset(const Gpu &gpu LIFETIMEBOUND);
-        Asset(const Gpu &gpu LIFETIMEBOUND, std::uint32_t textureCount);
 
         /**
-         * Get maximum available texture count for asset, including the fallback texture.
+         * @brief Get maximum available sampler (in Apple system) or texture (otherwise) count for asset, including the fallback texture.
+         *
          * @param gpu The GPU object that is storing <tt>maxPerStageDescriptorUpdateAfterBindSamplers</tt> which have been retrieved from physical device selection.
-         * @return The maximum available texture count.
+         * @return The maximum available sampler count.
          */
-        [[nodiscard]] static std::uint32_t maxTextureCount(const Gpu &gpu) noexcept;
+        [[nodiscard]] static std::uint32_t maxSamplerCount(const Gpu &gpu) noexcept;
+
+#if __APPLE__
+        /**
+         * @brief Get maximum available image count for asset, including the fallback texture.
+         *
+         * @param gpu The GPU object that is storing <tt>maxPerStageDescriptorUpdateAfterBindSampledImages</tt> which have been retrieved from physical device selection.
+         * @return The maximum available image count.
+         */
+        [[nodiscard]] static std::uint32_t maxImageCount(const Gpu &gpu) noexcept;
+#endif
     };
 }
 
@@ -34,39 +55,43 @@ vk_gltf_viewer::vulkan::dsl::Asset::Asset(const Gpu &gpu)
                 { 1, vk::ShaderStageFlagBits::eVertex },
                 { 1, vk::ShaderStageFlagBits::eVertex },
                 { 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment },
-                { maxTextureCount(gpu), vk::ShaderStageFlagBits::eFragment })),
+            #if __APPLE__
+                { maxSamplerCount(gpu), vk::ShaderStageFlagBits::eFragment },
+                { maxImageCount(gpu), vk::ShaderStageFlagBits::eFragment })),
+            #else
+                { maxSamplerCount(gpu), vk::ShaderStageFlagBits::eFragment })),
+            #endif
         },
         vk::DescriptorSetLayoutBindingFlagsCreateInfo {
             vku::unsafeProxy<vk::DescriptorBindingFlags>({
                 {},
                 {},
                 {},
+            #if __APPLE__
+                vk::DescriptorBindingFlagBits::eUpdateAfterBind | vk::DescriptorBindingFlagBits::ePartiallyBound,
+                vk::DescriptorBindingFlagBits::eUpdateAfterBind | vk::DescriptorBindingFlagBits::ePartiallyBound | vk::DescriptorBindingFlagBits::eVariableDescriptorCount,
+            #else
                 vk::DescriptorBindingFlagBits::eUpdateAfterBind | vk::DescriptorBindingFlagBits::eVariableDescriptorCount,
+            #endif
             }),
         },
     }.get() } { }
 
-vk_gltf_viewer::vulkan::dsl::Asset::Asset(const Gpu &gpu, std::uint32_t textureCount)
-    : DescriptorSetLayout { gpu.device, vk::StructureChain {
-        vk::DescriptorSetLayoutCreateInfo {
-            vk::DescriptorSetLayoutCreateFlagBits::eUpdateAfterBindPool,
-            vku::unsafeProxy(getBindings(
-                { 1, vk::ShaderStageFlagBits::eVertex },
-                { 1, vk::ShaderStageFlagBits::eVertex },
-                { 1, vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment },
-                { textureCount, vk::ShaderStageFlagBits::eFragment })),
-        },
-        vk::DescriptorSetLayoutBindingFlagsCreateInfo {
-            vku::unsafeProxy<vk::DescriptorBindingFlags>({
-                {},
-                {},
-                {},
-                vk::DescriptorBindingFlagBits::eUpdateAfterBind,
-            }),
-        },
-    }.get() } { }
+std::uint32_t vk_gltf_viewer::vulkan::dsl::Asset::maxSamplerCount(const Gpu &gpu) noexcept {
+    constexpr std::uint32_t limit
+    #if __APPLE__
+        = 16U; // We don't need that many samplers.
+    #else
+        = 512U;
+    #endif
 
-std::uint32_t vk_gltf_viewer::vulkan::dsl::Asset::maxTextureCount(const Gpu &gpu) noexcept {
     // BRDF LUT texture and prefiltered map texture will acquire two slots, therefore we need to subtract 2.
-    return std::min(gpu.maxPerStageDescriptorUpdateAfterBindSamplers, 512U) - 2U;
+    return std::min(gpu.maxPerStageDescriptorUpdateAfterBindSamplers, limit) - 2U;
 }
+
+#if __APPLE__
+std::uint32_t vk_gltf_viewer::vulkan::dsl::Asset::maxImageCount(const Gpu& gpu) noexcept {
+    // BRDF LUT texture and prefiltered map texture will acquire two slots, therefore we need to subtract 2.
+    return std::min(gpu.maxPerStageDescriptorUpdateAfterBindSampledImages, 512U) - 2U;
+}
+#endif

--- a/interface/vulkan/texture/Textures.cppm
+++ b/interface/vulkan/texture/Textures.cppm
@@ -54,7 +54,12 @@ vk_gltf_viewer::vulkan::texture::Textures::Textures(
     const Fallback &fallbackTexture,
     BS::thread_pool<> &threadPool
 ) {
-    if (1 + assetExtended.asset.textures.size() > dsl::Asset::maxTextureCount(gpu)) {
+#if __APPLE__
+    if (1 + assetExtended.asset.samplers.size() > dsl::Asset::maxSamplerCount(gpu) ||
+        1 + assetExtended.asset.images.size() > dsl::Asset::maxImageCount(gpu)) {
+#else
+    if (1 + assetExtended.asset.textures.size() > dsl::Asset::maxSamplerCount(gpu)) {
+#endif
         // If asset texture count exceeds the available texture count provided by the GPU, throw the error before
         // processing data to avoid unnecessary processing.
         throw gltf::AssetProcessError::TooManyTextureError;

--- a/shaders/mask_jump_flood_seed.frag
+++ b/shaders/mask_jump_flood_seed.frag
@@ -29,7 +29,12 @@ layout (location = 0) out uvec2 outCoordinate;
 layout (set = 0, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
+#if SEPARATE_IMAGE_SAMPLER == 1
+layout (set = 0, binding = 3) uniform sampler samplers[];
+layout (set = 0, binding = 4) uniform texture2D images[];
+#else
 layout (set = 0, binding = 3) uniform sampler2D textures[];
+#endif
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;
@@ -38,7 +43,11 @@ void main(){
     if (USE_TEXTURE_TRANSFORM) {
         baseColorTexcoord = mat2(MATERIAL.baseColorTextureTransform) * baseColorTexcoord + MATERIAL.baseColorTextureTransform[2];
     }
+#if SEPARATE_IMAGE_SAMPLER == 1
+    baseColorAlpha *= texture(sampler2D(images[uint(MATERIAL.baseColorTextureIndex) & 0xFFFU], samplers[uint(MATERIAL.baseColorTextureIndex) >> 12U]), baseColorTexcoord).a;
+#else
     baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord).a;
+#endif
 #endif
 #if HAS_COLOR_0_ALPHA_ATTRIBUTE
     baseColorAlpha *= variadic_in.color0Alpha;

--- a/shaders/mask_multi_node_mouse_picking.frag
+++ b/shaders/mask_multi_node_mouse_picking.frag
@@ -30,7 +30,12 @@ layout (location = 2) in FRAG_VARIADIC_IN {
 layout (set = 0, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
+#if SEPARATE_IMAGE_SAMPLER == 1
+layout (set = 0, binding = 3) uniform sampler samplers[];
+layout (set = 0, binding = 4) uniform texture2D images[];
+#else
 layout (set = 0, binding = 3) uniform sampler2D textures[];
+#endif
 
 layout (set = 1, binding = 0) buffer MousePickingResultBuffer {
     uint packedBits[];
@@ -43,7 +48,11 @@ void main(){
     if (USE_TEXTURE_TRANSFORM) {
         baseColorTexcoord = mat2(MATERIAL.baseColorTextureTransform) * baseColorTexcoord + MATERIAL.baseColorTextureTransform[2];
     }
+#if SEPARATE_IMAGE_SAMPLER == 1
+    baseColorAlpha *= texture(sampler2D(images[uint(MATERIAL.baseColorTextureIndex) & 0xFFFU], samplers[uint(MATERIAL.baseColorTextureIndex) >> 12U]), baseColorTexcoord).a;
+#else
     baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord).a;
+#endif
 #endif
 #if HAS_COLOR_0_ALPHA_ATTRIBUTE
     baseColorAlpha *= variadic_in.color0Alpha;

--- a/shaders/mask_node_index.frag
+++ b/shaders/mask_node_index.frag
@@ -30,7 +30,12 @@ layout (location = 0) out uint outNodeIndex;
 layout (set = 0, binding = 2, std430) readonly buffer MaterialBuffer {
     Material materials[];
 };
+#if SEPARATE_IMAGE_SAMPLER == 1
+layout (set = 0, binding = 3) uniform sampler samplers[];
+layout (set = 0, binding = 4) uniform texture2D images[];
+#else
 layout (set = 0, binding = 3) uniform sampler2D textures[];
+#endif
 
 void main(){
     float baseColorAlpha = MATERIAL.baseColorFactor.a;
@@ -39,7 +44,11 @@ void main(){
     if (USE_TEXTURE_TRANSFORM) {
         baseColorTexcoord = mat2(MATERIAL.baseColorTextureTransform) * baseColorTexcoord + MATERIAL.baseColorTextureTransform[2];
     }
+#if SEPARATE_IMAGE_SAMPLER == 1
+    baseColorAlpha *= texture(sampler2D(images[uint(MATERIAL.baseColorTextureIndex) & 0xFFFU], samplers[uint(MATERIAL.baseColorTextureIndex) >> 12U]), baseColorTexcoord).a;
+#else
     baseColorAlpha *= texture(textures[uint(MATERIAL.baseColorTextureIndex)], baseColorTexcoord).a;
+#endif
 #endif
 #if HAS_COLOR_0_ALPHA_ATTRIBUTE
     baseColorAlpha *= variadic_in.color0Alpha;


### PR DESCRIPTION
This PR, specifically for Apple systems, separates images and samplers in the fragment shader of the pipeline used for rendering glTF mesh primitives.

Before this change, the pipeline used a combined image sampler descriptor to reference glTF asset textures. The maximum number of such descriptors is limited by `VkPhysicalDeviceDescriptorIndexingProperties::maxPerStageDescriptorUpdateAfterBindSamplers`. On Apple systems that do not use Metal Argument Buffers, this limit is 16 — a very small number. After reserving some samplers for additional textures needed for shading, assets with more than 14 textures could not be loaded. While enabling Metal Argument Buffers can greatly increase this limit, unfortunately MoltenVK’s implementation is quite buggy.

In addition, unlike other systems that support `VkPhysicalDeviceVulkan12Features::descriptorBindingVariableDescriptorCount` — which allows the number of bound textures in a pipeline to be varied — MoltenVK’s buggy implementation meant that the existing code had to recreate the pipelines required for rendering an asset whenever the asset’s texture count changed.

The new implementation, for Apple systems only, changes the asset descriptor set layout: instead of using `vk::DescriptorType::eCombinedImageSampler` at binding 3 (starts from zero), binding 3 now uses `vk::DescriptorType::eSampler` and binding 4 uses `vk::DescriptorType::eSampledImage`. Binding 3 can hold up to 16 samplers, while binding 4 can hold up to 512 sampled images with a variable descriptor count. Instead of relying on texture index–based values, the asset now uses sampler index–based and image index–based values. In the material buffer, the `uint16_t` texture index packs the sampler index into the upper 4 MSBs and the image index into the lower 12 LSBs. Both bindings may be partially bound (as typically only up to two samplers are bound, and some images in the asset may not be referenced by any texture).

With this change, `VkPhysicalDeviceVulkan12Features::descriptorBindingVariableDescriptorCount` becomes a required feature. Pipelines involved in rendering the asset are now created only when a pipeline with different specialization is requested (i.e., regardless of changes to the asset’s texture count). In addition, the new optimization makes the asset descriptor set to be recreated only if the newly loaded asset contains more images than before, and it is not updated at all if there are no textures.